### PR TITLE
ci: capture diagnostics for hung test hosts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,8 @@ jobs:
             --logger "trx;LogFileName=test_results.trx" \
             --results-directory "$TEST_RESULTS_DIR" \
             --collect "XPlat Code Coverage" \
+            --blame-hang \
+            --blame-hang-timeout 5m \
             -- \
             DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
         env:


### PR DESCRIPTION
Adds a five-minute VSTest hang collector to the coverage command. A genuinely hung test host now fails with diagnostics instead of holding a required phase check indefinitely. This does not suppress or skip tests.