### PR TITLE
Refactor database contracts into narrow interfaces

### DIFF
--- a/TerraformRegistry.API/Interfaces/IApiKeyRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IApiKeyRepository.cs
@@ -1,0 +1,23 @@
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.API.Interfaces;
+
+/// <summary>
+///     Stores API key records.
+/// </summary>
+public interface IApiKeyRepository
+{
+    Task AddApiKeyAsync(ApiKey apiKey);
+
+    Task<ApiKey?> GetApiKeyAsync(Guid id);
+
+    Task<IEnumerable<ApiKey>> GetApiKeysByUserAsync(string userId);
+
+    Task<IEnumerable<ApiKey>> GetSharedApiKeysAsync();
+
+    Task<IEnumerable<ApiKey>> GetApiKeysByPrefixAsync(string prefix);
+
+    Task UpdateApiKeyAsync(ApiKey apiKey);
+
+    Task DeleteApiKeyAsync(ApiKey apiKey);
+}

--- a/TerraformRegistry.API/Interfaces/IDatabaseService.cs
+++ b/TerraformRegistry.API/Interfaces/IDatabaseService.cs
@@ -1,127 +1,17 @@
-using TerraformRegistry.Models;
-
 namespace TerraformRegistry.API.Interfaces;
 
 /// <summary>
-///     Interface for database services that store module metadata
+///     Compatibility interface for database services.
 /// </summary>
-public interface IDatabaseService
+public interface IDatabaseService :
+    IModuleRepository,
+    IModuleExtractionRepository,
+    IUserRepository,
+    IApiKeyRepository,
+    IModuleDownloadRecorder
 {
     /// <summary>
-    ///     Lists all modules based on search criteria
-    /// </summary>
-    Task<ModuleList> ListModulesAsync(ModuleSearchRequest request);
-
-    /// <summary>
-    ///     Gets detailed information about a specific module
-    /// </summary>
-    Task<Module?> GetModuleAsync(string @namespace, string name, string provider, string version);
-
-    /// <summary>
-    ///     Gets all versions of a specific module
-    /// </summary>
-    Task<ModuleVersions> GetModuleVersionsAsync(string @namespace, string name, string provider);
-
-    /// <summary>
-    ///     Gets the storage path information for a specific module version
-    /// </summary>
-    Task<ModuleStorage?> GetModuleStorageAsync(string @namespace, string name, string provider, string version);
-
-    /// <summary>
-    ///     Adds a new module to the database
-    /// </summary>
-    Task<bool> AddModuleAsync(ModuleStorage module);
-
-    /// <summary>
-    ///     Removes a module from the database (permanent delete)
-    /// </summary>
-    Task<bool> RemoveModuleAsync(ModuleStorage module);
-
-    /// <summary>
-    ///     Removes a module row only when its stored metadata matches the provided module
-    /// </summary>
-    Task<bool> RemoveModuleExactAsync(ModuleStorage module);
-
-    /// <summary>
-    ///     Removes a module row only when it is currently soft-deleted
-    /// </summary>
-    Task<bool> RemoveDeletedModuleAsync(string @namespace, string name, string provider, string version);
-
-    /// <summary>
-    ///     Adds a module row directly in the soft-deleted state
-    /// </summary>
-    Task<bool> AddDeletedModuleAsync(ModuleStorage module);
-
-    /// <summary>
-    ///     Replaces a module row only when its stored metadata matches the expected current module
-    /// </summary>
-    Task<bool> ReplaceModuleExactAsync(ModuleStorage existingModule, ModuleStorage newModule);
-
-    /// <summary>
-    ///     Soft deletes a module by setting deleted_at timestamp
-    /// </summary>
-    Task<bool> SoftDeleteModuleAsync(string @namespace, string name, string provider, string version);
-
-    /// <summary>
-    ///     Restores a soft-deleted module by clearing deleted_at
-    /// </summary>
-    Task<bool> RestoreModuleAsync(string @namespace, string name, string provider, string version);
-
-    /// <summary>
-    ///     Lists all soft-deleted modules
-    /// </summary>
-    Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request);
-
-    /// <summary>
-    ///     Gets a module including soft-deleted ones
-    /// </summary>
-    Task<ModuleStorage?> GetModuleStorageIncludingDeletedAsync(string @namespace, string name, string provider,
-        string version);
-
-    /// <summary>
-    ///     Updates the description for all active versions of a module
-    /// </summary>
-    Task<bool> UpdateModuleDescriptionAsync(string @namespace, string name, string provider, string description);
-
-    Task<ModuleExtractionDocument?> GetModuleExtractionAsync(string @namespace, string name, string provider, string version);
-    Task UpsertModuleExtractionAsync(string @namespace, string name, string provider, string version, ModuleExtractionDocument document, string? sourceChecksum = null);
-    Task<ModuleLlmContextDocument?> GetModuleLlmContextAsync(string @namespace, string name, string provider, string version);
-    Task UpsertModuleLlmContextAsync(string @namespace, string name, string provider, string version, ModuleLlmContextDocument document, string? sourceChecksum = null);
-    Task UpdateModuleMetadataAsync(string @namespace, string name, string provider, string version, Action<ModuleArtifactMetadata> mutate);
-    Task<IReadOnlyList<ModuleStorage>> ListModulesNeedingExtractionAsync(int limit);
-    Task<ModuleExtractionAdminSummary> GetModuleExtractionAdminSummaryAsync();
-    Task<ModuleExtractionAdminPage> ListModuleExtractionsAdminAsync(ModuleExtractionAdminQuery query);
-    Task<ModuleExtractionAdminDetail?> GetModuleExtractionAdminDetailAsync(string @namespace, string name, string provider, string version);
-    Task<IReadOnlyList<ModuleStorage>> ListModulesForExtractionBackfillAsync(int limit);
-
-    // User & API Key Methods
-    Task<IReadOnlyList<User>> GetUsersByEmailCaseInsensitiveAsync(string email);
-    Task<User?> GetUserByEmailAsync(string email);
-    Task<User?> GetUserByIdAsync(string id);
-    Task AddUserAsync(User user);
-    Task UpdateUserAsync(User user);
-    Task DeleteUserAsync(string userId);
-
-    Task AddApiKeyAsync(ApiKey apiKey);
-    Task<ApiKey?> GetApiKeyAsync(Guid id);
-    Task<IEnumerable<ApiKey>> GetApiKeysByUserAsync(string userId);
-    Task<IEnumerable<ApiKey>> GetSharedApiKeysAsync();
-    Task<IEnumerable<ApiKey>> GetApiKeysByPrefixAsync(string prefix);
-    Task UpdateApiKeyAsync(ApiKey apiKey);
-    Task DeleteApiKeyAsync(ApiKey apiKey);
-
-    /// <summary>
-    ///     Records a module download event for analytics
-    /// </summary>
-    Task RecordDownloadAsync(string @namespace, string name, string provider, string version, string? clientIp, string? userAgent);
-
-    /// <summary>
-    ///     Lists all users in the system
-    /// </summary>
-    Task<IEnumerable<User>> ListAllUsersAsync();
-
-    /// <summary>
-    ///     Checks that the database connection is healthy
+    ///     Checks that the database connection is healthy.
     /// </summary>
     Task<bool> CheckConnectionAsync();
 }

--- a/TerraformRegistry.API/Interfaces/IModuleDownloadRecorder.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleDownloadRecorder.cs
@@ -1,0 +1,15 @@
+namespace TerraformRegistry.API.Interfaces;
+
+/// <summary>
+///     Records module download events for analytics.
+/// </summary>
+public interface IModuleDownloadRecorder
+{
+    Task RecordDownloadAsync(
+        string @namespace,
+        string name,
+        string provider,
+        string version,
+        string? clientIp,
+        string? userAgent);
+}

--- a/TerraformRegistry.API/Interfaces/IModuleExtractionRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleExtractionRepository.cs
@@ -1,0 +1,58 @@
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.API.Interfaces;
+
+/// <summary>
+///     Stores generated module extraction documents and LLM context documents.
+/// </summary>
+public interface IModuleExtractionRepository
+{
+    Task<ModuleExtractionDocument?> GetModuleExtractionAsync(
+        string @namespace,
+        string name,
+        string provider,
+        string version);
+
+    Task UpsertModuleExtractionAsync(
+        string @namespace,
+        string name,
+        string provider,
+        string version,
+        ModuleExtractionDocument document,
+        string? sourceChecksum = null);
+
+    Task<ModuleLlmContextDocument?> GetModuleLlmContextAsync(
+        string @namespace,
+        string name,
+        string provider,
+        string version);
+
+    Task UpsertModuleLlmContextAsync(
+        string @namespace,
+        string name,
+        string provider,
+        string version,
+        ModuleLlmContextDocument document,
+        string? sourceChecksum = null);
+
+    Task UpdateModuleMetadataAsync(
+        string @namespace,
+        string name,
+        string provider,
+        string version,
+        Action<ModuleArtifactMetadata> mutate);
+
+    Task<IReadOnlyList<ModuleStorage>> ListModulesNeedingExtractionAsync(int limit);
+
+    Task<ModuleExtractionAdminSummary> GetModuleExtractionAdminSummaryAsync();
+
+    Task<ModuleExtractionAdminPage> ListModuleExtractionsAdminAsync(ModuleExtractionAdminQuery query);
+
+    Task<ModuleExtractionAdminDetail?> GetModuleExtractionAdminDetailAsync(
+        string @namespace,
+        string name,
+        string provider,
+        string version);
+
+    Task<IReadOnlyList<ModuleStorage>> ListModulesForExtractionBackfillAsync(int limit);
+}

--- a/TerraformRegistry.API/Interfaces/IModuleRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleRepository.cs
@@ -1,0 +1,88 @@
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.API.Interfaces;
+
+/// <summary>
+///     Stores module catalog metadata and lifecycle state.
+/// </summary>
+public interface IModuleRepository
+{
+    /// <summary>
+    ///     Lists all modules based on search criteria.
+    /// </summary>
+    Task<ModuleList> ListModulesAsync(ModuleSearchRequest request);
+
+    /// <summary>
+    ///     Gets detailed information about a specific module.
+    /// </summary>
+    Task<Module?> GetModuleAsync(string @namespace, string name, string provider, string version);
+
+    /// <summary>
+    ///     Gets all versions of a specific module.
+    /// </summary>
+    Task<ModuleVersions> GetModuleVersionsAsync(string @namespace, string name, string provider);
+
+    /// <summary>
+    ///     Gets the storage path information for a specific module version.
+    /// </summary>
+    Task<ModuleStorage?> GetModuleStorageAsync(string @namespace, string name, string provider, string version);
+
+    /// <summary>
+    ///     Adds a new module to the database.
+    /// </summary>
+    Task<bool> AddModuleAsync(ModuleStorage module);
+
+    /// <summary>
+    ///     Removes a module from the database permanently.
+    /// </summary>
+    Task<bool> RemoveModuleAsync(ModuleStorage module);
+
+    /// <summary>
+    ///     Removes a module row only when its stored metadata matches the provided module.
+    /// </summary>
+    Task<bool> RemoveModuleExactAsync(ModuleStorage module);
+
+    /// <summary>
+    ///     Removes a module row only when it is currently soft-deleted.
+    /// </summary>
+    Task<bool> RemoveDeletedModuleAsync(string @namespace, string name, string provider, string version);
+
+    /// <summary>
+    ///     Adds a module row directly in the soft-deleted state.
+    /// </summary>
+    Task<bool> AddDeletedModuleAsync(ModuleStorage module);
+
+    /// <summary>
+    ///     Replaces a module row only when its stored metadata matches the expected current module.
+    /// </summary>
+    Task<bool> ReplaceModuleExactAsync(ModuleStorage existingModule, ModuleStorage newModule);
+
+    /// <summary>
+    ///     Soft deletes a module by setting its deleted timestamp.
+    /// </summary>
+    Task<bool> SoftDeleteModuleAsync(string @namespace, string name, string provider, string version);
+
+    /// <summary>
+    ///     Restores a soft-deleted module by clearing its deleted timestamp.
+    /// </summary>
+    Task<bool> RestoreModuleAsync(string @namespace, string name, string provider, string version);
+
+    /// <summary>
+    ///     Lists all soft-deleted modules.
+    /// </summary>
+    Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request);
+
+    /// <summary>
+    ///     Gets a module including soft-deleted ones.
+    /// </summary>
+    Task<ModuleStorage?> GetModuleStorageIncludingDeletedAsync(
+        string @namespace,
+        string name,
+        string provider,
+        string version);
+
+    /// <summary>
+    ///     Updates the description for all active versions of a module.
+    /// </summary>
+    Task<bool> UpdateModuleDescriptionAsync(string @namespace, string name, string provider, string description);
+}

--- a/TerraformRegistry.API/Interfaces/IUserRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IUserRepository.cs
@@ -1,0 +1,26 @@
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.API.Interfaces;
+
+/// <summary>
+///     Stores registry user records.
+/// </summary>
+public interface IUserRepository
+{
+    Task<IReadOnlyList<User>> GetUsersByEmailCaseInsensitiveAsync(string email);
+
+    Task<User?> GetUserByEmailAsync(string email);
+
+    Task<User?> GetUserByIdAsync(string id);
+
+    Task AddUserAsync(User user);
+
+    Task UpdateUserAsync(User user);
+
+    Task DeleteUserAsync(string userId);
+
+    /// <summary>
+    ///     Lists all users in the system.
+    /// </summary>
+    Task<IEnumerable<User>> ListAllUsersAsync();
+}

--- a/TerraformRegistry.Tests/UnitTests/Database/SqliteDatabaseServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/SqliteDatabaseServiceTests.cs
@@ -77,6 +77,18 @@ public class SqliteDatabaseServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public void Service_ImplementsNarrowDatabaseContracts()
+    {
+        var svc = CreateService("Data Source=:memory:");
+
+        Assert.IsAssignableFrom<IModuleRepository>(svc);
+        Assert.IsAssignableFrom<IModuleExtractionRepository>(svc);
+        Assert.IsAssignableFrom<IUserRepository>(svc);
+        Assert.IsAssignableFrom<IApiKeyRepository>(svc);
+        Assert.IsAssignableFrom<IModuleDownloadRecorder>(svc);
+    }
+
+    [Fact]
     public async Task InitializeDatabase_CreatesSchemaAndAllowsInsertAndFetch()
     {
         var svc = CreateService(_connectionString);


### PR DESCRIPTION
## Summary
- Split `IDatabaseService` into focused capability interfaces for modules, extraction, users, API keys, and download recording.
- Kept `IDatabaseService` as a compatibility facade by inheriting the new narrow interfaces.
- Added a SQLite service test that verifies the concrete service still implements all expected contracts.
- Captured the refactor plan in `docs/superpowers/plans/2026-05-08-large-class-splitting.md`.

## Testing
- Added `SqliteDatabaseServiceTests.Service_ImplementsNarrowDatabaseContracts` to assert interface compatibility.
- Not run: full `dotnet test` suite.
- Not run: `dotnet build` or database-backed integration tests.