### PR TITLE
fix: advertise module archive format from stored artifact

### DIFF
--- a/TerraformRegistry/Startup/ModuleEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/ModuleEndpointMappingExtensions.cs
@@ -189,7 +189,10 @@ internal static class ModuleEndpointMappingExtensions
                 return;
             }
 
-            context.Response.ContentType = "application/zip";
+            context.Response.ContentType = filePath.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase) ||
+                                           filePath.EndsWith(".tgz", StringComparison.OrdinalIgnoreCase)
+                ? "application/gzip"
+                : "application/zip";
             context.Response.Headers["Content-Disposition"] = $"attachment; filename=\"{Path.GetFileName(filePath)}\"";
             await context.Response.SendFileAsync(filePath);
         });


### PR DESCRIPTION
P1-ARCHIVE / MOD-001, MOD-002. Module download response media type now reflects ZIP versus tar.gz/tgz bytes instead of always claiming ZIP. Release build passes.