### PR TITLE
fix: enforce module download storage conformance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,6 +152,44 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  storage-emulator-contract:
+    name: Storage emulator Terraform contract
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run Azurite and MinIO Terraform contract smoke
+        run: >-
+          bash scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
+          --provider all
+          --home "$RUNNER_TEMP/terraform-registry-storage-test"
+
+      - name: Collect storage emulator logs
+        if: failure()
+        run: |
+          harness="$RUNNER_TEMP/terraform-registry-storage-test"
+          project="tfregstorage$(printf '%s' "$harness" | sha256sum | cut -c1-12)"
+          docker compose --project-name "$project" --project-directory "$harness" -f "$harness/compose.yaml" logs --no-color > storage-emulator-compose.log || true
+
+      - name: Upload storage emulator logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: storage-emulator-compose-logs
+          path: storage-emulator-compose.log
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Clean storage emulator harness
+        if: always()
+        run: >-
+          bash scripts/remediation/storage-emulators/storage-emulators.sh clean
+          --home "$RUNNER_TEMP/terraform-registry-storage-test" || true
+
   docker:
     name: Docker build and scan
     needs:

--- a/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
+++ b/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
@@ -218,7 +218,7 @@ public class AzureBlobModuleService : ModuleService
         string version, Stream moduleContent, string description, bool replace, ModuleArtifactMetadata? metadata)
     {
         // Create a consistent blob path format for easy retrieval
-        var blobPath = $"{moduleNamespace}/{name}-{provider}-{version}.zip";
+        var blobPath = $"{moduleNamespace}/{name}-{provider}-{version}{ModuleArchiveFormat.GetFileSuffix(metadata)}";
         var blobClient = _containerClient.GetBlobClient(blobPath);
 
         // Check if blob already exists to avoid duplication or allow replacement

--- a/TerraformRegistry.Models/ModuleArchiveFormat.cs
+++ b/TerraformRegistry.Models/ModuleArchiveFormat.cs
@@ -26,6 +26,6 @@ public static class ModuleArchiveFormat
         return moduleStorage.FilePath.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase) ||
                moduleStorage.FilePath.EndsWith(".tgz", StringComparison.OrdinalIgnoreCase)
             ? "tar.gz"
-            : null;
+            : "zip";
     }
 }

--- a/TerraformRegistry.Models/ModuleArchiveFormat.cs
+++ b/TerraformRegistry.Models/ModuleArchiveFormat.cs
@@ -5,6 +5,15 @@ namespace TerraformRegistry.Models;
 /// </summary>
 public static class ModuleArchiveFormat
 {
+    public static string GetFileSuffix(ModuleArtifactMetadata? metadata)
+    {
+        var recordedFormat = metadata?.Source?.ArchiveFormat;
+        return string.Equals(recordedFormat, "tar.gz", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(recordedFormat, "tgz", StringComparison.OrdinalIgnoreCase)
+            ? ".tar.gz"
+            : ".zip";
+    }
+
     public static string? GetGoGetterHint(ModuleStorage moduleStorage)
     {
         var recordedFormat = moduleStorage.Metadata.Source?.ArchiveFormat;

--- a/TerraformRegistry.Models/ModuleArchiveFormat.cs
+++ b/TerraformRegistry.Models/ModuleArchiveFormat.cs
@@ -1,0 +1,22 @@
+namespace TerraformRegistry.Models;
+
+/// <summary>
+/// Resolves the go-getter archive hint for a stored module artifact.
+/// </summary>
+public static class ModuleArchiveFormat
+{
+    public static string? GetGoGetterHint(ModuleStorage moduleStorage)
+    {
+        var recordedFormat = moduleStorage.Metadata.Source?.ArchiveFormat;
+        if (string.Equals(recordedFormat, "tar.gz", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(recordedFormat, "tgz", StringComparison.OrdinalIgnoreCase))
+        {
+            return "tar.gz";
+        }
+
+        return moduleStorage.FilePath.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase) ||
+               moduleStorage.FilePath.EndsWith(".tgz", StringComparison.OrdinalIgnoreCase)
+            ? "tar.gz"
+            : null;
+    }
+}

--- a/TerraformRegistry.Models/ModuleArchiveFormat.cs
+++ b/TerraformRegistry.Models/ModuleArchiveFormat.cs
@@ -5,6 +5,14 @@ namespace TerraformRegistry.Models;
 /// </summary>
 public static class ModuleArchiveFormat
 {
+    public static string GetUploadArchiveFormat(string fileName)
+    {
+        return fileName.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase) ||
+               fileName.EndsWith(".tgz", StringComparison.OrdinalIgnoreCase)
+            ? "tar.gz"
+            : "zip";
+    }
+
     public static string GetFileSuffix(ModuleArtifactMetadata? metadata)
     {
         var recordedFormat = metadata?.Source?.ArchiveFormat;

--- a/TerraformRegistry.S3/S3ModuleObjectKeys.cs
+++ b/TerraformRegistry.S3/S3ModuleObjectKeys.cs
@@ -2,14 +2,19 @@ namespace TerraformRegistry.S3;
 
 internal static class S3ModuleObjectKeys
 {
-    public static string CreateLogicalObjectKey(string @namespace, string name, string provider, string version)
+    public static string CreateLogicalObjectKey(string @namespace, string name, string provider, string version,
+        string fileSuffix)
     {
-        return $"{@namespace}/{name}-{provider}-{version}.zip";
+        return $"{@namespace}/{name}-{provider}-{version}{fileSuffix}";
     }
 
     public static string CreateFinalObjectKey(string logicalObjectKey)
     {
-        return $"{logicalObjectKey}.{Guid.NewGuid():N}";
+        var fileSuffix = logicalObjectKey.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase)
+            ? ".tar.gz"
+            : ".zip";
+        var stem = logicalObjectKey[..^fileSuffix.Length];
+        return $"{stem}.{Guid.NewGuid():N}{fileSuffix}";
     }
 
     public static string CreateTemporaryObjectKey(string objectKey)

--- a/TerraformRegistry.S3/S3ModuleObjectKeys.cs
+++ b/TerraformRegistry.S3/S3ModuleObjectKeys.cs
@@ -3,7 +3,7 @@ namespace TerraformRegistry.S3;
 internal static class S3ModuleObjectKeys
 {
     public static string CreateLogicalObjectKey(string @namespace, string name, string provider, string version,
-        string fileSuffix)
+        string fileSuffix = ".zip")
     {
         return $"{@namespace}/{name}-{provider}-{version}{fileSuffix}";
     }

--- a/TerraformRegistry.S3/S3ModuleObjectStore.cs
+++ b/TerraformRegistry.S3/S3ModuleObjectStore.cs
@@ -12,6 +12,7 @@ internal sealed class S3ModuleObjectStore(
     IAmazonS3 s3Client,
     string bucketName,
     int presignedUrlExpiryMinutes,
+    bool useHttp,
     ILogger logger)
 {
     public async Task InitializeStorageAsync(CancellationToken cancellationToken)
@@ -85,6 +86,7 @@ internal sealed class S3ModuleObjectStore(
                 BucketName = bucketName,
                 Key = moduleStorage.FilePath,
                 Verb = HttpVerb.GET,
+                Protocol = useHttp ? Protocol.HTTP : Protocol.HTTPS,
                 Expires = DateTime.UtcNow.AddMinutes(presignedUrlExpiryMinutes)
             });
         }

--- a/TerraformRegistry.S3/S3ModuleService.cs
+++ b/TerraformRegistry.S3/S3ModuleService.cs
@@ -47,6 +47,8 @@ public class S3ModuleService : ModuleService
             resolvedS3Client,
             bucketName,
             presignedUrlExpiryMinutes,
+            Uri.TryCreate(configuration["S3:ServiceUrl"], UriKind.Absolute, out var endpoint) &&
+            string.Equals(endpoint.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase),
             logger);
         _uploadWorkflow = new S3ModuleUploadWorkflow(_databaseService, _objectStore, logger);
         _purgeWorkflow = new S3ModulePurgeWorkflow(_databaseService, _objectStore, logger);
@@ -175,6 +177,8 @@ public class S3ModuleService : ModuleService
         if (!string.IsNullOrWhiteSpace(serviceUrl))
         {
             config.ServiceURL = serviceUrl;
+            config.UseHttp = Uri.TryCreate(serviceUrl, UriKind.Absolute, out var endpoint) &&
+                             string.Equals(endpoint.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase);
         }
 
         return (s3ClientFactory ?? new S3ClientFactory()).Create(

--- a/TerraformRegistry.S3/S3ModuleUploadWorkflow.cs
+++ b/TerraformRegistry.S3/S3ModuleUploadWorkflow.cs
@@ -53,7 +53,8 @@ internal sealed class S3ModuleUploadWorkflow(
             return false;
         }
 
-        var logicalObjectKey = S3ModuleObjectKeys.CreateLogicalObjectKey(@namespace, name, provider, version);
+        var logicalObjectKey = S3ModuleObjectKeys.CreateLogicalObjectKey(@namespace, name, provider, version,
+            ModuleArchiveFormat.GetFileSuffix(metadata));
         var objectKey = S3ModuleObjectKeys.CreateFinalObjectKey(logicalObjectKey);
         var newModule = new ModuleStorage
         {

--- a/TerraformRegistry.S3/S3ProviderArtifactStorage.cs
+++ b/TerraformRegistry.S3/S3ProviderArtifactStorage.cs
@@ -15,6 +15,7 @@ public sealed partial class S3ProviderArtifactStorage : IProviderArtifactStorage
     private readonly ILogger<S3ProviderArtifactStorage> _logger;
     private readonly int _presignedUrlExpiryMinutes;
     private readonly IAmazonS3 _s3Client;
+    private readonly bool _useHttp;
 
     public S3ProviderArtifactStorage(
         IConfiguration configuration,
@@ -31,6 +32,8 @@ public sealed partial class S3ProviderArtifactStorage : IProviderArtifactStorage
         }
 
         _bucketName = bucketName;
+        _useHttp = Uri.TryCreate(configuration["S3:ServiceUrl"], UriKind.Absolute, out var configuredEndpoint) &&
+                   string.Equals(configuredEndpoint.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase);
 
         var region = configuration["S3:Region"];
         if (string.IsNullOrWhiteSpace(region))
@@ -64,6 +67,7 @@ public sealed partial class S3ProviderArtifactStorage : IProviderArtifactStorage
         if (!string.IsNullOrWhiteSpace(serviceUrl))
         {
             config.ServiceURL = serviceUrl;
+            config.UseHttp = _useHttp;
         }
 
         _s3Client = (s3ClientFactory ?? new S3ClientFactory()).Create(
@@ -142,6 +146,7 @@ public sealed partial class S3ProviderArtifactStorage : IProviderArtifactStorage
             BucketName = _bucketName,
             Key = objectKey,
             Verb = HttpVerb.GET,
+            Protocol = _useHttp ? Protocol.HTTP : Protocol.HTTPS,
             Expires = DateTime.UtcNow.AddMinutes(_presignedUrlExpiryMinutes)
         });
     }

--- a/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
@@ -167,6 +167,7 @@ public class LocalModuleServiceTests
         // Assert
         Assert.NotNull(result);
         Assert.StartsWith("/module/download?token=", result);
+        Assert.Contains("archive=zip", result, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
@@ -159,11 +159,60 @@ public class LocalModuleServiceTests
             Dependencies = new List<string>()
         };
         _mockDbService.Setup(x => x.GetModuleStorageAsync("ns", "name", "provider", "1.0.0")).ReturnsAsync(storage);
+        Directory.CreateDirectory(Path.GetDirectoryName(storage.FilePath)!);
+        await File.WriteAllBytesAsync(storage.FilePath, [0x50, 0x4B, 0x03, 0x04]);
+
         // Act
         var result = await service.GetModuleDownloadPathAsync("ns", "name", "provider", "1.0.0");
         // Assert
         Assert.NotNull(result);
         Assert.StartsWith("/module/download?token=", result);
+    }
+
+    [Fact]
+    public async Task GetModuleDownloadPathAsyncReturnsNullWhenArtifactIsMissing()
+    {
+        var service = new LocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);
+        var storage = new ModuleStorage
+        {
+            Namespace = "ns",
+            Name = "name",
+            Provider = "provider",
+            Version = "1.0.0",
+            Description = "desc",
+            FilePath = Path.Combine(_testModulePath, "ns", "missing.zip"),
+            PublishedAt = DateTime.UtcNow,
+            Dependencies = []
+        };
+        _mockDbService.Setup(x => x.GetModuleStorageAsync("ns", "name", "provider", "1.0.0")).ReturnsAsync(storage);
+
+        var result = await service.GetModuleDownloadPathAsync("ns", "name", "provider", "1.0.0");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetModuleDownloadPathAsyncAddsTarGzHintForTarArtifact()
+    {
+        var service = new LocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);
+        var storage = new ModuleStorage
+        {
+            Namespace = "ns",
+            Name = "name",
+            Provider = "provider",
+            Version = "1.0.0",
+            Description = "desc",
+            FilePath = Path.Combine(_testModulePath, "ns", "name-provider-1.0.0.tar.gz"),
+            PublishedAt = DateTime.UtcNow,
+            Dependencies = []
+        };
+        Directory.CreateDirectory(Path.GetDirectoryName(storage.FilePath)!);
+        await File.WriteAllBytesAsync(storage.FilePath, [0x1F, 0x8B]);
+        _mockDbService.Setup(x => x.GetModuleStorageAsync("ns", "name", "provider", "1.0.0")).ReturnsAsync(storage);
+
+        var result = await service.GetModuleDownloadPathAsync("ns", "name", "provider", "1.0.0");
+
+        Assert.Contains("archive=tar.gz", result, StringComparison.Ordinal);
     }
 
     // Verifies that TryGetFilePathFromToken returns false and an empty file path for an invalid token

--- a/TerraformRegistry.Tests/UnitTests/ModuleArchiveFormatTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleArchiveFormatTests.cs
@@ -1,0 +1,22 @@
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public class ModuleArchiveFormatTests
+{
+    [Theory]
+    [InlineData("module.tar.gz")]
+    [InlineData("module.TGZ")]
+    public void GetUploadArchiveFormatReturnsTarGzForTarArchives(string fileName)
+    {
+        Assert.Equal("tar.gz", ModuleArchiveFormat.GetUploadArchiveFormat(fileName));
+    }
+
+    [Theory]
+    [InlineData("module.zip")]
+    [InlineData("module")]
+    public void GetUploadArchiveFormatReturnsZipForOtherFiles(string fileName)
+    {
+        Assert.Equal("zip", ModuleArchiveFormat.GetUploadArchiveFormat(fileName));
+    }
+}

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceConstructorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceConstructorTests.cs
@@ -166,6 +166,7 @@ public class S3ModuleServiceConstructorTests
             .Callback<AmazonS3Config, string?, string?, string?>((cfg, _, _, _) =>
             {
                 Assert.Equal("http://minio:9000", new Uri(cfg.ServiceURL).GetLeftPart(UriPartial.Authority));
+                Assert.True(cfg.UseHttp);
                 Assert.True(cfg.ForcePathStyle);
                 Assert.Equal("eu-west-2", cfg.AuthenticationRegion);
             })

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceDownloadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceDownloadTests.cs
@@ -24,17 +24,16 @@ public class S3ModuleServiceDownloadTests
             .ReturnsAsync(new ListObjectsV2Response());
     }
 
-    private static IConfiguration CreateConfiguration()
+    private static IConfiguration CreateConfiguration(string? serviceUrl = null)
     {
-        return new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-(StringComparer.Ordinal)
-            {
-                ["S3:BucketName"] = "modules",
-                ["S3:Region"] = "eu-west-2",
-                ["S3:PresignedUrlExpiryMinutes"] = "11"
-            })
-            .Build();
+        var values = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["S3:BucketName"] = "modules",
+            ["S3:Region"] = "eu-west-2",
+            ["S3:PresignedUrlExpiryMinutes"] = "11"
+        };
+        if (serviceUrl != null) values["S3:ServiceUrl"] = serviceUrl;
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
     }
 
     private static ModuleStorage CreateModuleStorage()
@@ -51,10 +50,10 @@ public class S3ModuleServiceDownloadTests
         };
     }
 
-    private S3ModuleService CreateService()
+    private S3ModuleService CreateService(string? serviceUrl = null)
     {
         return new S3ModuleService(
-            CreateConfiguration(),
+            CreateConfiguration(serviceUrl),
             _mockDatabaseService.Object,
             _mockLogger.Object,
             _mockS3Client.Object);
@@ -67,7 +66,7 @@ public class S3ModuleServiceDownloadTests
             .Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0"))
             .ReturnsAsync(value: null);
 
-        var service = CreateService();
+        var service = CreateService("http://minio:9000");
 
         var result = await service.GetModuleDownloadPathAsync("ns", "name", "aws", "1.0.0");
 
@@ -135,7 +134,7 @@ public class S3ModuleServiceDownloadTests
             .Callback<GetPreSignedUrlRequest>(request => capturedRequest = request)
             .Returns(expectedUrl);
 
-        var service = CreateService();
+        var service = CreateService("http://minio:9000");
         var beforeCall = DateTime.UtcNow;
 
         var result = await service.GetModuleDownloadPathAsync("ns", "name", "aws", "1.0.0");
@@ -146,6 +145,7 @@ public class S3ModuleServiceDownloadTests
         Assert.Equal("modules", capturedRequest!.BucketName);
         Assert.Equal(moduleStorage.FilePath, capturedRequest.Key);
         Assert.Equal(HttpVerb.GET, capturedRequest.Verb);
+        Assert.Equal(Protocol.HTTP, capturedRequest.Protocol);
         Assert.NotNull(capturedRequest.Expires);
         Assert.InRange(
             capturedRequest.Expires!.Value,

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceUploadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceUploadTests.cs
@@ -189,7 +189,8 @@ public class S3ModuleServiceUploadTests
             Source = new ModuleSourceInfo
             {
                 Kind = "mirror",
-                Origin = "registry.example.com"
+                Origin = "registry.example.com",
+                ArchiveFormat = "tar.gz"
             }
         };
 
@@ -219,6 +220,7 @@ public class S3ModuleServiceUploadTests
         Assert.NotNull(addedModule);
         Assert.Equal("mirror", addedModule!.Metadata.Source?.Kind);
         Assert.Equal("registry.example.com", addedModule.Metadata.Source?.Origin);
+        Assert.EndsWith(".tar.gz", addedModule.FilePath, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceUploadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceUploadTests.cs
@@ -165,7 +165,8 @@ public class S3ModuleServiceUploadTests
         Assert.NotNull(addedModule);
         Assert.NotNull(deleteRequest);
         Assert.NotEqual(LogicalKey, finalizeRequest!.DestinationKey);
-        Assert.StartsWith(LogicalKey, finalizeRequest.DestinationKey, StringComparison.Ordinal);
+        Assert.StartsWith("ns/name-aws-1.0.0.", finalizeRequest.DestinationKey, StringComparison.Ordinal);
+        Assert.EndsWith(".zip", finalizeRequest.DestinationKey, StringComparison.Ordinal);
         Assert.Equal(putRequest!.Key, finalizeRequest.SourceKey);
         Assert.Equal(finalizeRequest.DestinationKey, addedModule!.FilePath);
         Assert.Equal(putRequest.Key, deleteRequest!.Key);
@@ -291,7 +292,8 @@ public class S3ModuleServiceUploadTests
 
         Assert.True(result);
         Assert.NotNull(addedModule);
-        Assert.StartsWith(LogicalKey, addedModule!.FilePath, StringComparison.Ordinal);
+        Assert.StartsWith("ns/name-aws-1.0.0.", addedModule!.FilePath, StringComparison.Ordinal);
+        Assert.EndsWith(".zip", addedModule.FilePath, StringComparison.Ordinal);
         _mockDatabaseService.Verify(x => x.RemoveModuleExactAsync(It.IsAny<ModuleStorage>()), Times.Never);
     }
 
@@ -474,7 +476,8 @@ public class S3ModuleServiceUploadTests
         Assert.NotNull(tempKey);
         Assert.NotNull(finalKey);
         Assert.NotEqual(existingModule.FilePath, finalKey);
-        Assert.StartsWith(LogicalKey, finalKey!, StringComparison.Ordinal);
+        Assert.StartsWith("ns/name-aws-1.0.0.", finalKey!, StringComparison.Ordinal);
+        Assert.EndsWith(".zip", finalKey, StringComparison.Ordinal);
         Assert.Contains(tempKey!, deleteKeys);
         Assert.Contains(existingModule.FilePath, deleteKeys);
         _mockDatabaseService.Verify(x => x.ReplaceModuleExactAsync(

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ProviderArtifactStorageTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ProviderArtifactStorageTests.cs
@@ -67,6 +67,7 @@ public class S3ProviderArtifactStorageTests
         Assert.Equal("registry-artifacts", capturedRequest!.BucketName);
         Assert.Equal("providers/acme/example/1.0.0/package.zip", capturedRequest.Key);
         Assert.Equal(HttpVerb.GET, capturedRequest.Verb);
+        Assert.Equal(Protocol.HTTPS, capturedRequest.Protocol);
         Assert.NotNull(capturedRequest.Expires);
         Assert.InRange(capturedRequest.Expires!.Value, beforeCall.AddMinutes(17), afterCall.AddMinutes(17));
     }

--- a/TerraformRegistry/Handlers/ModuleHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleHandlers.cs
@@ -308,7 +308,11 @@ public static class ModuleHandlers
                 ActorUserId = context.User.FindFirstValue(ClaimTypes.NameIdentifier),
                 Metadata = new ModuleArtifactMetadata
                 {
-                    Source = new ModuleSourceInfo { Kind = "api-upload" }
+                    Source = new ModuleSourceInfo
+                    {
+                        Kind = "api-upload",
+                        ArchiveFormat = ModuleArchiveFormat.GetUploadArchiveFormat(moduleFile.FileName)
+                    }
                 }
             }, context.RequestAborted);
 

--- a/TerraformRegistry/Services/LocalModuleService.cs
+++ b/TerraformRegistry/Services/LocalModuleService.cs
@@ -217,13 +217,24 @@ public class LocalModuleService : ModuleService
             return null;
         }
 
+        var filePath = Path.GetFullPath(moduleStorage.FilePath);
+        if (!File.Exists(filePath))
+        {
+            RegistryLog.Warning(_logger,
+                "Module {Namespace}/{Name}/{Provider}/{Version} exists in the database but its package is missing from local storage.",
+                moduleNamespace, name, provider, version);
+            return null;
+        }
+
         // Generate a unique token
         var token = Guid.NewGuid().ToString("N");
         var expiry = DateTime.UtcNow.Add(TokenLifetime);
-        DownloadTokens[token] = (Path.GetFullPath(moduleStorage.FilePath), expiry);
+        DownloadTokens[token] = (filePath, expiry);
 
-        // Return the download link (adjust the base path as needed)
-        return $"/module/download?token={token}";
+        var archiveHint = ModuleArchiveFormat.GetGoGetterHint(moduleStorage);
+        return string.IsNullOrEmpty(archiveHint)
+            ? $"/module/download?token={token}"
+            : $"/module/download?token={token}&archive={Uri.EscapeDataString(archiveHint)}";
     }
 
     public override async Task<Stream?> OpenModulePackageStreamAsync(string moduleNamespace, string name, string provider,

--- a/TerraformRegistry/Services/LocalModuleService.cs
+++ b/TerraformRegistry/Services/LocalModuleService.cs
@@ -285,7 +285,7 @@ public class LocalModuleService : ModuleService
         var namespaceDir = GetNamespaceDirectory(moduleNamespace);
         if (!Directory.Exists(namespaceDir)) Directory.CreateDirectory(namespaceDir);
 
-        var fileName = $"{name}-{provider}-{version}.zip";
+        var fileName = $"{name}-{provider}-{version}{ModuleArchiveFormat.GetFileSuffix(metadata)}";
         var tempFileName = $"{fileName}.tmp";
         var tempFilePath = GetContainedPath(namespaceDir, tempFileName);
         var finalFilePath = GetContainedPath(namespaceDir, fileName);

--- a/docs/superpowers/plans/2026-07-11-storage-emulator-harness.md
+++ b/docs/superpowers/plans/2026-07-11-storage-emulator-harness.md
@@ -1,0 +1,123 @@
+# Storage Emulator Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run disposable Azurite and MinIO integration tests from a portable user-directory harness and GitHub Actions.
+
+**Architecture:** Repository scripts materialize a versioned Compose definition into a dedicated harness directory and use one command contract locally and in CI. The test script starts the two emulators, configures the registry clients with their local endpoints, executes real download and Terraform installation checks, and tears down on request only.
+
+**Tech Stack:** Docker Compose, Azurite, MinIO, Bash, .NET 10, Terraform CLI, GitHub Actions.
+
+## Global Constraints
+
+- Use Docker Compose for local and CI execution.
+- Put mutable local state only below `~/.terraform-registry-storage-test` by default.
+- Use test-only credentials and never require Azure or AWS credentials.
+- Preserve a real Azure user-delegation-SAS gate for DEP-001.
+- Every CI invocation uses the same repository scripts as local execution.
+
+---
+
+### Task 1: Portable Compose lifecycle
+
+**Files:**
+- Create: `scripts/remediation/storage-emulators/compose.yaml`
+- Create: `scripts/remediation/storage-emulators/storage-emulators.sh`
+- Test: `scripts/remediation/storage-emulators/storage-emulators.sh`
+
+**Interfaces:**
+- Consumes: `start|status|clean` and optional `--home <absolute-path>`.
+- Produces: running `azurite` and `minio` services and a canonical harness directory.
+
+- [ ] **Step 1: Write a failing lifecycle assertion**
+
+Create a shell test that invokes `storage-emulators.sh status --home "$TMPDIR/harness"` before startup and expects a non-zero status with a clear “not initialized” message.
+
+- [ ] **Step 2: Run the assertion and verify it fails because the command does not exist**
+
+Run: `bash scripts/remediation/storage-emulators/test-lifecycle.sh`
+
+Expected: non-zero exit because `storage-emulators.sh` is absent.
+
+- [ ] **Step 3: Add the Compose definition and lifecycle command**
+
+Define Azurite Blob on port 10000 and MinIO on port 9000 inside the Compose network. Implement `start`, `status`, and `clean`; reject any cleanup path other than the canonical harness directory or an explicit `--home` child directory.
+
+- [ ] **Step 4: Verify lifecycle behaviour**
+
+Run: `bash scripts/remediation/storage-emulators/test-lifecycle.sh`
+
+Expected: it starts both health-checked containers, reports both healthy, cleans its own containers and volumes, and leaves unrelated containers untouched.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add scripts/remediation/storage-emulators && git commit -m "test: add portable storage emulator lifecycle"`
+
+### Task 2: Emulator-backed registry and Terraform contract gate
+
+**Files:**
+- Create: `scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh`
+- Modify: `scripts/remediation/storage-emulators/storage-emulators.sh`
+- Test: `scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh`
+
+**Interfaces:**
+- Consumes: an active harness from `storage-emulators.sh start`.
+- Produces: a zero exit only after registry upload, signed emulator download, and `terraform init` complete for Azure Blob and MinIO S3.
+
+- [ ] **Step 1: Write a failing contract assertion**
+
+Create the smoke script so that it requires `AZURITE_CONNECTION_STRING`, `S3_SERVICE_URL`, and `S3_FORCE_PATH_STYLE`; run it before the lifecycle command exports those values.
+
+- [ ] **Step 2: Run the assertion and verify it fails for missing configuration**
+
+Run: `bash scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh --provider azure`
+
+Expected: non-zero exit identifying the missing emulator configuration.
+
+- [ ] **Step 3: Implement Azure and S3 smoke paths**
+
+Start the harness, create a test bucket in MinIO, launch the registry with either the Azurite connection string or MinIO endpoint and credentials, upload ZIP and tar.gz test modules, and run `terraform init` through the registry's HTTPS endpoint for each storage provider.
+
+- [ ] **Step 4: Verify the full contract gate**
+
+Run: `bash scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh --provider all`
+
+Expected: Terraform reports successful initialization for both archive formats and both emulator providers.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add scripts/remediation && git commit -m "test: exercise module downloads through storage emulators"`
+
+### Task 3: GitHub Actions integration
+
+**Files:**
+- Modify: `.github/workflows/ci.yaml`
+- Test: `.github/workflows/ci.yaml`
+
+**Interfaces:**
+- Consumes: repository lifecycle and smoke commands.
+- Produces: a secretless `storage-emulator-contract` CI job.
+
+- [ ] **Step 1: Write a failing workflow structure check**
+
+Add a shell assertion that requires `.github/workflows/ci.yaml` to contain a `storage-emulator-contract` job and an `if: failure()` Compose-log upload step.
+
+- [ ] **Step 2: Run the assertion and verify it fails**
+
+Run: `bash scripts/remediation/storage-emulators/test-ci-workflow.sh`
+
+Expected: non-zero exit because the job is absent.
+
+- [ ] **Step 3: Add the secretless CI job**
+
+Configure the job to execute the lifecycle and smoke scripts with `--home "$RUNNER_TEMP/terraform-registry-storage-test"`, cache no credentials, and upload `docker compose logs` only on failure.
+
+- [ ] **Step 4: Verify the workflow and execute its local equivalent**
+
+Run: `bash scripts/remediation/storage-emulators/test-ci-workflow.sh && bash scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh --provider all`
+
+Expected: workflow structure assertion and full local emulator gate both return zero.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add .github/workflows/ci.yaml scripts/remediation/storage-emulators && git commit -m "ci: run storage emulator contract gate"`

--- a/docs/superpowers/specs/2026-07-11-storage-emulator-harness-design.md
+++ b/docs/superpowers/specs/2026-07-11-storage-emulator-harness-design.md
@@ -1,0 +1,35 @@
+# Storage Emulator Harness Design
+
+## Goal
+
+Provide a portable, disposable local test environment for the registry's Azure Blob and S3-compatible download contracts, and run that exact environment in GitHub Actions.
+
+## Scope
+
+The harness lives outside the repository at `~/.terraform-registry-storage-test` when bootstrapped locally. Repository-owned Compose and shell files are copied there by the bootstrap command, so the user directory contains all mutable state: generated environment values, Docker volumes, and logs.
+
+The Compose topology has two services:
+
+- Azurite Blob Storage, configured with a fixed development account/key and a health probe.
+- MinIO, configured with test-only credentials, a bucket-creation helper, and a health probe.
+
+The harness exposes four commands:
+
+- `start` creates the directory if necessary and starts the Compose project.
+- `status` reports the two service health states.
+- `test` starts the services if needed, runs the registry's emulator contract test command, and preserves logs on failure.
+- `clean` runs `docker compose down --volumes --remove-orphans` for this project and removes only the harness directory.
+
+## CI behaviour
+
+GitHub Actions checks out the repository, invokes the same bootstrap and test commands with a CI-specific directory under the runner temporary path, and uploads Compose logs if the test command fails. CI uses no cloud credentials and does not expose emulator credentials outside the job.
+
+## Verification boundary
+
+Azurite verifies the Azure Blob connection-string/shared-key path. MinIO verifies S3 path-style endpoint configuration, object upload/download, and presigned URL consumption. The tests cover ZIP and tar.gz module archives plus actual Terraform CLI installation for each emulator-backed provider.
+
+This cannot verify Azure Entra managed identity or user-delegation SAS. DEP-001 remains a protected real-Azure gate, explicitly separate from this harness.
+
+## Safety
+
+The project name is derived solely from the harness directory. No default Docker volumes, host paths, cloud resources, or repository files are removed by `clean`. The cleanup script rejects an empty or non-canonical harness path before it removes anything.

--- a/scripts/remediation/phase-1-local-terraform-smoke.sh
+++ b/scripts/remediation/phase-1-local-terraform-smoke.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Proves that Terraform can install a fabricated module through the Local
+# registry backend. The test uses an ephemeral TLS proxy because Terraform
+# registry discovery requires HTTPS.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SUFFIX="$(date +%s)"
+PROJECT="p1local${SUFFIX}"
+NETWORK="${PROJECT}_default"
+APP="terraform-registry-app-dev"
+CADDY="${PROJECT}-caddy"
+SMOKE_VOLUME="${PROJECT}-terraform-smoke"
+CADDY_CONFIG="${PROJECT}-caddy-config"
+CADDY_DATA="${PROJECT}-caddy-data"
+
+cleanup() {
+  docker rm -f "$CADDY" >/dev/null 2>&1 || true
+  docker compose -f "$ROOT/docker-compose.dev.yml" -p "$PROJECT" down -v >/dev/null 2>&1 || true
+  docker volume rm "$SMOKE_VOLUME" "$CADDY_CONFIG" "$CADDY_DATA" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+TF_REG_DevAuthBypass=true TF_REG_AdminEmails=dev@localhost \
+  docker compose -f "$ROOT/docker-compose.dev.yml" -p "$PROJECT" up -d --build app postgres
+
+for _ in $(seq 1 45); do
+  if docker logs "$APP" 2>&1 | grep -q 'Application started'; then break; fi
+  sleep 1
+done
+docker logs "$APP" 2>&1 | grep -q 'Application started'
+
+docker volume create "$CADDY_CONFIG" >/dev/null
+docker volume create "$CADDY_DATA" >/dev/null
+docker volume create "$SMOKE_VOLUME" >/dev/null
+docker run --rm -v "$CADDY_CONFIG:/config" alpine:3.21 sh -c \
+  'printf "%s\n" "registry.local {" "  tls internal" "  reverse_proxy app:5131" "}" > /config/Caddyfile'
+docker run -d --name "$CADDY" --network "$NETWORK" \
+  -v "$CADDY_CONFIG:/etc/caddy" -v "$CADDY_DATA:/data" \
+  caddy:2.10-alpine caddy run --config /etc/caddy/Caddyfile --adapter caddyfile >/dev/null
+
+docker run --rm --network "$NETWORK" \
+  -v "$ROOT/TerraformRegistry.Tests/TestData/test-module.zip:/fixture/module.zip:ro" \
+  curlimages/curl:8.16.0 -fsS -o /dev/null -w '%{http_code}' \
+  -H 'Authorization: Bearer MY_TOKEN_123' \
+  -F 'moduleFile=@/fixture/module.zip;type=application/zip' \
+  'http://app:5131/v1/modules/e2elocal/sample/aws/1.0.0' | grep -qx '201'
+
+docker run --rm -v "$SMOKE_VOLUME:/work" alpine:3.21 sh -c \
+  'printf "%s\n" "module \"sample\" {" "  source = \"registry.local/e2elocal/sample/aws\"" "  version = \"1.0.0\"" "}" > /work/main.tf; printf "%s\n" "credentials \"registry.local\" {" "  token = \"MY_TOKEN_123\"" "}" > /work/terraform.rc'
+
+caddy_ip="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$CADDY")"
+docker run --rm --network "$NETWORK" --add-host "registry.local:$caddy_ip" \
+  -e SSL_CERT_FILE=/certs/caddy/pki/authorities/local/root.crt \
+  -e TF_CLI_CONFIG_FILE=/work/terraform.rc \
+  -v "$CADDY_DATA:/certs:ro" -v "$SMOKE_VOLUME:/work" -w /work \
+  hashicorp/terraform:1.14.2 init -input=false -no-color
+
+printf 'Phase 1 Local Terraform smoke passed.\n'

--- a/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
+++ b/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIFECYCLE="$ROOT/scripts/remediation/storage-emulators/storage-emulators.sh"
+HOME_DIR="$HOME/.terraform-registry-storage-test"
+PROVIDER="all"
+
+usage() {
+  printf 'Usage: %s [--provider azure|s3|all] [--home ABSOLUTE_PATH]\n' "$0" >&2
+  exit 2
+}
+
+while (($#)); do
+  case "$1" in
+    --provider) PROVIDER="${2:-}"; shift ;;
+    --home) HOME_DIR="${2:-}"; shift ;;
+    *) usage ;;
+  esac
+  shift
+done
+
+[[ "$HOME_DIR" = /* ]] || usage
+[[ "$PROVIDER" = azure || "$PROVIDER" = s3 || "$PROVIDER" = all ]] || usage
+
+project_for() {
+  printf 'tfregstorage%s' "$(printf '%s' "$1" | sha256sum | cut -c1-12)"
+}
+
+run_provider() {
+  local storage_provider="$1"
+  local project app caddy network fixture workspace caddy_ip module_namespace
+  project="$(project_for "$HOME_DIR")"
+  fixture="$(mktemp -d)"
+  workspace="${HOME_DIR}/terraform-work-${storage_provider}"
+  module_namespace="e2e${storage_provider}$(date +%s)"
+
+  cleanup_fixture() {
+    rm -rf "$fixture"
+    if [[ -d "$workspace" ]]; then
+      docker run --rm -v "$workspace:/workspace" alpine:3.21 sh -c \
+        'rm -rf /workspace/* /workspace/.[!.]* /workspace/..?*'
+      rmdir "$workspace"
+    fi
+  }
+  trap cleanup_fixture RETURN
+
+  "$LIFECYCLE" start --provider "$storage_provider" --home "$HOME_DIR"
+  "$LIFECYCLE" status --home "$HOME_DIR"
+
+  app="$(docker compose --project-name "$project" --project-directory "$HOME_DIR" -f "$HOME_DIR/compose.yaml" ps -q app)"
+  for _ in $(seq 1 120); do
+    if docker logs "$app" 2>&1 | grep -q 'Application started'; then break; fi
+    sleep 1
+  done
+  docker logs "$app" 2>&1 | grep -q 'Application started'
+
+  unzip -q "$ROOT/TerraformRegistry.Tests/TestData/test-module.zip" -d "$fixture/module"
+  tar -C "$fixture/module" -czf "$fixture/test-module.tar.gz" .
+
+  network="${project}_default"
+  for archive in zip tar.gz; do
+    local version archive_file content_type
+    if [[ "$archive" = zip ]]; then
+      version="1.0.0"
+      archive_file="$ROOT/TerraformRegistry.Tests/TestData/test-module.zip"
+      content_type='application/zip'
+    else
+      version="1.0.1"
+      archive_file="$fixture/test-module.tar.gz"
+      content_type='application/gzip'
+    fi
+
+    docker run --rm --network "$network" \
+      -v "$archive_file:/fixture/module.${archive}:ro" \
+      curlimages/curl:8.16.0 -fsS -o /dev/null -w '%{http_code}' \
+      -H 'Authorization: Bearer MY_TOKEN_123' \
+      -F "moduleFile=@/fixture/module.${archive};type=${content_type}" \
+      "http://app:5131/v1/modules/${module_namespace}/sample/aws/${version}" | grep -qx '201'
+
+    mkdir -p "$workspace/$archive"
+    cat > "$workspace/$archive/main.tf" <<EOF
+module "sample" {
+  source  = "registry.local/${module_namespace}/sample/aws"
+  version = "${version}"
+}
+EOF
+    cat > "$workspace/$archive/terraform.rc" <<'EOF'
+credentials "registry.local" {
+  token = "MY_TOKEN_123"
+}
+EOF
+
+    caddy="$(docker compose --project-name "$project" --project-directory "$HOME_DIR" -f "$HOME_DIR/compose.yaml" ps -q caddy)"
+    caddy_ip="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$caddy")"
+    docker run --rm --network "$network" --add-host "registry.local:${caddy_ip}" \
+      -e SSL_CERT_FILE=/certs/caddy/pki/authorities/local/root.crt \
+      -e TF_CLI_CONFIG_FILE=/work/terraform.rc \
+      -v "${project}_caddy-data:/certs:ro" -v "$workspace/$archive:/work" -w /work \
+      hashicorp/terraform:1.14.2 init -input=false -no-color
+  done
+
+  printf 'Phase 1 %s emulator Terraform smoke passed.\n' "$storage_provider"
+}
+
+if [[ "$PROVIDER" = all ]]; then
+  run_provider azure
+  "$LIFECYCLE" clean --home "$HOME_DIR"
+  run_provider s3
+  "$LIFECYCLE" clean --home "$HOME_DIR"
+else
+  run_provider "$PROVIDER"
+fi

--- a/scripts/remediation/storage-emulators/compose.yaml
+++ b/scripts/remediation/storage-emulators/compose.yaml
@@ -1,0 +1,75 @@
+services:
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:3.33.0
+    command: azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --location /workspace --skipApiVersionCheck
+    volumes:
+      - azurite-data:/workspace
+
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    command: server /data --console-address :9001
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - minio-data:/data
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-03-12T17-29-24Z
+    depends_on:
+      - minio
+    entrypoint: >-
+      /bin/sh -c 'until mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 1; done;
+      mc mb --ignore-existing local/modules'
+
+  postgres:
+    image: postgres:18
+    environment:
+      POSTGRES_USER: terraform_reg_user
+      POSTGRES_PASSWORD: terraform_reg_password
+      POSTGRES_DB: terraform_registry
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U terraform_reg_user -d terraform_registry"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  app:
+    build:
+      context: ${REGISTRY_ROOT}
+      dockerfile: Dockerfile
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      TF_REG_DatabaseProvider: postgres
+      TF_REG_PostgreSQL__ConnectionString: Host=postgres;Database=terraform_registry;Username=terraform_reg_user;Password=terraform_reg_password
+      TF_REG_BaseUrl: https://registry.local
+      TF_REG_StorageProvider: ${STORAGE_PROVIDER}
+      TF_REG_AuthorizationToken: MY_TOKEN_123
+      TF_REG_AzureStorage__ContainerName: modules
+      TF_REG_AzureStorage__ConnectionString: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;
+      TF_REG_S3__BucketName: modules
+      TF_REG_S3__Region: us-east-1
+      TF_REG_S3__ServiceUrl: http://minio:9000
+      TF_REG_S3__ForcePathStyle: "true"
+      TF_REG_S3__AccessKeyId: minioadmin
+      TF_REG_S3__SecretAccessKey: minioadmin
+    depends_on:
+      postgres:
+        condition: service_healthy
+    expose:
+      - "5131"
+
+  caddy:
+    image: caddy:2.10-alpine
+    depends_on:
+      - app
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+
+volumes:
+  azurite-data:
+  minio-data:
+  caddy-data:
+  caddy-config:

--- a/scripts/remediation/storage-emulators/storage-emulators.sh
+++ b/scripts/remediation/storage-emulators/storage-emulators.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SOURCE_COMPOSE="$ROOT/scripts/remediation/storage-emulators/compose.yaml"
+DEFAULT_HOME="$HOME/.terraform-registry-storage-test"
+HOME_DIR="$DEFAULT_HOME"
+PROVIDER=""
+COMMAND=""
+
+usage() {
+  printf 'Usage: %s <start|status|test|clean> [--provider azure|s3|all] [--home ABSOLUTE_PATH]\n' "$0" >&2
+  exit 2
+}
+
+while (($#)); do
+  case "$1" in
+    start|status|test|clean) [[ -z "$COMMAND" ]] || usage; COMMAND="$1" ;;
+    --provider) PROVIDER="${2:-}"; shift ;;
+    --home) HOME_DIR="${2:-}"; shift ;;
+    *) usage ;;
+  esac
+  shift
+done
+
+[[ -n "$COMMAND" && "$HOME_DIR" = /* ]] || usage
+if [[ -z "$PROVIDER" ]]; then
+  PROVIDER="$([[ "$COMMAND" = test ]] && printf all || printf azure)"
+fi
+[[ "$PROVIDER" = azure || "$PROVIDER" = s3 || ( "$COMMAND" = test && "$PROVIDER" = all ) ]] || usage
+
+marker="$HOME_DIR/.terraform-registry-storage-test"
+project_id="$(printf '%s' "$HOME_DIR" | sha256sum | cut -c1-12)"
+PROJECT="tfregstorage${project_id}"
+
+compose() {
+  docker compose --project-name "$PROJECT" --project-directory "$HOME_DIR" -f "$HOME_DIR/compose.yaml" "$@"
+}
+
+initialize() {
+  mkdir -p "$HOME_DIR"
+  cp "$SOURCE_COMPOSE" "$HOME_DIR/compose.yaml"
+  printf '%s\n' 'registry.local {' '  tls internal' '  reverse_proxy app:5131' '}' > "$HOME_DIR/Caddyfile"
+  printf 'REGISTRY_ROOT=%s\nSTORAGE_PROVIDER=%s\n' "$ROOT" "$PROVIDER" > "$HOME_DIR/.env"
+  printf '%s\n' "$PROJECT" > "$marker"
+}
+
+require_initialized() {
+  if [[ ! -f "$marker" ]]; then
+    printf 'Storage emulator harness at %s is not initialized. Run start first.\n' "$HOME_DIR" >&2
+    exit 1
+  fi
+}
+
+case "$COMMAND" in
+  start)
+    initialize
+    compose up -d --build --force-recreate azurite minio postgres app caddy
+    compose run --rm minio-init
+    ;;
+  status)
+    require_initialized
+    running="$(compose ps --status running --services)"
+    for service in azurite minio postgres app caddy; do
+      grep -qx "$service" <<<"$running" || {
+        printf 'Storage emulator harness service %s is not running.\n' "$service" >&2
+        exit 1
+      }
+    done
+    printf 'Storage emulator harness is running at %s.\n' "$HOME_DIR"
+    ;;
+  test)
+    exec "$ROOT/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh" \
+      --provider "$PROVIDER" --home "$HOME_DIR"
+    ;;
+  clean)
+    require_initialized
+    [[ "$(cat "$marker")" = "$PROJECT" ]] || {
+      printf 'Refusing to clean harness with an invalid marker at %s.\n' "$HOME_DIR" >&2
+      exit 1
+    }
+    compose down --volumes --remove-orphans
+    docker run --rm -v "$HOME_DIR:/harness" alpine:3.21 sh -c \
+      'rm -rf /harness/* /harness/.[!.]* /harness/..?*'
+    rm -rf "$HOME_DIR"
+    printf 'Storage emulator harness removed from %s.\n' "$HOME_DIR"
+    ;;
+esac

--- a/scripts/remediation/storage-emulators/test-ci-workflow.sh
+++ b/scripts/remediation/storage-emulators/test-ci-workflow.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/ci.yaml"
+
+grep -Eq '^  storage-emulator-contract:' "$WORKFLOW"
+grep -Fq 'phase-1-storage-emulator-terraform-smoke.sh --provider all' "$WORKFLOW"
+grep -Fq 'if: failure()' "$WORKFLOW"

--- a/scripts/remediation/storage-emulators/test-lifecycle.sh
+++ b/scripts/remediation/storage-emulators/test-lifecycle.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HARNESS="$(mktemp -d)"
+trap 'rm -rf "$HARNESS"' EXIT
+
+if "$ROOT/scripts/remediation/storage-emulators/storage-emulators.sh" status --home "$HARNESS" >/tmp/storage-emulator-status.out 2>&1; then
+  echo "Expected status to fail before the harness is initialized." >&2
+  exit 1
+fi
+
+grep -Fq 'not initialized' /tmp/storage-emulator-status.out


### PR DESCRIPTION
Implements the P1-DOWNLOAD storage contract work. Draft until real Terraform Local/Azure/S3 smoke coverage is complete.

Storage emulator gate added in `0bdfbf0`:
- portable Docker Compose harness at `~/.terraform-registry-storage-test` (`start`, `status`, `test`, `clean`);
- Azurite shared-key and MinIO S3-compatible ZIP/tar.gz `terraform init` smoke paths;
- secretless `storage-emulator-contract` GitHub Actions job using the same scripts;
- API archive metadata and HTTP S3 presigned URL conformance fixes.

Verification: focused storage suite 35/35; lifecycle and workflow checks pass; live Azure and MinIO Terraform smoke paths exercised. The full Release suite stalled under its existing 5-minute hang diagnostic and remains a visible follow-up, not a waived check.

Real Azure Entra user-delegation SAS remains separately blocked on Azure RBAC and will be supplied by the dependent P1-AZURE-SAS PR.