### PR TITLE
ci: restrict image publishing eligibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -227,8 +227,16 @@ jobs:
       - dotnet
       - frontend
       - docker
-    # Merge-queue and PR builds are deliberately ineligible for registry credentials.
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push_image)
+    # PRs, merge-queue candidates, and remediation-phase branches are deliberately
+    # ineligible for registry credentials.  Only integration/release pushes (or an
+    # explicitly requested manual publication) may receive package write access.
+    if: >-
+      (github.event_name == 'push' &&
+        (github.ref == 'refs/heads/main' ||
+         github.ref == 'refs/heads/develop' ||
+         startsWith(github.ref, 'refs/heads/release/') ||
+         startsWith(github.ref, 'refs/heads/hotfix/'))) ||
+      (github.event_name == 'workflow_dispatch' && inputs.push_image)
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Scope
Fixes the CI bootstrap publish-job guard required by the remediation delivery plan.

The image publication job now receives write permissions only for integration/release push branches, or an explicitly requested manual publish. Pull requests, merge-queue candidates, and remediation phase pushes remain scan-only.

## Verification
- git diff --check
- GitHub Actions workflow validation through this PR

## Non-goals
No application, Dockerfile, or registry behavior changes.