### PR TITLE
fix: preserve PostgreSQL VCS data during migration

### DIFF
--- a/TerraformRegistry.Migrations/Scripts/PostgreSQL/010_vcs_connections.sql
+++ b/TerraformRegistry.Migrations/Scripts/PostgreSQL/010_vcs_connections.sql
@@ -12,21 +12,69 @@ CREATE TABLE IF NOT EXISTS vcs_connections (
 );
 CREATE INDEX IF NOT EXISTS idx_vcs_connections_active ON vcs_connections(is_active);
 
-DROP TABLE IF EXISTS vcs_sources;
-CREATE TABLE vcs_sources (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    namespace VARCHAR(255) NOT NULL,
-    name VARCHAR(255) NOT NULL,
-    provider VARCHAR(255) NOT NULL,
-    repo_owner VARCHAR(255) NOT NULL,
-    repo_name VARCHAR(255) NOT NULL,
-    connection_id UUID NOT NULL REFERENCES vcs_connections(id) ON DELETE CASCADE,
-    is_active BOOLEAN NOT NULL DEFAULT true,
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_vcs_sources_module ON vcs_sources(namespace, name, provider);
-CREATE INDEX IF NOT EXISTS idx_vcs_sources_repo ON vcs_sources(repo_owner, repo_name);
-CREATE INDEX IF NOT EXISTS idx_vcs_sources_user ON vcs_sources(user_id);
+-- Do not rebuild vcs_sources here. The original migration dropped the table and
+-- irreversibly lost every source, PAT, webhook secret, and timestamp. Expand the
+-- existing table, copy each legacy credential into a connection, then contract
+-- only the duplicated credential columns after every source has a relationship.
+ALTER TABLE vcs_sources ADD COLUMN IF NOT EXISTS connection_id UUID;
+
+DO $$
+DECLARE
+    source_row RECORD;
+    new_connection_id UUID;
+BEGIN
+    FOR source_row IN
+        SELECT id, user_id, namespace, name, provider, repo_owner, repo_name,
+               pat_encrypted, webhook_secret, is_active, created_at, updated_at
+        FROM vcs_sources
+        WHERE connection_id IS NULL
+    LOOP
+        INSERT INTO vcs_connections (
+            label, provider, pat_encrypted, webhook_secret, created_by,
+            is_active, created_at, updated_at)
+        VALUES (
+            source_row.repo_owner || '/' || source_row.repo_name,
+            source_row.provider,
+            source_row.pat_encrypted,
+            source_row.webhook_secret,
+            source_row.user_id,
+            source_row.is_active,
+            source_row.created_at,
+            source_row.updated_at)
+        RETURNING id INTO new_connection_id;
+
+        UPDATE vcs_sources
+        SET connection_id = new_connection_id
+        WHERE id = source_row.id;
+    END LOOP;
+END $$;
+
+ALTER TABLE vcs_sources ALTER COLUMN connection_id SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'vcs_sources_connection_id_fkey'
+          AND conrelid = 'vcs_sources'::regclass)
+    THEN
+        ALTER TABLE vcs_sources
+            ADD CONSTRAINT vcs_sources_connection_id_fkey
+            FOREIGN KEY (connection_id) REFERENCES vcs_connections(id) ON DELETE CASCADE;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'vcs_sources_user_id_fkey'
+          AND conrelid = 'vcs_sources'::regclass)
+    THEN
+        ALTER TABLE vcs_sources
+            ADD CONSTRAINT vcs_sources_user_id_fkey
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+    END IF;
+END $$;
+
+ALTER TABLE vcs_sources DROP COLUMN IF EXISTS pat_encrypted;
+ALTER TABLE vcs_sources DROP COLUMN IF EXISTS webhook_secret;
+
 CREATE INDEX IF NOT EXISTS idx_vcs_sources_connection ON vcs_sources(connection_id);

--- a/TerraformRegistry.Migrations/Scripts/PostgreSQL/018_validate_vcs_connection_upgrade.sql
+++ b/TerraformRegistry.Migrations/Scripts/PostgreSQL/018_validate_vcs_connection_upgrade.sql
@@ -1,0 +1,25 @@
+-- Migration 010 was previously journaled after dropping vcs_sources. DbUp will
+-- not replay an edited embedded script, so do not attempt a destructive repair
+-- here. Validate the journaled shape and fail closed if it is not a complete,
+-- usable VCS connection upgrade.
+DO $$
+BEGIN
+    IF to_regclass('public.vcs_connections') IS NULL
+       OR to_regclass('public.vcs_sources') IS NULL
+       OR NOT EXISTS (
+           SELECT 1 FROM information_schema.columns
+           WHERE table_schema = 'public' AND table_name = 'vcs_sources'
+             AND column_name = 'connection_id' AND is_nullable = 'NO')
+       OR EXISTS (
+           SELECT 1 FROM information_schema.columns
+           WHERE table_schema = 'public' AND table_name = 'vcs_sources'
+             AND column_name IN ('pat_encrypted', 'webhook_secret'))
+       OR NOT EXISTS (
+           SELECT 1 FROM pg_constraint
+           WHERE conname = 'vcs_sources_connection_id_fkey'
+             AND conrelid::regclass::text = 'vcs_sources')
+    THEN
+        RAISE EXCEPTION
+            'Unsafe VCS migration state: migration 010 is journaled but vcs_sources is not a complete connection-backed schema. Restore a backup or follow the migration recovery runbook; no automatic destructive repair was attempted.';
+    END IF;
+END $$;

--- a/TerraformRegistry.Tests/DbUpPostgresqlMigrationTests.cs
+++ b/TerraformRegistry.Tests/DbUpPostgresqlMigrationTests.cs
@@ -287,6 +287,88 @@ public class DbUpPostgresqlMigrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Migration010PreservesPopulatedLegacyVcsSourcesAndCredentials()
+    {
+        var connectionString = CreateFreshDatabase();
+        MigrateUpTo(9, connectionString);
+
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            INSERT INTO users (id, email, provider, provider_id, created_at, updated_at)
+            VALUES ('user-1', 'test@example.com', 'github', 'gh-123', '2024-01-02T03:04:05Z', '2024-02-03T04:05:06Z');
+            INSERT INTO vcs_sources (id, user_id, namespace, name, provider, repo_owner, repo_name, pat_encrypted, webhook_secret, is_active, created_at, updated_at)
+            VALUES
+                ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'user-1', 'hashicorp', 'consul', 'aws', 'hashicorp', 'terraform-aws-consul', 'encrypted-pat-a', 'webhook-a', true, '2024-03-04T05:06:07Z', '2024-04-05T06:07:08Z'),
+                ('b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'user-1', 'hashicorp', 'vault', 'aws', 'hashicorp', 'terraform-aws-vault', 'encrypted-pat-b', 'webhook-b', false, '2024-05-06T07:08:09Z', '2024-06-07T08:09:10Z');";
+        await cmd.ExecuteNonQueryAsync();
+
+        MigrateUpTo(10, connectionString);
+
+        cmd.CommandText = @"
+            SELECT s.id, s.user_id, s.namespace, s.name, s.provider, s.repo_owner, s.repo_name,
+                   s.is_active, s.created_at, s.updated_at,
+                   c.pat_encrypted, c.webhook_secret, c.created_by, c.is_active, c.created_at, c.updated_at
+            FROM vcs_sources s
+            JOIN vcs_connections c ON c.id = s.connection_id
+            ORDER BY s.id";
+        await using var reader = await cmd.ExecuteReaderAsync();
+
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", reader.GetGuid(0).ToString());
+        Assert.Equal("user-1", reader.GetString(1));
+        Assert.Equal("hashicorp", reader.GetString(2));
+        Assert.Equal("consul", reader.GetString(3));
+        Assert.Equal("aws", reader.GetString(4));
+        Assert.Equal("hashicorp", reader.GetString(5));
+        Assert.Equal("terraform-aws-consul", reader.GetString(6));
+        Assert.True(reader.GetBoolean(7));
+        Assert.Equal(DateTimeOffset.Parse("2024-03-04T05:06:07Z", CultureInfo.InvariantCulture), reader.GetFieldValue<DateTimeOffset>(8));
+        Assert.Equal(DateTimeOffset.Parse("2024-04-05T06:07:08Z", CultureInfo.InvariantCulture), reader.GetFieldValue<DateTimeOffset>(9));
+        Assert.Equal("encrypted-pat-a", reader.GetString(10));
+        Assert.Equal("webhook-a", reader.GetString(11));
+        Assert.Equal("user-1", reader.GetString(12));
+        Assert.True(reader.GetBoolean(13));
+        Assert.Equal(DateTimeOffset.Parse("2024-03-04T05:06:07Z", CultureInfo.InvariantCulture), reader.GetFieldValue<DateTimeOffset>(14));
+        Assert.Equal(DateTimeOffset.Parse("2024-04-05T06:07:08Z", CultureInfo.InvariantCulture), reader.GetFieldValue<DateTimeOffset>(15));
+
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal("b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", reader.GetGuid(0).ToString());
+        Assert.Equal("encrypted-pat-b", reader.GetString(10));
+        Assert.Equal("webhook-b", reader.GetString(11));
+        Assert.False(reader.GetBoolean(13));
+        Assert.False(await reader.ReadAsync());
+    }
+
+    [Fact]
+    public async Task Migration018RejectsMalformedAlreadyJournaledVcsConnectionStateWithoutDeletingRows()
+    {
+        var connectionString = CreateFreshDatabase();
+        MigrateUpTo(10, connectionString);
+
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            INSERT INTO users (id, email, provider, provider_id, created_at, updated_at)
+            VALUES ('user-1', 'test@example.com', 'github', 'gh-123', NOW(), NOW());
+            INSERT INTO vcs_connections (id, label, provider, webhook_secret, created_by, is_active, created_at, updated_at)
+            VALUES ('c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'connection', 'github', 'secret', 'user-1', true, NOW(), NOW());
+            INSERT INTO vcs_sources (id, user_id, namespace, name, provider, repo_owner, repo_name, connection_id, is_active, created_at, updated_at)
+            VALUES ('d0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'user-1', 'hashicorp', 'consul', 'aws', 'hashicorp', 'terraform-aws-consul', 'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', true, NOW(), NOW());
+            ALTER TABLE vcs_sources DROP CONSTRAINT vcs_sources_connection_id_fkey;
+            ALTER TABLE vcs_sources ALTER COLUMN connection_id DROP NOT NULL;";
+        await cmd.ExecuteNonQueryAsync();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => MigrateUpTo(18, connectionString));
+        Assert.Contains("Unsafe VCS migration state", exception.ToString());
+
+        cmd.CommandText = "SELECT COUNT(*) FROM vcs_sources WHERE id = 'd0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'";
+        Assert.Equal(1L, (long)(await cmd.ExecuteScalarAsync())!);
+    }
+
+    [Fact]
     public async Task Migration011AddsWebhooksUserIdIndex()
     {
         var connStr = CreateFreshDatabase();


### PR DESCRIPTION
## Scope
Preserves populated legacy `vcs_sources` data when migration 010 introduces VCS connections, and fails closed for unsafe already-journaled states.

## Verification
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-build --filter "FullyQualifiedName~DbUpPostgresqlMigrationTests" --logger "console;verbosity=minimal"` (22 passed)
- `git diff --check`