### PR TITLE
fix: make container provider storage writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV TF_REG_Sqlite__ConnectionString="Data Source=/data/terraform.db"
 RUN apk upgrade --no-cache
 COPY --from=publish /app/publish .
 COPY --from=terraform-config-inspect /out/terraform-config-inspect /usr/local/bin/terraform-config-inspect
-RUN mkdir -p /app/modules /data && chown app:app /app/modules /data
+RUN mkdir -p /app/modules /app/providers /data && chown app:app /app/modules /app/providers /data
 # Create web directory and copy static files
 COPY TerraformRegistry/web /app/web
 USER app

--- a/TerraformRegistry.Tests/AssemblyInfo.cs
+++ b/TerraformRegistry.Tests/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+// Integration tests create disposable Docker resources and in-process hosts.
+// Serializing the assembly prevents startup and port races from masking the
+// behavior under test in CI.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/TerraformRegistry.Tests/DbUpPostgresqlMigrationTests.cs
+++ b/TerraformRegistry.Tests/DbUpPostgresqlMigrationTests.cs
@@ -884,11 +884,23 @@ public class DbUpPostgresqlMigrationTests : IAsyncLifetime
     private string CreateFreshDatabase()
     {
         var dbName = $"test_{Guid.NewGuid():N}";
-        using var conn = new NpgsqlConnection(_postgresContainer.GetConnectionString());
-        conn.Open();
-        using var cmd = conn.CreateCommand();
-        cmd.CommandText = $"CREATE DATABASE \"{dbName}\"";
-        cmd.ExecuteNonQuery();
+        var deadline = DateTime.UtcNow.AddSeconds(30);
+        while (true)
+        {
+            try
+            {
+                using var conn = new NpgsqlConnection(_postgresContainer.GetConnectionString());
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = $"CREATE DATABASE \"{dbName}\"";
+                cmd.ExecuteNonQuery();
+                break;
+            }
+            catch (PostgresException exception) when (exception.SqlState == "57P03" && DateTime.UtcNow < deadline)
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(250));
+            }
+        }
 
         var builder = new NpgsqlConnectionStringBuilder(_postgresContainer.GetConnectionString())
         {


### PR DESCRIPTION
P1-DOCKER / DEP-002. Ensures the declared non-root container user owns and can write the default provider store. Verified by building the image and asserting module, provider, and data paths are writable as the image user.