### PR TITLE
fix: return protocol status for all module downloads

### DIFF
--- a/TerraformRegistry.Tests/UnitTests/ModuleMirrorServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleMirrorServiceTests.cs
@@ -520,7 +520,7 @@ public sealed class ModuleMirrorServiceTests
     }
 
     [Fact]
-    public async Task LatestDownloadUsesUpstreamVersionsWhenNoLocalVersionExists()
+    public async Task LatestDownloadUsesProtocolStatusWithoutTerraformUserAgent()
     {
         var moduleService = new Mock<IModuleService>();
         moduleService.Setup(x => x.GetModuleVersionsAsync("hashicorp", "vpc", "aws"))
@@ -542,7 +542,7 @@ public sealed class ModuleMirrorServiceTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync("/module/download?token=latest");
         var context = new DefaultHttpContext();
-        context.Request.Headers.UserAgent = "Terraform/1.9";
+        context.Request.Headers.UserAgent = "generic-http-client";
 
         var result = await ModuleHandlers.DownloadLatestModule(
             "hashicorp",

--- a/TerraformRegistry/Handlers/ModuleHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleHandlers.cs
@@ -194,19 +194,10 @@ public static class ModuleHandlers
             }
         });
 
-        // Terraform CLI expects 204 + X-Terraform-Get. Portal/browser should follow a redirect.
-        var accept = context.Request.Headers["Accept"].ToString();
-        var isTerraformClient = userAgent.Contains("Terraform", StringComparison.OrdinalIgnoreCase) ||
-                                accept.Contains("terraform", StringComparison.OrdinalIgnoreCase);
-
-        if (isTerraformClient)
-        {
-            return NoContent();
-        }
-
-        context.Response.Headers.Location = downloadPath;
-        context.Response.StatusCode = StatusCodes.Status302Found;
-        return Empty;
+        // The module registry protocol always uses 204 with X-Terraform-Get.  The
+        // result must not vary with User-Agent because Terraform-compatible clients
+        // are not required to identify themselves as Terraform.
+        return NoContent();
     }
 
     /// <summary>


### PR DESCRIPTION
P1-PROTOCOL / MOD-004. Exact-version module downloads always return 204 with X-Terraform-Get, independent of User-Agent. The latest-version endpoint retains canonical version resolution. Focused handler tests pass.