### PR TITLE
security: preserve zero-role least privilege

### DIFF
--- a/TerraformRegistry.API/Permissions.cs
+++ b/TerraformRegistry.API/Permissions.cs
@@ -50,9 +50,6 @@ public static class Permissions
 
     public static readonly string[] DefaultUserPermissions =
     [
-        ModulesRead, ModulesUpload, ModulesDelete, ModulesRestore,
-        ModulesDescription,
-        ProvidersRead,
-        ApiKeysManage, AnalyticsView
+        ModulesRead, ProvidersRead, AnalyticsView
     ];
 }

--- a/TerraformRegistry.Tests/IntegrationTests/ApiKeyExpirationTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/ApiKeyExpirationTests.cs
@@ -18,6 +18,7 @@ public class ApiKeyExpirationTests(ITestOutputHelper output) : IntegrationTestBa
         using var scope = Factory.Services.CreateScope();
         var apiKeyService = scope.ServiceProvider.GetRequiredService<IApiKeyService>();
         var dbService = scope.ServiceProvider.GetRequiredService<IDatabaseService>();
+        var permissionService = scope.ServiceProvider.GetRequiredService<IPermissionService>();
 
         var user = new User
         {
@@ -29,6 +30,7 @@ public class ApiKeyExpirationTests(ITestOutputHelper output) : IntegrationTestBa
             UpdatedAt = DateTime.UtcNow
         };
         await dbService.AddUserAsync(user);
+        await permissionService.EnsureDefaultRoleAsync(user.Id);
 
         var (rawToken, apiKey) = await apiKeyService.CreateApiKeyAsync(user.Id, "expired key");
         apiKey.ExpiresAt = DateTime.UtcNow.AddHours(-1);
@@ -45,11 +47,40 @@ public class ApiKeyExpirationTests(ITestOutputHelper output) : IntegrationTestBa
     }
 
     [Fact]
+    public async Task ApiKeyForUserWithoutRolesReturnsForbidden()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var apiKeyService = scope.ServiceProvider.GetRequiredService<IApiKeyService>();
+        var dbService = scope.ServiceProvider.GetRequiredService<IDatabaseService>();
+
+        var user = new User
+        {
+            Id = Guid.NewGuid().ToString(),
+            Email = "zero-role-test@example.com",
+            Provider = "test",
+            ProviderId = "test-zero-role",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        await dbService.AddUserAsync(user);
+
+        var (rawToken, _) = await apiKeyService.CreateApiKeyAsync(user.Id, "zero role key");
+
+        var client = Factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", rawToken);
+
+        var response = await client.GetAsync("/v1/modules");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
     public async Task ValidApiKeyWithFutureExpirationSucceeds()
     {
         using var scope = Factory.Services.CreateScope();
         var apiKeyService = scope.ServiceProvider.GetRequiredService<IApiKeyService>();
         var dbService = scope.ServiceProvider.GetRequiredService<IDatabaseService>();
+        var permissionService = scope.ServiceProvider.GetRequiredService<IPermissionService>();
 
         var user = new User
         {
@@ -61,6 +92,7 @@ public class ApiKeyExpirationTests(ITestOutputHelper output) : IntegrationTestBa
             UpdatedAt = DateTime.UtcNow
         };
         await dbService.AddUserAsync(user);
+        await permissionService.EnsureDefaultRoleAsync(user.Id);
 
         var (rawToken, apiKey) = await apiKeyService.CreateApiKeyAsync(user.Id, "future key");
         apiKey.ExpiresAt = DateTime.UtcNow.AddDays(30);
@@ -79,6 +111,7 @@ public class ApiKeyExpirationTests(ITestOutputHelper output) : IntegrationTestBa
         using var scope = Factory.Services.CreateScope();
         var apiKeyService = scope.ServiceProvider.GetRequiredService<IApiKeyService>();
         var dbService = scope.ServiceProvider.GetRequiredService<IDatabaseService>();
+        var permissionService = scope.ServiceProvider.GetRequiredService<IPermissionService>();
 
         var user = new User
         {
@@ -90,6 +123,7 @@ public class ApiKeyExpirationTests(ITestOutputHelper output) : IntegrationTestBa
             UpdatedAt = DateTime.UtcNow
         };
         await dbService.AddUserAsync(user);
+        await permissionService.EnsureDefaultRoleAsync(user.Id);
 
         var (rawToken, _) = await apiKeyService.CreateApiKeyAsync(user.Id, "no expiry key");
 

--- a/TerraformRegistry.Tests/IntegrationTests/TerraformLoginTokenTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/TerraformLoginTokenTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Services;
 using Xunit.Abstractions;
 
@@ -89,8 +90,10 @@ public class TerraformLoginTokenTests(ITestOutputHelper output) : IntegrationTes
         using var scope = Factory.Services.CreateScope();
         var apiKeyService = scope.ServiceProvider.GetRequiredService<IApiKeyService>();
         var jwtService = scope.ServiceProvider.GetRequiredService<JwtService>();
+        var permissionService = scope.ServiceProvider.GetRequiredService<IPermissionService>();
 
         var user = await apiKeyService.GetOrCreateUserAsync(email, "test", Guid.NewGuid().ToString("N"));
+        await permissionService.EnsureDefaultRoleAsync(user.Id);
 
         var jwt = jwtService.GenerateToken(user.Id, email, "CLI User", "test");
         var client = Factory.CreateClient(new WebApplicationFactoryClientOptions

--- a/TerraformRegistry/Middleware/AuthenticationMiddleware.cs
+++ b/TerraformRegistry/Middleware/AuthenticationMiddleware.cs
@@ -186,7 +186,6 @@ public class AuthenticationMiddleware(
 
     /// <summary>
     /// Loads the user's RBAC permissions from the database and adds them as claims.
-    /// If the user has no roles yet, assigns the default role first (lazy bootstrap).
     /// </summary>
     private static async Task LoadPermissionsIntoClaims(HttpContext context)
     {
@@ -196,15 +195,6 @@ public class AuthenticationMiddleware(
         using var permScope = context.RequestServices.CreateScope();
         var permService = permScope.ServiceProvider.GetRequiredService<IPermissionService>();
         var perms = await permService.GetUserPermissionsAsync(userId);
-
-        // Lazy bootstrap: if the user has no permissions (no roles assigned yet),
-        // assign the default role and reload. This handles API-key-only users who
-        // never went through the login flow.
-        if (perms.Length == 0)
-        {
-            await permService.EnsureDefaultRoleAsync(userId);
-            perms = await permService.GetUserPermissionsAsync(userId);
-        }
 
         if (context.User.Identity is ClaimsIdentity identity)
         {


### PR DESCRIPTION
P1-AUTH / IAM-001, IAM-011. Removes request-time default-role assignment so role removal remains effective. The explicitly assigned built-in user role is reduced to read-only permissions. Focused authorization tests pass.