### PR TITLE
Fix module purge-from-trash failing on PostgreSQL

### DIFF
--- a/TerraformRegistry.PostgreSQL/Migrations/Migration_1_0_3.cs
+++ b/TerraformRegistry.PostgreSQL/Migrations/Migration_1_0_3.cs
@@ -1,0 +1,27 @@
+namespace TerraformRegistry.PostgreSQL.Migrations;
+
+using Npgsql;
+
+/// <summary>
+/// Adds ON DELETE CASCADE to module_downloads FK so purging modules
+/// with download history succeeds instead of silently failing.
+/// </summary>
+public class Migration_1_0_3 : IDatabaseMigration
+{
+    public string Version => "1.0.3";
+    public string Description => "Add ON DELETE CASCADE to module_downloads foreign key";
+
+    public async Task ApplyAsync(NpgsqlConnection connection, NpgsqlTransaction transaction)
+    {
+        var sql = @"
+            ALTER TABLE module_downloads
+                DROP CONSTRAINT IF EXISTS module_downloads_module_id_fkey;
+            ALTER TABLE module_downloads
+                ADD CONSTRAINT module_downloads_module_id_fkey
+                FOREIGN KEY (module_id) REFERENCES modules(id) ON DELETE CASCADE;
+        ";
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
@@ -403,11 +403,18 @@ public class PostgreSqlDatabaseService : IDatabaseService, IInitializableDb
             var rowsAffected = await command.ExecuteNonQueryAsync();
             return rowsAffected > 0;
         }
+        catch (PostgresException ex) when (ex.SqlState == "23503") // FK violation
+        {
+            _logger.LogError(ex,
+                "Cannot remove module {Namespace}/{Name}/{Provider}/{Version}: referenced by download records",
+                module.Namespace, module.Name, module.Provider, module.Version);
+            return false;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error removing module {Namespace}/{Name}/{Provider}/{Version} from database",
                 module.Namespace, module.Name, module.Provider, module.Version);
-            return false;
+            throw;
         }
     }
 

--- a/TerraformRegistry.Tests/IntegrationTests/ModuleTrashTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/ModuleTrashTests.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reflection;
+using Xunit.Abstractions;
+
+namespace TerraformRegistry.Tests.IntegrationTests;
+
+public class ModuleTrashTests(ITestOutputHelper output) : IntegrationTestBase(output, AuthToken)
+{
+    private const string TestDataDirectory = "TestData";
+    private const string TestModuleName = "test-module.zip";
+    protected const string AuthToken = "default-auth-token";
+
+    [Fact]
+    public async Task SoftDelete_ExistingModule_ReturnsNoContent()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AuthToken);
+
+        await UploadTestModule(client, "2.0.0");
+
+        var response = await client.DeleteAsync("/v1/modules/test-ns/test-name/test-provider/2.0.0");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SoftDelete_NonExistentModule_ReturnsNotFound()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AuthToken);
+
+        var response = await client.DeleteAsync("/v1/modules/test-ns/test-name/test-provider/99.99.99");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Restore_SoftDeletedModule_ReturnsNoContent()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AuthToken);
+
+        await UploadTestModule(client, "2.1.0");
+        await client.DeleteAsync("/v1/modules/test-ns/test-name/test-provider/2.1.0");
+
+        var response = await client.PostAsync("/v1/modules/test-ns/test-name/test-provider/2.1.0/restore", null);
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Purge_SoftDeletedModule_ReturnsNoContent()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AuthToken);
+
+        await UploadTestModule(client, "2.2.0");
+        await client.DeleteAsync("/v1/modules/test-ns/test-name/test-provider/2.2.0");
+
+        var response = await client.DeleteAsync("/v1/modules/test-ns/test-name/test-provider/2.2.0/purge");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Purge_ThenListTrash_ModuleIsGone()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AuthToken);
+
+        await UploadTestModule(client, "2.3.0");
+        await client.DeleteAsync("/v1/modules/test-ns/test-name/test-provider/2.3.0");
+        await client.DeleteAsync("/v1/modules/test-ns/test-name/test-provider/2.3.0/purge");
+
+        var trashResponse = await client.GetAsync("/v1/modules/trash");
+        var content = await trashResponse.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("2.3.0", content);
+    }
+
+    [Fact]
+    public async Task SoftDeletedModule_NotVisibleInModuleList()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AuthToken);
+
+        await UploadTestModule(client, "2.4.0");
+        await client.DeleteAsync("/v1/modules/test-ns/test-name/test-provider/2.4.0");
+
+        var listResponse = await client.GetAsync("/v1/modules");
+        var content = await listResponse.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("2.4.0", content);
+    }
+
+    [Fact]
+    public async Task SoftDeletedModule_VisibleInTrashList()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AuthToken);
+
+        await UploadTestModule(client, "2.5.0");
+        await client.DeleteAsync("/v1/modules/test-ns/test-name/test-provider/2.5.0");
+
+        var trashResponse = await client.GetAsync("/v1/modules/trash");
+        var content = await trashResponse.Content.ReadAsStringAsync();
+        Assert.Contains("2.5.0", content);
+    }
+
+    private async Task UploadTestModule(HttpClient client, string version)
+    {
+        var projectDir = GetProjectDirectory();
+        var moduleFilePath = Path.Combine(projectDir, TestDataDirectory, TestModuleName);
+        var fileName = Path.GetFileName(moduleFilePath);
+
+        await using var fileStream = File.OpenRead(moduleFilePath);
+        using var content = new MultipartFormDataContent();
+        using var streamContent = new StreamContent(fileStream);
+        streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/gzip");
+        content.Add(streamContent, "moduleFile", fileName);
+
+        var uploadResponse = await client.PostAsync($"/v1/modules/test-ns/test-name/test-provider/{version}", content);
+        Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
+    }
+
+    private string GetProjectDirectory()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var assemblyDirectory = Path.GetDirectoryName(assembly.Location);
+        var projectDir = Directory.GetParent(assemblyDirectory)?.Parent?.Parent?.FullName;
+
+        if (string.IsNullOrEmpty(projectDir) || !Directory.Exists(projectDir))
+            throw new DirectoryNotFoundException("Could not locate the test project directory.");
+
+        return projectDir;
+    }
+}

--- a/TerraformRegistry/Handlers/ModuleHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleHandlers.cs
@@ -240,6 +240,13 @@ public static class ModuleHandlers
         _logger.LogInformation("Deleting module version: {Namespace}/{Name}/{Provider}/{Version}",
             @namespace, name, provider, version);
 
+        if (!SemVerValidator.IsValid(version))
+        {
+            _logger.LogWarning("Invalid version format: {Version}", version);
+            return ErrorResponseExtensions.BadRequest(
+                $"Version '{version}' is not a valid Semantic Version (SemVer 2.0.0). Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILDMETADATA]");
+        }
+
         var result = await moduleService.DeleteModuleVersionAsync(@namespace, name, provider, version);
         if (!result) return ErrorResponseExtensions.NotFound("Module version not found");
 
@@ -259,6 +266,13 @@ public static class ModuleHandlers
         _logger.LogInformation("Restoring module version: {Namespace}/{Name}/{Provider}/{Version}",
             @namespace, name, provider, version);
 
+        if (!SemVerValidator.IsValid(version))
+        {
+            _logger.LogWarning("Invalid version format: {Version}", version);
+            return ErrorResponseExtensions.BadRequest(
+                $"Version '{version}' is not a valid Semantic Version (SemVer 2.0.0). Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILDMETADATA]");
+        }
+
         var result = await moduleService.RestoreModuleVersionAsync(@namespace, name, provider, version);
         if (!result) return ErrorResponseExtensions.NotFound("Deleted module version not found");
 
@@ -277,6 +291,13 @@ public static class ModuleHandlers
     {
         _logger.LogInformation("Purging module version: {Namespace}/{Name}/{Provider}/{Version}",
             @namespace, name, provider, version);
+
+        if (!SemVerValidator.IsValid(version))
+        {
+            _logger.LogWarning("Invalid version format: {Version}", version);
+            return ErrorResponseExtensions.BadRequest(
+                $"Version '{version}' is not a valid Semantic Version (SemVer 2.0.0). Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILDMETADATA]");
+        }
 
         var result = await moduleService.PurgeModuleVersionAsync(@namespace, name, provider, version);
         if (!result) return ErrorResponseExtensions.NotFound("Deleted module version not found");


### PR DESCRIPTION
## Summary

- **Root cause fix:** Added `ON DELETE CASCADE` to the `module_downloads.module_id` foreign key via Migration 1.0.3. This FK constraint was silently blocking `DELETE FROM modules` when download records existed, causing purge-from-trash to fail.
- **Error handling:** `RemoveModuleAsync` in PostgreSQL service now catches FK violations specifically and rethrows unexpected exceptions instead of swallowing all errors as `false`/404.
- **Input validation:** Added SemVer validation to delete/restore/purge handlers, matching the existing upload handler pattern. Invalid versions now return 400 instead of hitting the DB.
- **Test coverage:** Added 7 integration tests covering the full trash/restore/purge lifecycle using Testcontainers PostgreSQL.

## Test plan

- [x] All 129 tests pass (`dotnet test`)
- [x] New `ModuleTrashTests` cover: soft delete, restore, purge, trash visibility, module list exclusion
- [ ] Manual test: upload a module, download it (to create download records), soft-delete, purge from trash — verify it succeeds on PostgreSQL