### PR TITLE
security: establish endpoint rate-limit foundation

### DIFF
--- a/TerraformRegistry.Tests/UnitTests/RateLimitOptionsTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/RateLimitOptionsTests.cs
@@ -1,0 +1,83 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TerraformRegistry.Startup;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class RateLimitOptionsTests
+{
+    [Fact]
+    public void DefaultsDeclareEveryPlannedIngressPolicy()
+    {
+        var options = new RegistryRateLimitOptions();
+
+        Assert.Equivalent(
+            new[]
+            {
+                RateLimitPolicyNames.ModuleUpload,
+                RateLimitPolicyNames.ProviderUpload,
+                RateLimitPolicyNames.WebhookIngress,
+                RateLimitPolicyNames.ApiKeyVerification,
+                RateLimitPolicyNames.MirrorIngress
+            },
+            options.Policies.Keys);
+
+        Assert.All(options.Policies.Values, static policy => policy.Validate());
+    }
+
+    [Fact]
+    public void PartitionKeyUsesAuthenticatedPrincipalBeforeRemoteAddress()
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("203.0.113.9");
+        context.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.NameIdentifier, "user-123")], "test"));
+
+        Assert.Equal("principal:user-123", RateLimitPartitionKey.For(context));
+    }
+
+    [Fact]
+    public void PartitionKeyUsesRemoteAddressForAnonymousRequests()
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("203.0.113.9");
+
+        Assert.Equal("ip:203.0.113.9", RateLimitPartitionKey.For(context));
+    }
+
+    [Theory]
+    [InlineData("principal:user-123", "principal")]
+    [InlineData("ip:203.0.113.9", "ip")]
+    [InlineData("ip:unknown", "ip")]
+    public void PartitionCategoryExcludesTheRawPartitionValue(string key, string expected)
+    {
+        Assert.Equal(expected, RateLimitPartitionKey.CategoryFor(key));
+    }
+
+    [Fact]
+    public void InvalidPolicyConfigurationFailsValidation()
+    {
+        var policy = new RegistryRateLimitPolicyOptions { PermitLimit = 0 };
+
+        var exception = Assert.Throws<InvalidOperationException>(policy.Validate);
+
+        Assert.Contains("PermitLimit", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ServiceRegistrationValidatesAndExposesNamedRateLimitFoundation()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        var services = new ServiceCollection();
+
+        services.AddRegistryRateLimiting(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<RegistryRateLimitOptions>();
+
+        Assert.Contains(RateLimitPolicyNames.ModuleUpload, options.Policies.Keys);
+        Assert.NotNull(provider.GetRequiredService<RegistryRateLimitMetrics>());
+    }
+}

--- a/TerraformRegistry/Program.cs
+++ b/TerraformRegistry/Program.cs
@@ -125,6 +125,7 @@ app.UseMiddleware<AuthenticationMiddleware>(authToken, jwtService);
 
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseRateLimiter();
 
 if (enableSwagger)
 {

--- a/TerraformRegistry/Startup/RegistryRateLimitOptions.cs
+++ b/TerraformRegistry/Startup/RegistryRateLimitOptions.cs
@@ -1,0 +1,100 @@
+using System.Security.Claims;
+
+namespace TerraformRegistry.Startup;
+
+/// <summary>
+/// Names reserved for expensive ingress policies. Endpoint attachment is deliberately
+/// kept in the package which owns each ingress surface.
+/// </summary>
+public static class RateLimitPolicyNames
+{
+    public const string ModuleUpload = "module-upload";
+    public const string ProviderUpload = "provider-upload";
+    public const string WebhookIngress = "webhook-ingress";
+    public const string ApiKeyVerification = "api-key-verification";
+    public const string MirrorIngress = "mirror-ingress";
+}
+
+public sealed class RegistryRateLimitOptions
+{
+    public const string SectionName = "RateLimiting";
+
+    public Dictionary<string, RegistryRateLimitPolicyOptions> Policies { get; init; } = new(StringComparer.Ordinal)
+    {
+        [RateLimitPolicyNames.ModuleUpload] = new(),
+        [RateLimitPolicyNames.ProviderUpload] = new(),
+        [RateLimitPolicyNames.WebhookIngress] = new(),
+        [RateLimitPolicyNames.ApiKeyVerification] = new(),
+        [RateLimitPolicyNames.MirrorIngress] = new()
+    };
+
+    public void Validate()
+    {
+        foreach (var policyName in new[]
+                 {
+                     RateLimitPolicyNames.ModuleUpload,
+                     RateLimitPolicyNames.ProviderUpload,
+                     RateLimitPolicyNames.WebhookIngress,
+                     RateLimitPolicyNames.ApiKeyVerification,
+                     RateLimitPolicyNames.MirrorIngress
+                 })
+        {
+            if (!Policies.TryGetValue(policyName, out var policy))
+            {
+                throw new InvalidOperationException($"RateLimiting policy '{policyName}' is required.");
+            }
+
+            policy.Validate();
+        }
+    }
+}
+
+public sealed class RegistryRateLimitPolicyOptions
+{
+    public int PermitLimit { get; init; } = 60;
+    public int WindowSeconds { get; init; } = 60;
+    public int QueueLimit { get; init; }
+    public int ConcurrencyLimit { get; init; } = 4;
+
+    public void Validate()
+    {
+        if (PermitLimit <= 0)
+        {
+            throw new InvalidOperationException("RateLimiting PermitLimit must be greater than zero.");
+        }
+
+        if (WindowSeconds <= 0)
+        {
+            throw new InvalidOperationException("RateLimiting WindowSeconds must be greater than zero.");
+        }
+
+        if (QueueLimit < 0)
+        {
+            throw new InvalidOperationException("RateLimiting QueueLimit cannot be negative.");
+        }
+
+        if (ConcurrencyLimit <= 0)
+        {
+            throw new InvalidOperationException("RateLimiting ConcurrencyLimit must be greater than zero.");
+        }
+    }
+}
+
+public static class RateLimitPartitionKey
+{
+    public static string For(HttpContext context)
+    {
+        var principalId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!string.IsNullOrWhiteSpace(principalId))
+        {
+            return $"principal:{principalId}";
+        }
+
+        return context.Connection.RemoteIpAddress is { } address
+            ? $"ip:{address}"
+            : "ip:unknown";
+    }
+
+    public static string CategoryFor(string partitionKey) =>
+        partitionKey.StartsWith("principal:", StringComparison.Ordinal) ? "principal" : "ip";
+}

--- a/TerraformRegistry/Startup/RegistryRateLimitingExtensions.cs
+++ b/TerraformRegistry/Startup/RegistryRateLimitingExtensions.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics.Metrics;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace TerraformRegistry.Startup;
+
+public sealed class RegistryRateLimitMetrics : IDisposable
+{
+    private readonly Meter _meter = new("TerraformRegistry.RateLimiting");
+    private readonly Counter<long> _rejections;
+
+    public RegistryRateLimitMetrics()
+    {
+        _rejections = _meter.CreateCounter<long>("terraform_registry.rate_limit.rejections");
+    }
+
+    public void RecordRejection(string policy, string partitionCategory)
+    {
+        _rejections.Add(1,
+            new KeyValuePair<string, object?>("policy", policy),
+            new KeyValuePair<string, object?>("partition", partitionCategory));
+    }
+
+    public void Dispose() => _meter.Dispose();
+}
+
+public static class RegistryRateLimitingExtensions
+{
+    private const string PolicyItemKey = "terraform-registry.rate-limit-policy";
+
+    public static IServiceCollection AddRegistryRateLimiting(this IServiceCollection services, IConfiguration configuration)
+    {
+        var configured = new RegistryRateLimitOptions();
+        configuration.GetSection(RegistryRateLimitOptions.SectionName).Bind(configured);
+        configured.Validate();
+
+        services.AddSingleton(configured);
+        services.AddSingleton<RegistryRateLimitMetrics>();
+        services.AddRateLimiter(options =>
+        {
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+            options.OnRejected = async (context, cancellationToken) =>
+            {
+                var httpContext = context.HttpContext;
+                var policy = httpContext.Items[PolicyItemKey] as string ?? "unknown";
+                var partitionCategory = RateLimitPartitionKey.CategoryFor(RateLimitPartitionKey.For(httpContext));
+                httpContext.RequestServices.GetRequiredService<RegistryRateLimitMetrics>()
+                    .RecordRejection(policy, partitionCategory);
+
+                httpContext.Response.ContentType = "application/problem+json";
+                await httpContext.Response.WriteAsJsonAsync(new
+                {
+                    type = "https://tools.ietf.org/html/rfc6585#section-4",
+                    title = "Too Many Requests",
+                    status = StatusCodes.Status429TooManyRequests,
+                    detail = "The request exceeded the configured rate limit.",
+                    policy
+                }, cancellationToken);
+            };
+
+            foreach (var (name, policy) in configured.Policies)
+            {
+                options.AddPolicy(name, httpContext =>
+                {
+                    httpContext.Items[PolicyItemKey] = name;
+                    var partition = RateLimitPartitionKey.For(httpContext);
+                    return RateLimitPartition.GetFixedWindowLimiter(partition, _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = policy.PermitLimit,
+                        Window = TimeSpan.FromSeconds(policy.WindowSeconds),
+                        QueueLimit = policy.QueueLimit,
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        AutoReplenishment = true
+                    });
+                });
+            }
+        });
+
+        return services;
+    }
+}

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -24,6 +24,7 @@ internal static class ServiceRegistrationExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
+        services.AddRegistryRateLimiting(configuration);
         services.Configure<DatabaseRetryOptions>(configuration.GetSection("DatabaseRetry"));
         services.Configure<WebhookSecurityOptions>(configuration.GetSection("WebhookSecurity"));
         services.Configure<ModuleExtractionOptions>(configuration.GetSection("ModuleExtraction"));

--- a/TerraformRegistry/appsettings.json
+++ b/TerraformRegistry/appsettings.json
@@ -38,6 +38,15 @@
     "InitialDelaySeconds": 2,
     "MaxDelaySeconds": 30
   },
+  "RateLimiting": {
+    "Policies": {
+      "module-upload": { "PermitLimit": 60, "WindowSeconds": 60, "QueueLimit": 0, "ConcurrencyLimit": 4 },
+      "provider-upload": { "PermitLimit": 60, "WindowSeconds": 60, "QueueLimit": 0, "ConcurrencyLimit": 4 },
+      "webhook-ingress": { "PermitLimit": 60, "WindowSeconds": 60, "QueueLimit": 0, "ConcurrencyLimit": 4 },
+      "api-key-verification": { "PermitLimit": 60, "WindowSeconds": 60, "QueueLimit": 0, "ConcurrencyLimit": 4 },
+      "mirror-ingress": { "PermitLimit": 60, "WindowSeconds": 60, "QueueLimit": 0, "ConcurrencyLimit": 4 }
+    }
+  },
   "ModuleExtraction": {
     "Enabled": true,
     "ToolPath": "terraform-config-inspect",


### PR DESCRIPTION
Implements P2-RATE / ING-004 foundation only.

- validates and registers named ingress policies for module upload, provider upload, webhooks, API-key verification, and mirroring;
- defines stable principal-first/IP fallback partition keys;
- emits common JSON 429 overload responses and low-cardinality rejection metrics;
- adds the rate limiter middleware without attaching policies to endpoints.

Endpoint attachments remain explicitly deferred to P2-RATE-ATTACH after the dependent P2 leaves merge.

Verification: `dotnet test ... --filter FullyQualifiedName~RateLimitOptionsTests` (8 passing).