### PR TITLE
fix: guard startup against unsafe migration state

### DIFF
--- a/TerraformRegistry.API/Interfaces/IModuleService.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleService.cs
@@ -8,6 +8,11 @@ namespace TerraformRegistry.API.Interfaces;
 public interface IModuleService
 {
     /// <summary>
+    ///     Performs required storage initialization after database migration has completed.
+    /// </summary>
+    Task InitializeStorageAsync(CancellationToken cancellationToken);
+
+    /// <summary>
     ///     Lists all modules
     /// </summary>
     Task<ModuleList> ListModulesAsync(ModuleSearchRequest request);

--- a/TerraformRegistry.API/Interfaces/IStartupReadiness.cs
+++ b/TerraformRegistry.API/Interfaces/IStartupReadiness.cs
@@ -1,0 +1,11 @@
+namespace TerraformRegistry.API.Interfaces;
+
+/// <summary>
+///     Tracks completion of mandatory startup work that is not represented by a simple connection check.
+/// </summary>
+public interface IStartupReadiness
+{
+    bool IsStorageInitialized { get; }
+
+    void MarkStorageInitialized();
+}

--- a/TerraformRegistry.API/ModuleService.cs
+++ b/TerraformRegistry.API/ModuleService.cs
@@ -10,6 +10,12 @@ namespace TerraformRegistry.API;
 public abstract class ModuleService : IModuleService
 {
     /// <summary>
+    ///     Performs storage work that must run only after database migration has completed.
+    ///     Constructors must remain side-effect free so application startup can establish schema safety first.
+    /// </summary>
+    public virtual Task InitializeStorageAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
     ///     Lists all modules
     /// </summary>
     public abstract Task<ModuleList> ListModulesAsync(ModuleSearchRequest request);

--- a/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
+++ b/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
@@ -91,22 +91,14 @@ public class AzureBlobModuleService : ModuleService
         // Initialize Azure Blob Storage container client
         _containerClient = clientToUse.GetBlobContainerClient(_containerName);
 
-        // Ensure container exists
-        try
-        {
-            RegistryLog.Information(_logger, "Ensuring blob container '{ContainerName}' exists...", _containerName);
-            _containerClient.CreateIfNotExists();
-            RegistryLog.Information(_logger, "Blob container '{ContainerName}' is ready.", _containerName);
-        }
-        catch (Exception ex)
-        {
-            RegistryLog.Error(_logger, ex,
-                "Failed to create or verify blob container '{ContainerName}'. This may prevent module operations.",
-                _containerName);
-            throw; // Re-throw as this is a critical failure for the service's operation.
-        }
+    }
 
-        LoadExistingModulesAsync().GetAwaiter().GetResult();
+    public override async Task InitializeStorageAsync(CancellationToken cancellationToken)
+    {
+        RegistryLog.Information(_logger, "Ensuring blob container '{ContainerName}' exists...", _containerName);
+        await _containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+        await LoadExistingModulesAsync(cancellationToken);
+        RegistryLog.Information(_logger, "Blob container '{ContainerName}' is ready.", _containerName);
     }
 
     /// <summary>
@@ -343,7 +335,7 @@ public class AzureBlobModuleService : ModuleService
     ///     2. It ensures consistency between what's in blob storage and what's in the database
     ///     3. It helps with migration scenarios when moving from one database to another
     /// </remarks>
-    private async Task LoadExistingModulesAsync()
+    private async Task LoadExistingModulesAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -351,7 +343,7 @@ public class AzureBlobModuleService : ModuleService
             var syncCount = 0;
 
             // List all blobs in the container
-            await foreach (var blobItem in _containerClient.GetBlobsAsync())
+            await foreach (var blobItem in _containerClient.GetBlobsAsync(cancellationToken: cancellationToken))
             {
                 try
                 {
@@ -359,7 +351,7 @@ public class AzureBlobModuleService : ModuleService
                     var blobClient = _containerClient.GetBlobClient(blobItem.Name);
 
                     // Get blob metadata
-                    var properties = await blobClient.GetPropertiesAsync();
+                    var properties = await blobClient.GetPropertiesAsync(cancellationToken: cancellationToken);
 
                     ModuleStorage? module = null;
 
@@ -458,8 +450,8 @@ public class AzureBlobModuleService : ModuleService
         }
         catch (Exception ex)
         {
-            // Log any errors during initialization
             RegistryLog.Error(_logger, ex, "Error during blob storage/database synchronization");
+            throw new InvalidOperationException("Initial Azure Blob storage synchronization failed.", ex);
         }
     }
 

--- a/TerraformRegistry.Migrations/DbUpMigrator.cs
+++ b/TerraformRegistry.Migrations/DbUpMigrator.cs
@@ -30,8 +30,8 @@ public class DbUpMigrator
         var upgrader = BuildUpgrader(provider, connectionString, scriptFilter);
 
         var executedScripts = upgrader.GetExecutedScripts();
+        ValidateMigrationState(provider, connectionString, executedScripts);
         BootstrapExistingDatabase(provider, connectionString, upgrader, executedScripts);
-        RepairOverBootstrappedJournal(provider, connectionString, upgrader, executedScripts);
 
         var result = upgrader.PerformUpgrade();
 
@@ -92,6 +92,135 @@ public class DbUpMigrator
 
         return scriptName => scriptName.Contains(folder, StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    ///     Refuses to guess how to recover a database whose journal and schema disagree.
+    ///     DbUp's journal is the source of truth for a known upgrade path; silently editing it
+    ///     can skip destructive scripts or make a partially applied migration permanent.
+    /// </summary>
+    private void ValidateMigrationState(
+        string provider,
+        string connectionString,
+        List<string> executedScripts)
+    {
+        var allScripts = Assembly.GetExecutingAssembly()
+            .GetManifestResourceNames()
+            .Where(GetScriptFilter(provider))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        if (executedScripts.Any(script => !allScripts.Contains(script, StringComparer.OrdinalIgnoreCase)))
+            ThrowUnsafeState(provider, "the DbUp journal contains a script that is not embedded in this application version");
+
+        var legacyMigrationCount = provider switch
+        {
+            "postgres" => GetPostgresLegacyMigrationCount(connectionString, dropTable: false),
+            "sqlite" => GetSqliteLegacyMigrationCount(connectionString, dropTable: false),
+            _ => throw new ArgumentException($"Unsupported database provider: {provider}")
+        };
+
+        var hasLegacyJournal = provider switch
+        {
+            "postgres" => HasPostgresTable(connectionString, "schema_version"),
+            "sqlite" => HasSqliteTable(connectionString, "schema_version"),
+            _ => false
+        };
+
+        if (hasLegacyJournal && executedScripts.Count > 0)
+            ThrowUnsafeState(provider, "both the legacy schema_version table and the DbUp journal are present");
+
+        if (hasLegacyJournal && (legacyMigrationCount == 0 || legacyMigrationCount > allScripts.Count))
+            ThrowUnsafeState(provider, $"the legacy schema_version table contains {legacyMigrationCount} entries, which cannot be mapped safely to {allScripts.Count} embedded scripts");
+
+        if (executedScripts.Count == 0)
+        {
+            if (!hasLegacyJournal && HasApplicationSchema(provider, connectionString))
+                ThrowUnsafeState(provider, "application tables exist but neither a legacy journal nor a DbUp journal entry identifies their migration state");
+
+            if (hasLegacyJournal)
+                ValidateSchemaForScripts(provider, connectionString, allScripts.Take(legacyMigrationCount));
+
+            return;
+        }
+
+        var expectedPrefix = allScripts.Take(executedScripts.Count).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (executedScripts.Count != expectedPrefix.Count || !executedScripts.All(expectedPrefix.Contains))
+            ThrowUnsafeState(provider, "the DbUp journal is not a contiguous prefix of the embedded migration chain");
+
+        ValidateSchemaForScripts(provider, connectionString, executedScripts);
+    }
+
+    private static void ValidateSchemaForScripts(string provider, string connectionString, IEnumerable<string> scripts)
+    {
+        foreach (var scriptName in scripts)
+        {
+            foreach (var table in RequiredTablesForScript(scriptName))
+            {
+                var exists = provider switch
+                {
+                    "postgres" => HasPostgresTable(connectionString, table),
+                    "sqlite" => HasSqliteTable(connectionString, table),
+                    _ => false
+                };
+
+                if (!exists)
+                    ThrowUnsafeState(provider, $"the journal records '{scriptName}' but required table '{table}' is missing");
+            }
+        }
+    }
+
+    private static IEnumerable<string> RequiredTablesForScript(string scriptName)
+    {
+        // These table sentinels cover every migration that creates durable state.  Migrations
+        // which only add columns/indexes are intentionally not inferred from a table check.
+        return scriptName switch
+        {
+            var name when name.Contains("001_initial_schema", StringComparison.OrdinalIgnoreCase) => ["modules"],
+            var name when name.Contains("002_users_and_api_keys", StringComparison.OrdinalIgnoreCase) => ["users", "api_keys"],
+            var name when name.Contains("004_downloads", StringComparison.OrdinalIgnoreCase) => ["module_downloads"],
+            var name when name.Contains("005_webhooks", StringComparison.OrdinalIgnoreCase) => ["webhooks"],
+            var name when name.Contains("006_vcs_connections", StringComparison.OrdinalIgnoreCase) => ["vcs_connections"],
+            var name when name.Contains("007_vcs_sources", StringComparison.OrdinalIgnoreCase) => ["vcs_sources"],
+            var name when name.Contains("008_rbac", StringComparison.OrdinalIgnoreCase) => ["roles", "user_roles"],
+            var name when name.Contains("009_audit_logs", StringComparison.OrdinalIgnoreCase) => ["audit_logs"],
+            var name when name.Contains("013_module_extractions", StringComparison.OrdinalIgnoreCase) => ["module_extractions"],
+            var name when name.Contains("013_provider_registry", StringComparison.OrdinalIgnoreCase) => ["providers", "provider_versions", "provider_platforms"],
+            var name when name.Contains("014_runtime_settings", StringComparison.OrdinalIgnoreCase) => ["runtime_settings"],
+            var name when name.Contains("015_module_llm_contexts", StringComparison.OrdinalIgnoreCase) => ["module_llm_contexts"],
+            var name when name.Contains("016_mirror_cache", StringComparison.OrdinalIgnoreCase) => ["mirror_provider_indexes", "mirror_provider_packages", "mirror_module_versions", "mirror_module_packages"],
+            _ => []
+        };
+    }
+
+    private static bool HasApplicationSchema(string provider, string connectionString) => provider switch
+    {
+        "postgres" => HasPostgresTable(connectionString, "modules") || HasPostgresTable(connectionString, "users"),
+        "sqlite" => HasSqliteTable(connectionString, "modules") || HasSqliteTable(connectionString, "users"),
+        _ => false
+    };
+
+    private static bool HasPostgresTable(string connectionString, string tableName)
+    {
+        using var conn = new Npgsql.NpgsqlConnection(connectionString);
+        conn.Open();
+        using var command = conn.CreateCommand();
+        command.CommandText = "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_schema = current_schema() AND table_name = @name)";
+        command.Parameters.AddWithValue("name", tableName);
+        return (bool)(command.ExecuteScalar() ?? false);
+    }
+
+    private static bool HasSqliteTable(string connectionString, string tableName)
+    {
+        using var conn = new Microsoft.Data.Sqlite.SqliteConnection(connectionString);
+        conn.Open();
+        using var command = conn.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = @name";
+        command.Parameters.AddWithValue("@name", tableName);
+        return (long)(command.ExecuteScalar() ?? 0L) > 0;
+    }
+
+    private static void ThrowUnsafeState(string provider, string detail) => throw new InvalidOperationException(
+        $"Unsafe database migration state for {provider}: {detail}. The application will not modify this database; restore a verified backup or reconcile the journal and schema manually before retrying.");
 
     /// <summary>
     ///     Detects existing databases migrated by the legacy MigrationManager and

--- a/TerraformRegistry.S3/S3ModuleObjectStore.cs
+++ b/TerraformRegistry.S3/S3ModuleObjectStore.cs
@@ -14,20 +14,13 @@ internal sealed class S3ModuleObjectStore(
     int presignedUrlExpiryMinutes,
     ILogger logger)
 {
-    public void TryPrimeStorage()
+    public async Task InitializeStorageAsync(CancellationToken cancellationToken)
     {
-        try
+        await s3Client.ListObjectsV2Async(new ListObjectsV2Request
         {
-            s3Client.ListObjectsV2Async(new ListObjectsV2Request
-            {
-                BucketName = bucketName,
-                MaxKeys = 1
-            }).GetAwaiter().GetResult();
-        }
-        catch (Exception ex)
-        {
-            RegistryLog.Error(logger, ex, "Failed to reach S3 bucket '{BucketName}' during startup.", bucketName);
-        }
+            BucketName = bucketName,
+            MaxKeys = 1
+        }, cancellationToken);
     }
 
     public async Task<(bool Healthy, string? Reason)> CheckStorageAsync()

--- a/TerraformRegistry.S3/S3ModuleService.cs
+++ b/TerraformRegistry.S3/S3ModuleService.cs
@@ -51,8 +51,10 @@ public class S3ModuleService : ModuleService
         _uploadWorkflow = new S3ModuleUploadWorkflow(_databaseService, _objectStore, logger);
         _purgeWorkflow = new S3ModulePurgeWorkflow(_databaseService, _objectStore, logger);
 
-        _objectStore.TryPrimeStorage();
     }
+
+    public override Task InitializeStorageAsync(CancellationToken cancellationToken) =>
+        _objectStore.InitializeStorageAsync(cancellationToken);
 
     public override Task<ModuleList> ListModulesAsync(ModuleSearchRequest request)
     {

--- a/TerraformRegistry.Tests/DbUpMigratorTests.cs
+++ b/TerraformRegistry.Tests/DbUpMigratorTests.cs
@@ -228,6 +228,60 @@ public class DbUpMigratorTests : IDisposable
         Assert.Throws<ArgumentException>(() => migrator.Migrate("mysql", "fake-connection"));
     }
 
+    [Fact]
+    public void MigrateFailsClosedWhenApplicationSchemaIsUnjournaled()
+    {
+        using var command = _connection.CreateCommand();
+        command.CommandText = "CREATE TABLE modules (id INTEGER PRIMARY KEY)";
+        command.ExecuteNonQuery();
+
+        var migrator = new DbUpMigrator(_logger);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => migrator.Migrate("sqlite", _connectionString));
+
+        Assert.Contains("Unsafe database migration state", exception.Message);
+        Assert.Contains("neither a legacy journal nor a DbUp journal entry", exception.Message);
+        Assert.DoesNotContain("SchemaVersions", GetSqliteTableNames(_connection));
+    }
+
+    [Fact]
+    public void MigrateFailsClosedWhenJournaledSchemaIsMissingRequiredTable()
+    {
+        var migrator = new DbUpMigrator(_logger);
+        migrator.Migrate("sqlite", _connectionString);
+
+        using (var command = _connection.CreateCommand())
+        {
+            command.CommandText = "DROP TABLE audit_logs";
+            command.ExecuteNonQuery();
+        }
+
+        var exception = Assert.Throws<InvalidOperationException>(() => migrator.Migrate("sqlite", _connectionString));
+
+        Assert.Contains("Unsafe database migration state", exception.Message);
+        Assert.Contains("009_audit_logs", exception.Message);
+        Assert.Contains("audit_logs", exception.Message);
+        Assert.Equal(GetEmbeddedScriptNames(".Scripts.SQLite.").Count, GetSqliteJournalEntryCount(_connection));
+    }
+
+    [Fact]
+    public void MigrateFailsClosedWhenJournalHasGap()
+    {
+        var migrator = new DbUpMigrator(_logger);
+        migrator.Migrate("sqlite", _connectionString);
+
+        using (var command = _connection.CreateCommand())
+        {
+            command.CommandText = "DELETE FROM SchemaVersions WHERE ScriptName LIKE '%002_users_and_api_keys%'";
+            Assert.Equal(1, command.ExecuteNonQuery());
+        }
+
+        var exception = Assert.Throws<InvalidOperationException>(() => migrator.Migrate("sqlite", _connectionString));
+
+        Assert.Contains("Unsafe database migration state", exception.Message);
+        Assert.Contains("not a contiguous prefix", exception.Message);
+    }
+
     private static List<string> GetEmbeddedScriptNames(string providerFolder)
     {
         return typeof(DbUpMigrator).Assembly
@@ -252,6 +306,23 @@ public class DbUpMigratorTests : IDisposable
         return scriptNames
             .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    private static long GetSqliteJournalEntryCount(SqliteConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM SchemaVersions";
+        return (long)command.ExecuteScalar()!;
+    }
+
+    private static List<string> GetSqliteTableNames(SqliteConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT name FROM sqlite_master WHERE type = 'table'";
+        using var reader = command.ExecuteReader();
+        var tables = new List<string>();
+        while (reader.Read()) tables.Add(reader.GetString(0));
+        return tables;
     }
 
     private static List<string> GetSqliteColumns(SqliteConnection connection, string tableName)

--- a/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceConstructorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceConstructorTests.cs
@@ -29,9 +29,9 @@ public class AzureBlobModuleServiceConstructorTests
         _mockBlobServiceClient.Setup(s => s.GetBlobContainerClient(It.IsAny<string>()))
             .Returns(_mockBlobContainerClient.Object);
         _mockBlobContainerClient.Setup(c =>
-                c.CreateIfNotExists(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(),
+                c.CreateIfNotExistsAsync(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(),
                     It.IsAny<BlobContainerEncryptionScopeOptions>(), It.IsAny<CancellationToken>()))
-            .Returns(Mock.Of<Response<BlobContainerInfo>>());
+            .ReturnsAsync(Mock.Of<Response<BlobContainerInfo>>());
         _mockBlobContainerClient.Setup(c => c.GetBlobsAsync(BlobTraits.None, BlobStates.None, null, default))
             .Returns(AsyncPageable<BlobItem>.FromPages([]));
     }
@@ -50,9 +50,9 @@ public class AzureBlobModuleServiceConstructorTests
         return configBuilder.Build();
     }
 
-    // Test: Should initialize clients and create the container if it does not exist
+    // Storage I/O is deferred until hosted startup has completed database migration.
     [Fact]
-    public void ConstructorInitializesClientsAndCreatesContainerIfNotExists()
+    public async Task InitializationCreatesContainerAfterSideEffectFreeConstruction()
     {
         // Arrange
         var settings = new Dictionary<string, string?>
@@ -74,7 +74,12 @@ public class AzureBlobModuleServiceConstructorTests
         Assert.NotNull(service);
         _mockBlobServiceClient.Verify(s => s.GetBlobContainerClient(_containerName), Times.Once);
         _mockBlobContainerClient.Verify(
-            c => c.CreateIfNotExists(PublicAccessType.None, null, null, It.IsAny<CancellationToken>()), Times.Once);
+            c => c.CreateIfNotExistsAsync(PublicAccessType.None, null, null, It.IsAny<CancellationToken>()), Times.Never);
+
+        await service.InitializeStorageAsync(CancellationToken.None);
+
+        _mockBlobContainerClient.Verify(
+            c => c.CreateIfNotExistsAsync(PublicAccessType.None, null, null, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // Test: Should throw ArgumentNullException if ContainerName is missing from configuration
@@ -166,9 +171,9 @@ public class AzureBlobModuleServiceConstructorTests
             It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
     }
 
-    // Test: Should log and rethrow if CreateIfNotExists throws
+    // Test: Storage initialization propagates container failures.
     [Fact]
-    public void ConstructorLogsAndRethrowsIfCreateIfNotExistsFails()
+    public async Task InitializationRethrowsIfCreateIfNotExistsFails()
     {
         var settings = new Dictionary<string, string?>
 (StringComparer.Ordinal)
@@ -179,24 +184,18 @@ public class AzureBlobModuleServiceConstructorTests
         var configuration = CreateConfiguration(settings);
         var testException = new InvalidOperationException("fail");
         _mockBlobContainerClient.Setup(c =>
-                c.CreateIfNotExists(PublicAccessType.None, null, null, It.IsAny<CancellationToken>()))
+                c.CreateIfNotExistsAsync(PublicAccessType.None, null, null, It.IsAny<CancellationToken>()))
             .Throws(testException);
         _mockBlobServiceClient.Setup(s => s.GetBlobContainerClient(_containerName))
             .Returns(_mockBlobContainerClient.Object);
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-            new AzureBlobModuleService(configuration, _mockDatabaseService.Object, _mockLogger.Object,
-                _mockBlobServiceClient.Object));
+        var service = new AzureBlobModuleService(configuration, _mockDatabaseService.Object, _mockLogger.Object,
+            _mockBlobServiceClient.Object);
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => service.InitializeStorageAsync(CancellationToken.None));
         Assert.Equal(testException, ex);
-        _mockLogger.Verify(x => x.Log(
-            LogLevel.Error,
-            It.IsAny<EventId>(),
-            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Failed to create or verify blob container")),
-            testException,
-            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
     }
 
     [Fact]
-    public void ConstructorSynchronizesExistingBlobsIntoDatabase()
+    public async Task InitializationSynchronizesExistingBlobsIntoDatabase()
     {
         var settings = new Dictionary<string, string?>
 (StringComparer.Ordinal)
@@ -229,6 +228,9 @@ public class AzureBlobModuleServiceConstructorTests
 
         var service = new AzureBlobModuleService(configuration, _mockDatabaseService.Object, _mockLogger.Object,
             _mockBlobServiceClient.Object);
+
+        _mockDatabaseService.Verify(db => db.AddModuleAsync(It.IsAny<TerraformRegistry.Models.ModuleStorage>()), Times.Never);
+        await service.InitializeStorageAsync(CancellationToken.None);
 
         Assert.NotNull(service);
         _mockDatabaseService.Verify(db => db.AddModuleAsync(It.Is<TerraformRegistry.Models.ModuleStorage>(m =>

--- a/TerraformRegistry.Tests/UnitTests/HealthHandlersTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/HealthHandlersTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Handlers;
+using TerraformRegistry.Services;
 
 namespace TerraformRegistry.Tests.UnitTests;
 
@@ -30,6 +31,7 @@ public class HealthHandlersTests
             database.Object,
             modules.Object,
             providers.Object,
+            InitializedReadiness(),
             context,
             configuration);
 
@@ -61,6 +63,7 @@ public class HealthHandlersTests
             database.Object,
             modules.Object,
             providers.Object,
+            InitializedReadiness(),
             context,
             configuration);
 
@@ -71,6 +74,34 @@ public class HealthHandlersTests
         var providerStorage = json.RootElement.GetProperty("checks").GetProperty("providerArtifactStorage");
         Assert.Equal("unhealthy", providerStorage.GetProperty("status").GetString());
         Assert.Equal("provider bucket unavailable", providerStorage.GetProperty("reason").GetString());
+    }
+
+    [Fact]
+    public async Task HandleReadyBeforeInitialStoragePassReturns503()
+    {
+        var database = new Mock<IDatabaseService>();
+        database.Setup(service => service.CheckConnectionAsync()).ReturnsAsync(true);
+
+        var modules = new Mock<IModuleService>();
+        modules.Setup(service => service.CheckStorageAsync()).ReturnsAsync((true, null));
+
+        var providers = new Mock<IProviderArtifactStorage>();
+        providers.Setup(storage => storage.CheckStorageAsync(It.IsAny<CancellationToken>())).ReturnsAsync((true, null));
+
+        var context = CreateAuthenticatedContext();
+        var result = await HealthHandlers.HandleReady(
+            database.Object,
+            modules.Object,
+            providers.Object,
+            new StartupReadiness(),
+            context,
+            CreateConfiguration());
+
+        var json = await ExecuteAndReadJsonAsync(result, context);
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, context.Response.StatusCode);
+        Assert.Equal("not_ready", json.RootElement.GetProperty("status").GetString());
+        Assert.Equal("unhealthy", json.RootElement.GetProperty("checks").GetProperty("startup").GetProperty("status").GetString());
     }
 
     private static DefaultHttpContext CreateAuthenticatedContext()
@@ -96,6 +127,13 @@ public class HealthHandlersTests
                 ["AuthorizationToken"] = "ready-test-token"
             })
             .Build();
+    }
+
+    private static IStartupReadiness InitializedReadiness()
+    {
+        var readiness = new StartupReadiness();
+        readiness.MarkStorageInitialized();
+        return readiness;
     }
 
     private static async Task<JsonDocument> ExecuteAndReadJsonAsync(IResult result, DefaultHttpContext context)

--- a/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
@@ -30,12 +30,16 @@ public class LocalModuleServiceTests
         if (Directory.Exists(_testModulePath)) Directory.Delete(_testModulePath, true);
     }
 
-    // Verifies that the constructor creates the module storage directory if it does not exist
+    // Storage work is deferred until hosted startup completes database migration.
     [Fact]
-    public void ConstructorCreatesModuleStorageDirectory()
+    public async Task InitializeStorageCreatesModuleStorageDirectory()
     {
         // Arrange/Act
         var service = new LocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);
+        Assert.False(Directory.Exists(_testModulePath));
+
+        await service.InitializeStorageAsync(CancellationToken.None);
+
         // Assert
         Assert.True(Directory.Exists(_testModulePath));
     }

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceConstructorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceConstructorTests.cs
@@ -113,7 +113,7 @@ public class S3ModuleServiceConstructorTests
     }
 
     [Fact]
-    public void ConstructorUsesProvidedIAmazonS3AndSkipsFactory()
+    public async Task InitializationUsesProvidedIAmazonS3AndSkipsFactory()
     {
         var config = CreateConfiguration(new Dictionary<string, string?>
 (StringComparer.Ordinal)
@@ -133,6 +133,12 @@ public class S3ModuleServiceConstructorTests
         _mockClientFactory.Verify(
             x => x.Create(It.IsAny<AmazonS3Config>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()),
             Times.Never);
+        _mockS3Client.Verify(
+            x => x.ListObjectsV2Async(It.IsAny<ListObjectsV2Request>(), default),
+            Times.Never);
+
+        await service.InitializeStorageAsync(CancellationToken.None);
+
         _mockS3Client.Verify(
             x => x.ListObjectsV2Async(
                 It.Is<ListObjectsV2Request>(r => r.BucketName == "modules" && r.MaxKeys == 1),

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServicePurgeAndHealthTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServicePurgeAndHealthTests.cs
@@ -715,8 +715,7 @@ public class S3ModuleServicePurgeAndHealthTests
     public async Task CheckStorageAsyncReturnsUnhealthyWhenListFails()
     {
         _mockS3Client
-            .SetupSequence(x => x.ListObjectsV2Async(It.IsAny<ListObjectsV2Request>(), default))
-            .ReturnsAsync(new ListObjectsV2Response())
+            .Setup(x => x.ListObjectsV2Async(It.IsAny<ListObjectsV2Request>(), default))
             .ThrowsAsync(new AmazonS3Exception("bucket unavailable"));
 
         var service = CreateService();

--- a/TerraformRegistry.Tests/UnitTests/StorageInitializationHostedServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/StorageInitializationHostedServiceTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Services;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public class StorageInitializationHostedServiceTests
+{
+    [Fact]
+    public async Task StartAsyncInitializesStorageAndMarksReadinessOnlyAfterItCompletes()
+    {
+        var moduleService = new Mock<IModuleService>();
+        var initializationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowInitializationToComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        moduleService
+            .Setup(service => service.InitializeStorageAsync(It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                initializationStarted.SetResult();
+                await allowInitializationToComplete.Task;
+            });
+
+        var services = new ServiceCollection();
+        services.AddSingleton(moduleService.Object);
+        var readiness = new StartupReadiness();
+        var hostedService = new StorageInitializationHostedService(
+            services.BuildServiceProvider(),
+            readiness,
+            NullLogger<StorageInitializationHostedService>.Instance);
+
+        var startTask = hostedService.StartAsync(CancellationToken.None);
+        await initializationStarted.Task;
+        Assert.False(readiness.IsStorageInitialized);
+
+        allowInitializationToComplete.SetResult();
+        await startTask;
+
+        Assert.True(readiness.IsStorageInitialized);
+        moduleService.Verify(service => service.InitializeStorageAsync(CancellationToken.None), Times.Once);
+    }
+}

--- a/TerraformRegistry/Handlers/HealthHandlers.cs
+++ b/TerraformRegistry/Handlers/HealthHandlers.cs
@@ -17,6 +17,7 @@ public static class HealthHandlers
         IDatabaseService dbService,
         IModuleService moduleService,
         IProviderArtifactStorage providerArtifactStorage,
+        IStartupReadiness startupReadiness,
         HttpContext context,
         IConfiguration configuration)
     {
@@ -28,7 +29,7 @@ public static class HealthHandlers
         var dbHealthy = await dbTask;
         var (storageHealthy, storageReason) = await storageTask;
         var (providerStorageHealthy, providerStorageReason) = await providerStorageTask;
-        var isReady = dbHealthy && storageHealthy && providerStorageHealthy;
+        var isReady = startupReadiness.IsStorageInitialized && dbHealthy && storageHealthy && providerStorageHealthy;
 
         var wantDetail = string.Equals(
             context.Request.Query["detail"].FirstOrDefault(),
@@ -47,6 +48,11 @@ public static class HealthHandlers
                     database = new
                     {
                         status = dbHealthy ? "healthy" : "unhealthy"
+                    },
+                    startup = new
+                    {
+                        status = startupReadiness.IsStorageInitialized ? "healthy" : "unhealthy",
+                        reason = startupReadiness.IsStorageInitialized ? null : "Initial storage initialization has not completed"
                     },
                     storage = new
                     {

--- a/TerraformRegistry/Program.cs
+++ b/TerraformRegistry/Program.cs
@@ -79,8 +79,6 @@ if (authToken == "default-auth-token"
         "AuthorizationToken is set to the default placeholder value. Configure a unique secret before running outside Development/Test.");
 }
 
-app.Services.GetRequiredService<IModuleService>();
-
 app.UseHttpsRedirection();
 
 // Add global exception handling middleware early in the pipeline

--- a/TerraformRegistry/Services/LocalModuleService.cs
+++ b/TerraformRegistry/Services/LocalModuleService.cs
@@ -36,11 +36,14 @@ public class LocalModuleService : ModuleService
         // Log the storage path being used
         RegistryLog.Information(_logger, "Using local module storage path: {Path}", _moduleStorageRoot);
 
-        // Ensure module storage directory exists
-        if (!Directory.Exists(_moduleStorageRoot)) Directory.CreateDirectory(_moduleStorageRoot);
+    }
 
-        // Load existing modules from disk
+    public override Task InitializeStorageAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Directory.CreateDirectory(_moduleStorageRoot);
         LoadExistingModules();
+        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/TerraformRegistry/Services/StartupReadiness.cs
+++ b/TerraformRegistry/Services/StartupReadiness.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using TerraformRegistry.API.Interfaces;
+
+namespace TerraformRegistry.Services;
+
+public sealed class StartupReadiness : IStartupReadiness
+{
+    private int _storageInitialized;
+
+    public bool IsStorageInitialized => Volatile.Read(ref _storageInitialized) == 1;
+
+    public void MarkStorageInitialized() => Volatile.Write(ref _storageInitialized, 1);
+}

--- a/TerraformRegistry/Services/StorageInitializationHostedService.cs
+++ b/TerraformRegistry/Services/StorageInitializationHostedService.cs
@@ -1,0 +1,24 @@
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.API.Logging;
+
+namespace TerraformRegistry.Services;
+
+/// <summary>
+///     Runs the initial storage pass after database migration. Registration order ensures the
+///     database initializer completes before this service is started.
+/// </summary>
+public sealed class StorageInitializationHostedService(
+    IServiceProvider serviceProvider,
+    IStartupReadiness startupReadiness,
+    ILogger<StorageInitializationHostedService> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var moduleService = serviceProvider.GetRequiredService<IModuleService>();
+        await moduleService.InitializeStorageAsync(cancellationToken);
+        startupReadiness.MarkStorageInitialized();
+        RegistryLog.Information(logger, "Initial storage initialization completed successfully.");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/TerraformRegistry/Startup/EndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/EndpointMappingExtensions.cs
@@ -41,8 +41,9 @@ internal static class EndpointMappingExtensions
 
         app.MapGet("/ready",
                 (IDatabaseService dbService, IModuleService moduleService,
-                        IProviderArtifactStorage providerArtifactStorage, HttpContext context, IConfiguration config) =>
-                    HealthHandlers.HandleReady(dbService, moduleService, providerArtifactStorage, context, config))
+                        IProviderArtifactStorage providerArtifactStorage, IStartupReadiness startupReadiness,
+                        HttpContext context, IConfiguration config) =>
+                    HealthHandlers.HandleReady(dbService, moduleService, providerArtifactStorage, startupReadiness, context, config))
             .WithTags("Health")
             .WithDescription("Readiness probe — use ?detail=true with auth for component details")
             .Produces(200)

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -34,6 +34,7 @@ internal static class ServiceRegistrationExtensions
         services.AddSingleton<IS3ClientFactory, S3ClientFactory>();
 
         services.AddSingleton<DbUpMigrator>();
+        services.AddSingleton<IStartupReadiness, StartupReadiness>();
         services.AddSingleton<IInitializableDb>(provider =>
         {
             var db = provider.GetRequiredService<IDatabaseService>();
@@ -46,6 +47,7 @@ internal static class ServiceRegistrationExtensions
         services.AddProviderRegistryServices();
 
         services.AddHostedService<DatabaseInitializerHostedService>();
+        services.AddHostedService<StorageInitializationHostedService>();
         services.AddHttpClient();
         services.AddHttpClient("TerraformRegistryMirrorDiscovery", client =>
             {


### PR DESCRIPTION
P0-GUARD: validates unsafe/mixed/interrupted journal states before migration; moves storage initialization after migration; gates readiness until initial storage pass completes.\n\nTests: focused migration/startup/storage suite.