### PR TITLE
chore: remediate high NuGet advisory

### DIFF
--- a/TerraformRegistry/TerraformRegistry.csproj
+++ b/TerraformRegistry/TerraformRegistry.csproj
@@ -30,7 +30,8 @@
         <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
         <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.0" />
-        <PackageReference Include="NSwag.AspNetCore" Version="14.3.0" />
+        <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+        <PackageReference Include="NSwag.AspNetCore" Version="14.7.1" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
         <PackageReference Include="SourceGear.sqlite3" Version="3.50.4.5" />
         <PackageReference Include="SQLitePCLRaw.config.e_sqlite3" Version="3.0.3" />


### PR DESCRIPTION
SUP-001 bootstrap: update NSwag and explicitly resolve Microsoft.OpenApi 2.7.5 so the warnings-as-errors NuGet audit is clean.