### PR TITLE
security: enforce user admission and disable state

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ For Azure Blob Storage and S3-compatible storage, one configured container or bu
 - `AuthorizationToken` / `TF_REG_AUTHORIZATIONTOKEN` must be set to a unique secret outside `Development` and `Test`.
 - `Oidc:JwtSecretKey` / `TF_REG_OIDC__JWTSECRETKEY` must be set to a secret that is at least 32 characters long. Outside `Development`, the placeholder value is rejected.
 - OIDC login requires a non-empty provider email and rejects same-email logins when they resolve to a different provider or provider ID.
+- OIDC admission is closed by default. To provision new users, set `UserAdmission:Mode` to `ConstrainedAutoProvision` and configure at least one of `AllowedIssuers`, `AllowedTenants`, `AllowedDomains`, or `AllowedEmails`. `RequireVerifiedEmail` defaults to `true`; missing provider claims fail closed when their corresponding constraint is configured.
+- Disabled users are rejected immediately for portal sessions, bearer JWTs, API keys, and Terraform login authorization. Existing user records remain active after the migration unless an operator explicitly disables them.
 - Outbound admin webhooks only support `http` and `https` targets. Private and local network destinations are blocked unless `WebhookSecurity:AllowPrivateNetworks` / `TF_REG_WEBHOOKSECURITY__ALLOWPRIVATENETWORKS` is explicitly enabled.
 
 ### Architecture Options

--- a/TerraformRegistry.Migrations/Scripts/PostgreSQL/019_user_admission_state.sql
+++ b/TerraformRegistry.Migrations/Scripts/PostgreSQL/019_user_admission_state.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_users_active ON users(is_active);

--- a/TerraformRegistry.Migrations/Scripts/SQLite/017_user_admission_state.sql
+++ b/TerraformRegistry.Migrations/Scripts/SQLite/017_user_admission_state.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1;
+
+CREATE INDEX IF NOT EXISTS idx_users_active ON users(is_active);

--- a/TerraformRegistry.Models/User.cs
+++ b/TerraformRegistry.Models/User.cs
@@ -25,6 +25,9 @@ public class User
     [MaxLength(255)]
     public string ProviderId { get; set; } = string.Empty;
 
+    [Column("is_active")]
+    public bool IsActive { get; set; } = true;
+
     [Column("created_at")]
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlUserRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlUserRepository.cs
@@ -10,7 +10,7 @@ public sealed class PostgreSqlUserRepository(string connectionString) : IUserRep
     {
         const string sql =
             """
-            SELECT id, email, provider, provider_id, created_at, updated_at
+            SELECT id, email, provider, provider_id, is_active, created_at, updated_at
             FROM users
             WHERE lower(email) = lower(@email)
             ORDER BY CASE WHEN email = @email THEN 0 ELSE 1 END, created_at ASC
@@ -38,7 +38,7 @@ public sealed class PostgreSqlUserRepository(string connectionString) : IUserRep
 
     public async Task<User?> GetUserByIdAsync(string id)
     {
-        const string sql = "SELECT id, email, provider, provider_id, created_at, updated_at FROM users WHERE id = @id";
+        const string sql = "SELECT id, email, provider, provider_id, is_active, created_at, updated_at FROM users WHERE id = @id";
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync();
         await using var command = new NpgsqlCommand(sql, connection);
@@ -53,8 +53,8 @@ public sealed class PostgreSqlUserRepository(string connectionString) : IUserRep
     public async Task AddUserAsync(User user)
     {
         const string sql = @"
-            INSERT INTO users (id, email, provider, provider_id, created_at, updated_at)
-            VALUES (@id, @email, @provider, @providerId, @createdAt, @updatedAt)";
+            INSERT INTO users (id, email, provider, provider_id, is_active, created_at, updated_at)
+            VALUES (@id, @email, @provider, @providerId, @isActive, @createdAt, @updatedAt)";
 
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync();
@@ -64,6 +64,7 @@ public sealed class PostgreSqlUserRepository(string connectionString) : IUserRep
         command.Parameters.AddWithValue("@email", user.Email);
         command.Parameters.AddWithValue("@provider", user.Provider);
         command.Parameters.AddWithValue("@providerId", user.ProviderId);
+        command.Parameters.AddWithValue("@isActive", user.IsActive);
         command.Parameters.AddWithValue("@createdAt", user.CreatedAt);
         command.Parameters.AddWithValue("@updatedAt", user.UpdatedAt);
 
@@ -73,7 +74,7 @@ public sealed class PostgreSqlUserRepository(string connectionString) : IUserRep
     public async Task UpdateUserAsync(User user)
     {
         const string sql =
-            "UPDATE users SET email=@email, provider=@provider, provider_id=@providerId, updated_at=@updatedAt WHERE id=@id";
+            "UPDATE users SET email=@email, provider=@provider, provider_id=@providerId, is_active=@isActive, updated_at=@updatedAt WHERE id=@id";
 
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync();
@@ -83,6 +84,7 @@ public sealed class PostgreSqlUserRepository(string connectionString) : IUserRep
         command.Parameters.AddWithValue("@email", user.Email);
         command.Parameters.AddWithValue("@provider", user.Provider);
         command.Parameters.AddWithValue("@providerId", user.ProviderId);
+        command.Parameters.AddWithValue("@isActive", user.IsActive);
         command.Parameters.AddWithValue("@updatedAt", user.UpdatedAt);
 
         await command.ExecuteNonQueryAsync();
@@ -100,7 +102,7 @@ public sealed class PostgreSqlUserRepository(string connectionString) : IUserRep
 
     public async Task<IEnumerable<User>> ListAllUsersAsync()
     {
-        const string sql = "SELECT id, email, provider, provider_id, created_at, updated_at FROM users ORDER BY created_at DESC";
+        const string sql = "SELECT id, email, provider, provider_id, is_active, created_at, updated_at FROM users ORDER BY created_at DESC";
         var users = new List<User>();
 
         await using var connection = new NpgsqlConnection(connectionString);
@@ -123,8 +125,9 @@ public sealed class PostgreSqlUserRepository(string connectionString) : IUserRep
             Email = reader.GetString(1),
             Provider = reader.GetString(2),
             ProviderId = reader.GetString(3),
-            CreatedAt = reader.GetDateTime(4),
-            UpdatedAt = reader.GetDateTime(5)
+            IsActive = reader.GetBoolean(4),
+            CreatedAt = reader.GetDateTime(5),
+            UpdatedAt = reader.GetDateTime(6)
         };
     }
 }

--- a/TerraformRegistry.Tests/IntegrationTests/ApiKeyExpirationTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/ApiKeyExpirationTests.cs
@@ -75,6 +75,89 @@ public class ApiKeyExpirationTests(ITestOutputHelper output) : IntegrationTestBa
     }
 
     [Fact]
+    public async Task DisabledUserApiKeyReturnsUnauthorizedImmediately()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var apiKeyService = scope.ServiceProvider.GetRequiredService<IApiKeyService>();
+        var dbService = scope.ServiceProvider.GetRequiredService<IDatabaseService>();
+        var permissionService = scope.ServiceProvider.GetRequiredService<IPermissionService>();
+
+        var user = new User
+        {
+            Id = Guid.NewGuid().ToString(),
+            Email = "disabled-key-test@example.com",
+            Provider = "test",
+            ProviderId = "test-disabled-key",
+            IsActive = false,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        await dbService.AddUserAsync(user);
+        await permissionService.EnsureDefaultRoleAsync(user.Id);
+        var (rawToken, _) = await apiKeyService.CreateApiKeyAsync(user.Id, "disabled key");
+
+        var client = Factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", rawToken);
+
+        var response = await client.GetAsync("/v1/modules");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DisabledUserSessionJwtReturnsUnauthorizedImmediately()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var dbService = scope.ServiceProvider.GetRequiredService<IDatabaseService>();
+        var jwtService = scope.ServiceProvider.GetRequiredService<JwtService>();
+        var user = new User
+        {
+            Id = Guid.NewGuid().ToString(),
+            Email = "disabled-session-test@example.com",
+            Provider = "test",
+            ProviderId = "test-disabled-session",
+            IsActive = false,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        await dbService.AddUserAsync(user);
+
+        var client = Factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Cookie", $"tf-session={jwtService.GenerateToken(user.Id, user.Email, "Disabled", user.Provider)}");
+
+        var response = await client.GetAsync("/v1/modules");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DisabledUserPortalSessionIsRedirectedToLogin()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var dbService = scope.ServiceProvider.GetRequiredService<IDatabaseService>();
+        var jwtService = scope.ServiceProvider.GetRequiredService<JwtService>();
+        var user = new User
+        {
+            Id = Guid.NewGuid().ToString(),
+            Email = "disabled-portal-test@example.com",
+            Provider = "test",
+            ProviderId = "test-disabled-portal",
+            IsActive = false,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        await dbService.AddUserAsync(user);
+
+        var client = Factory.CreateClient(new() { AllowAutoRedirect = false });
+        client.DefaultRequestHeaders.Add("Cookie", $"tf-session={jwtService.GenerateToken(user.Id, user.Email, "Disabled", user.Provider)}");
+
+        var response = await client.GetAsync("/modules");
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Equal("/login", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
     public async Task ValidApiKeyWithFutureExpirationSucceeds()
     {
         using var scope = Factory.Services.CreateScope();

--- a/TerraformRegistry.Tests/IntegrationTests/IntegrationTestBase.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/IntegrationTestBase.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Models;
 using TerraformRegistry.Services;
+using TerraformRegistry.Startup;
 using Testcontainers.PostgreSql;
 using Xunit.Abstractions;
 using Xunit.Extensions.Logging;
@@ -68,6 +69,8 @@ public abstract class IntegrationTestBase : IAsyncLifetime
                         ["ProviderStoragePath"] = providerStoragePath,
                         ["PORT"] = "0",
                         ["AuthorizationToken"] = _authToken,
+                        ["UserAdmission:Mode"] = "ConstrainedAutoProvision",
+                        ["UserAdmission:AllowedDomains:0"] = "example.com",
                         ["Oidc:JwtSecretKey"] = "integration-test-jwt-secret-key-32-chars-minimum"
                     });
                 });
@@ -79,6 +82,13 @@ public abstract class IntegrationTestBase : IAsyncLifetime
                     {
                         JwtSecretKey = "integration-test-jwt-secret-key-32-chars-minimum",
                         JwtExpiryHours = 24
+                    });
+                    services.RemoveAll<UserAdmissionOptions>();
+                    services.AddSingleton(new UserAdmissionOptions
+                    {
+                        Mode = UserAdmissionMode.ConstrainedAutoProvision,
+                        AllowedDomains = ["example.com"],
+                        RequireVerifiedEmail = false
                     });
                 });
 

--- a/TerraformRegistry.Tests/UnitTests/UserAdmissionOptionsTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/UserAdmissionOptionsTests.cs
@@ -1,0 +1,67 @@
+using TerraformRegistry.Startup;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public class UserAdmissionOptionsTests
+{
+    [Fact]
+    public void NewUsersAreActiveByDefault()
+    {
+        var user = new TerraformRegistry.Models.User();
+
+        Assert.True(user.IsActive);
+    }
+
+    [Fact]
+    public void DefaultsToClosedAdmission()
+    {
+        var options = new UserAdmissionOptions();
+
+        Assert.Equal(UserAdmissionMode.Closed, options.Mode);
+        options.Validate();
+    }
+
+    [Fact]
+    public void AutoProvisionRequiresAtLeastOneConstraint()
+    {
+        var options = new UserAdmissionOptions
+        {
+            Mode = UserAdmissionMode.ConstrainedAutoProvision
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(options.Validate);
+
+        Assert.Contains("constraint", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AutoProvisionAcceptsAnAllowlistedEmail()
+    {
+        var options = new UserAdmissionOptions
+        {
+            Mode = UserAdmissionMode.ConstrainedAutoProvision,
+            AllowedEmails = ["user@example.com"]
+        };
+
+        options.Validate();
+        Assert.True(options.Allows("github", "tenant-a", "user@example.com", emailVerified: true));
+    }
+
+    [Fact]
+    public void ConfiguredIssuerTenantDomainAndVerifiedEmailMustAllMatch()
+    {
+        var options = new UserAdmissionOptions
+        {
+            Mode = UserAdmissionMode.ConstrainedAutoProvision,
+            AllowedIssuers = ["https://issuer.example"],
+            AllowedTenants = ["tenant-a"],
+            AllowedDomains = ["example.com"]
+        };
+
+        Assert.True(options.Allows("https://issuer.example", "tenant-a", "user@example.com", emailVerified: true));
+        Assert.False(options.Allows("", "tenant-a", "user@example.com", emailVerified: true));
+        Assert.False(options.Allows("https://issuer.example", "", "user@example.com", emailVerified: true));
+        Assert.False(options.Allows("https://issuer.example", "tenant-a", "user@other.example", emailVerified: true));
+        Assert.False(options.Allows("https://issuer.example", "tenant-a", "user@example.com", emailVerified: false));
+    }
+}

--- a/TerraformRegistry/Handlers/AuthHandlers.cs
+++ b/TerraformRegistry/Handlers/AuthHandlers.cs
@@ -117,7 +117,13 @@ public static class AuthHandlers
         User user;
         try
         {
-            user = await apiKeyService.GetOrCreateOidcUserAsync(userInfo.Email, provider, userInfo.Id);
+            user = await apiKeyService.GetOrCreateOidcUserAsync(new OidcUserAdmission(
+                userInfo.Email,
+                provider,
+                userInfo.Id,
+                userInfo.Issuer,
+                userInfo.TenantId,
+                userInfo.EmailVerified));
         }
         catch (InvalidOperationException ex)
         {

--- a/TerraformRegistry/Middleware/AuthenticationMiddleware.cs
+++ b/TerraformRegistry/Middleware/AuthenticationMiddleware.cs
@@ -156,24 +156,19 @@ public class AuthenticationMiddleware(
             if (!string.IsNullOrEmpty(header) && header.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 var jwtToken = header.Substring(BearerPrefix.Length);
-                // If we are here, it might be a JWT (or an invalid API key)
-                // Only try JWT validation if it looks like one
-                if (jwtToken.Contains('.', StringComparison.Ordinal) && jwtToken.Count(c => c == '.') == 2)
+                var principal = jwtService.ValidateToken(jwtToken);
+                if (principal != null)
                 {
-                    var principal = jwtService.ValidateToken(jwtToken);
-                    if (principal != null)
+                    if (!await IsCurrentUserActiveAsync(context, principal))
                     {
-                        if (!await IsCurrentUserActiveAsync(context, principal))
-                        {
-                            await WriteUnauthorizedResponseAsync(context, path);
-                            return;
-                        }
-
-                        context.User = principal;
-                        await LoadPermissionsIntoClaims(context);
-                        await next(context);
+                        await WriteUnauthorizedResponseAsync(context, path);
                         return;
                     }
+
+                    context.User = principal;
+                    await LoadPermissionsIntoClaims(context);
+                    await next(context);
+                    return;
                 }
             }
 

--- a/TerraformRegistry/Middleware/AuthenticationMiddleware.cs
+++ b/TerraformRegistry/Middleware/AuthenticationMiddleware.cs
@@ -152,24 +152,24 @@ public class AuthenticationMiddleware(
                 RegistryLog.Information(logger, "Processing request for {Path}. No session cookie found.", path);
             }
 
-            // Check 4: JWT in Authorization header (Bearer token)
-            if (!string.IsNullOrEmpty(header) && header.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))
+            // Check 4: JWT in Authorization header (Bearer token). The validator receives an empty token for
+            // non-bearer requests, so request-controlled format checks never guard token validation.
+            var jwtToken = !string.IsNullOrEmpty(header) && header.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase)
+                ? header.Substring(BearerPrefix.Length)
+                : string.Empty;
+            var jwtPrincipal = jwtService.ValidateToken(jwtToken);
+            if (jwtPrincipal != null)
             {
-                var jwtToken = header.Substring(BearerPrefix.Length);
-                var principal = jwtService.ValidateToken(jwtToken);
-                if (principal != null)
+                if (!await IsCurrentUserActiveAsync(context, jwtPrincipal))
                 {
-                    if (!await IsCurrentUserActiveAsync(context, principal))
-                    {
-                        await WriteUnauthorizedResponseAsync(context, path);
-                        return;
-                    }
-
-                    context.User = principal;
-                    await LoadPermissionsIntoClaims(context);
-                    await next(context);
+                    await WriteUnauthorizedResponseAsync(context, path);
                     return;
                 }
+
+                context.User = jwtPrincipal;
+                await LoadPermissionsIntoClaims(context);
+                await next(context);
+                return;
             }
 
             // No valid authentication found

--- a/TerraformRegistry/Middleware/AuthenticationMiddleware.cs
+++ b/TerraformRegistry/Middleware/AuthenticationMiddleware.cs
@@ -122,6 +122,12 @@ public class AuthenticationMiddleware(
                 var principal = jwtService.ValidateToken(sessionToken);
                 if (principal != null)
                 {
+                    if (!await IsCurrentUserActiveAsync(context, principal))
+                    {
+                        await WriteUnauthorizedResponseAsync(context, path);
+                        return;
+                    }
+
                     context.User = principal;
                     await LoadPermissionsIntoClaims(context);
                     RegistryLog.Information(logger,
@@ -157,6 +163,12 @@ public class AuthenticationMiddleware(
                     var principal = jwtService.ValidateToken(jwtToken);
                     if (principal != null)
                     {
+                        if (!await IsCurrentUserActiveAsync(context, principal))
+                        {
+                            await WriteUnauthorizedResponseAsync(context, path);
+                            return;
+                        }
+
                         context.User = principal;
                         await LoadPermissionsIntoClaims(context);
                         await next(context);
@@ -201,6 +213,19 @@ public class AuthenticationMiddleware(
             foreach (var perm in perms)
                 identity.AddClaim(new Claim("permission", perm));
         }
+    }
+
+    private static async Task<bool> IsCurrentUserActiveAsync(HttpContext context, ClaimsPrincipal principal)
+    {
+        var userId = principal.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? principal.FindFirst("sub")?.Value;
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return false;
+        }
+
+        using var scope = context.RequestServices.CreateScope();
+        var dbService = scope.ServiceProvider.GetRequiredService<IDatabaseService>();
+        return (await dbService.GetUserByIdAsync(userId))?.IsActive == true;
     }
 
     /// <summary>

--- a/TerraformRegistry/Middleware/PortalAuthenticationMiddleware.cs
+++ b/TerraformRegistry/Middleware/PortalAuthenticationMiddleware.cs
@@ -85,11 +85,16 @@ public class PortalAuthenticationMiddleware(
         if (!string.IsNullOrEmpty(token))
         {
             var principal = jwtService.ValidateToken(token);
-            if (principal != null)
+            if (principal != null && await IsCurrentUserActiveAsync(context, principal))
             {
                 context.User = principal;
                 RegistryLog.Information(logger, "Portal session validated for {Path}. User: {User}", path,
                     principal.Identity?.Name);
+            }
+            else if (principal != null)
+            {
+                context.Response.Cookies.Delete(SessionCookieName);
+                RegistryLog.Warning(logger, "Rejected portal session for inactive or removed user on {Path}", path);
             }
         }
 
@@ -125,6 +130,19 @@ public class PortalAuthenticationMiddleware(
         return ProtectedPortalPaths.Any(p =>
             path.Equals(p, StringComparison.OrdinalIgnoreCase) ||
             path.StartsWith(p + "/", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static async Task<bool> IsCurrentUserActiveAsync(HttpContext context, ClaimsPrincipal principal)
+    {
+        var userId = principal.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? principal.FindFirst("sub")?.Value;
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return false;
+        }
+
+        using var scope = context.RequestServices.CreateScope();
+        var dbService = scope.ServiceProvider.GetRequiredService<IDatabaseService>();
+        return (await dbService.GetUserByIdAsync(userId))?.IsActive == true;
     }
 
     private static bool IsStaticFile(string path)

--- a/TerraformRegistry/Models/OidcOptions.cs
+++ b/TerraformRegistry/Models/OidcOptions.cs
@@ -45,4 +45,7 @@ public class UserInfo
     public string Name { get; set; } = string.Empty;
     public string Provider { get; set; } = string.Empty;
     public string AvatarUrl { get; set; } = string.Empty;
+    public string Issuer { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public bool EmailVerified { get; set; }
 }

--- a/TerraformRegistry/Services/ApiKeyService.cs
+++ b/TerraformRegistry/Services/ApiKeyService.cs
@@ -4,10 +4,14 @@ using Konscious.Security.Cryptography;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.API.Logging;
 using TerraformRegistry.Models;
+using TerraformRegistry.Startup;
 
 namespace TerraformRegistry.Services;
 
-public class ApiKeyService(IDatabaseService dbService, ILogger<ApiKeyService> logger) : IApiKeyService
+public class ApiKeyService(
+    IDatabaseService dbService,
+    ILogger<ApiKeyService> logger,
+    UserAdmissionOptions userAdmissionOptions) : IApiKeyService
 {
     private const int TokenLength = 32;
     // private const string TokenPrefix = "tf-"; // Removed prefix requirement
@@ -75,6 +79,13 @@ public class ApiKeyService(IDatabaseService dbService, ILogger<ApiKeyService> lo
                     return new ApiKeyValidationResult(null, true);
                 }
 
+                var user = await dbService.GetUserByIdAsync(key.UserId);
+                if (user?.IsActive != true)
+                {
+                    RegistryLog.Warning(logger, "Rejected API key for inactive or missing user {UserId}", key.UserId);
+                    return new ApiKeyValidationResult(null, false);
+                }
+
                 key.LastUsedAt = DateTime.UtcNow;
                 await dbService.UpdateApiKeyAsync(key);
                 return new ApiKeyValidationResult(key, false);
@@ -139,12 +150,17 @@ public class ApiKeyService(IDatabaseService dbService, ILogger<ApiKeyService> lo
 
     public async Task<User> GetOrCreateOidcUserAsync(string email, string provider, string providerId)
     {
-        if (string.IsNullOrWhiteSpace(email))
+        return await GetOrCreateOidcUserAsync(new OidcUserAdmission(email, provider, providerId, provider, string.Empty, true));
+    }
+
+    public async Task<User> GetOrCreateOidcUserAsync(OidcUserAdmission admission)
+    {
+        if (string.IsNullOrWhiteSpace(admission.Email))
         {
             throw new InvalidOperationException("OIDC login requires a non-empty email address.");
         }
 
-        var canonicalEmail = CanonicalizeEmail(email);
+        var canonicalEmail = CanonicalizeEmail(admission.Email);
         var matchingUsers = await dbService.GetUsersByEmailCaseInsensitiveAsync(canonicalEmail);
         if (matchingUsers.Count > 1)
         {
@@ -155,12 +171,18 @@ public class ApiKeyService(IDatabaseService dbService, ILogger<ApiKeyService> lo
         var user = matchingUsers.Count == 0 ? null : matchingUsers[0];
         if (user == null)
         {
+            if (userAdmissionOptions.Mode != UserAdmissionMode.ConstrainedAutoProvision ||
+                !userAdmissionOptions.Allows(admission.Issuer, admission.TenantId, canonicalEmail, admission.EmailVerified))
+            {
+                throw new InvalidOperationException("OIDC admission policy denied this new identity.");
+            }
+
             user = new User
             {
                 Id = Guid.NewGuid().ToString(),
                 Email = canonicalEmail,
-                Provider = provider,
-                ProviderId = providerId,
+                Provider = admission.Provider,
+                ProviderId = admission.ProviderId,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };
@@ -168,11 +190,16 @@ public class ApiKeyService(IDatabaseService dbService, ILogger<ApiKeyService> lo
             return user;
         }
 
-        if (!string.Equals(user.Provider, provider, StringComparison.OrdinalIgnoreCase) ||
-            !string.Equals(user.ProviderId, providerId, StringComparison.Ordinal))
+        if (!string.Equals(user.Provider, admission.Provider, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(user.ProviderId, admission.ProviderId, StringComparison.Ordinal))
         {
             throw new InvalidOperationException(
                 $"The email '{canonicalEmail}' is already linked to a different identity. Manual account linking is required.");
+        }
+
+        if (!user.IsActive)
+        {
+            throw new InvalidOperationException("The user account is disabled.");
         }
 
         return user;

--- a/TerraformRegistry/Services/IApiKeyService.cs
+++ b/TerraformRegistry/Services/IApiKeyService.cs
@@ -53,6 +53,9 @@ public interface IApiKeyService
     /// </summary>
     Task<User> GetOrCreateOidcUserAsync(string email, string provider, string providerId);
 
+    Task<User> GetOrCreateOidcUserAsync(OidcUserAdmission admission) =>
+        GetOrCreateOidcUserAsync(admission.Email, admission.Provider, admission.ProviderId);
+
     /// <summary>
     /// Ensures a User record exists for the given external details.
     /// </summary>
@@ -63,3 +66,11 @@ public interface IApiKeyService
     /// </summary>
     Task<User?> GetUserByIdAsync(string id);
 }
+
+public sealed record OidcUserAdmission(
+    string Email,
+    string Provider,
+    string ProviderId,
+    string Issuer,
+    string TenantId,
+    bool EmailVerified);

--- a/TerraformRegistry/Services/JwtService.cs
+++ b/TerraformRegistry/Services/JwtService.cs
@@ -81,6 +81,11 @@ public class JwtService
     /// </summary>
     public ClaimsPrincipal? ValidateToken(string token)
     {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return null;
+        }
+
         try
         {
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_secretKey));

--- a/TerraformRegistry/Services/OAuthService.cs
+++ b/TerraformRegistry/Services/OAuthService.cs
@@ -172,7 +172,9 @@ public class OAuthService
             Email = email,
             Name = root.TryGetProperty("name", out var nameProp) ? nameProp.GetString() ?? root.GetProperty("login").GetString() ?? "" : root.GetProperty("login").GetString() ?? "",
             Provider = "github",
-            AvatarUrl = root.TryGetProperty("avatar_url", out var avatarProp) ? avatarProp.GetString() ?? "" : ""
+            AvatarUrl = root.TryGetProperty("avatar_url", out var avatarProp) ? avatarProp.GetString() ?? "" : "",
+            Issuer = "https://github.com",
+            EmailVerified = false
         };
     }
 
@@ -280,7 +282,9 @@ public class OAuthService
             Email = email,
             Name = root.TryGetProperty("displayName", out var nameProp) ? nameProp.GetString() ?? "" : "",
             Provider = "azuread",
-            AvatarUrl = "" // Azure doesn't provide avatar in basic profile
+            AvatarUrl = "", // Azure doesn't provide avatar in basic profile
+            Issuer = new Uri(config.AuthorizationEndpoint).GetLeftPart(UriPartial.Authority),
+            EmailVerified = false
         };
     }
 

--- a/TerraformRegistry/Services/Sqlite/SqliteUserRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteUserRepository.cs
@@ -14,7 +14,7 @@ public sealed class SqliteUserRepository(string connectionString) : IUserReposit
         await using var cmd = connection.CreateCommand();
         cmd.CommandText =
             """
-            SELECT id, email, provider, provider_id, created_at, updated_at
+            SELECT id, email, provider, provider_id, is_active, created_at, updated_at
             FROM users
             WHERE lower(email) = lower($email)
             ORDER BY CASE WHEN email = $email THEN 0 ELSE 1 END, created_at ASC
@@ -42,7 +42,7 @@ public sealed class SqliteUserRepository(string connectionString) : IUserReposit
         await using var connection = new SqliteConnection(connectionString);
         await connection.OpenAsync();
         await using var cmd = connection.CreateCommand();
-        cmd.CommandText = "SELECT id, email, provider, provider_id, created_at, updated_at FROM users WHERE id = $id";
+        cmd.CommandText = "SELECT id, email, provider, provider_id, is_active, created_at, updated_at FROM users WHERE id = $id";
         cmd.Parameters.AddWithValue("$id", id);
 
         await using var reader = await cmd.ExecuteReaderAsync();
@@ -57,13 +57,14 @@ public sealed class SqliteUserRepository(string connectionString) : IUserReposit
         await connection.OpenAsync();
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
-            INSERT INTO users (id, email, provider, provider_id, created_at, updated_at)
-            VALUES ($id, $email, $prov, $provId, $created, $updated)";
+            INSERT INTO users (id, email, provider, provider_id, is_active, created_at, updated_at)
+            VALUES ($id, $email, $prov, $provId, $isActive, $created, $updated)";
 
         cmd.Parameters.AddWithValue("$id", user.Id);
         cmd.Parameters.AddWithValue("$email", user.Email);
         cmd.Parameters.AddWithValue("$prov", user.Provider);
         cmd.Parameters.AddWithValue("$provId", user.ProviderId);
+        cmd.Parameters.AddWithValue("$isActive", user.IsActive ? 1 : 0);
         cmd.Parameters.AddWithValue("$created", user.CreatedAt.ToString("o", CultureInfo.InvariantCulture));
         cmd.Parameters.AddWithValue("$updated", user.UpdatedAt.ToString("o", CultureInfo.InvariantCulture));
 
@@ -77,7 +78,7 @@ public sealed class SqliteUserRepository(string connectionString) : IUserReposit
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
             UPDATE users SET 
-                email = $email, provider = $prov, provider_id = $provId, 
+                email = $email, provider = $prov, provider_id = $provId, is_active = $isActive,
                 updated_at = $updated
             WHERE id = $id";
 
@@ -85,6 +86,7 @@ public sealed class SqliteUserRepository(string connectionString) : IUserReposit
         cmd.Parameters.AddWithValue("$email", user.Email);
         cmd.Parameters.AddWithValue("$prov", user.Provider);
         cmd.Parameters.AddWithValue("$provId", user.ProviderId);
+        cmd.Parameters.AddWithValue("$isActive", user.IsActive ? 1 : 0);
         cmd.Parameters.AddWithValue("$updated", user.UpdatedAt.ToString("o", CultureInfo.InvariantCulture));
 
         await cmd.ExecuteNonQueryAsync();
@@ -106,7 +108,7 @@ public sealed class SqliteUserRepository(string connectionString) : IUserReposit
         await using var connection = new SqliteConnection(connectionString);
         await connection.OpenAsync();
         await using var cmd = connection.CreateCommand();
-        cmd.CommandText = "SELECT id, email, provider, provider_id, created_at, updated_at FROM users ORDER BY created_at DESC";
+        cmd.CommandText = "SELECT id, email, provider, provider_id, is_active, created_at, updated_at FROM users ORDER BY created_at DESC";
 
         await using var reader = await cmd.ExecuteReaderAsync();
         while (await reader.ReadAsync())
@@ -124,8 +126,9 @@ public sealed class SqliteUserRepository(string connectionString) : IUserReposit
             Email = reader.GetString(1),
             Provider = reader.GetString(2),
             ProviderId = reader.GetString(3),
-            CreatedAt = DateTime.Parse(reader.GetString(4), CultureInfo.InvariantCulture),
-            UpdatedAt = DateTime.Parse(reader.GetString(5), CultureInfo.InvariantCulture)
+            IsActive = reader.GetInt64(4) != 0,
+            CreatedAt = DateTime.Parse(reader.GetString(5), CultureInfo.InvariantCulture),
+            UpdatedAt = DateTime.Parse(reader.GetString(6), CultureInfo.InvariantCulture)
         };
     }
 }

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -88,6 +88,10 @@ internal static class ServiceRegistrationExtensions
         var oidcOptions = new OidcOptions();
         configuration.GetSection("Oidc").Bind(oidcOptions);
         services.AddSingleton(oidcOptions);
+        var userAdmissionOptions = new UserAdmissionOptions();
+        configuration.GetSection(UserAdmissionOptions.SectionName).Bind(userAdmissionOptions);
+        userAdmissionOptions.Validate();
+        services.AddSingleton(userAdmissionOptions);
         services.AddSingleton<JwtService>();
         services.AddSingleton<OAuthService>();
         services.AddSingleton(new TerraformLoginOptions());

--- a/TerraformRegistry/Startup/UserAdmissionOptions.cs
+++ b/TerraformRegistry/Startup/UserAdmissionOptions.cs
@@ -1,0 +1,52 @@
+namespace TerraformRegistry.Startup;
+
+public enum UserAdmissionMode
+{
+    Closed,
+    ExistingUsersOnly,
+    ConstrainedAutoProvision
+}
+
+public sealed class UserAdmissionOptions
+{
+    public const string SectionName = "UserAdmission";
+
+    public UserAdmissionMode Mode { get; set; } = UserAdmissionMode.Closed;
+    public string[] AllowedIssuers { get; set; } = [];
+    public string[] AllowedTenants { get; set; } = [];
+    public string[] AllowedDomains { get; set; } = [];
+    public string[] AllowedEmails { get; set; } = [];
+    public bool RequireVerifiedEmail { get; set; } = true;
+
+    public void Validate()
+    {
+        if (Mode != UserAdmissionMode.ConstrainedAutoProvision)
+        {
+            return;
+        }
+
+        if (AllowedIssuers.Length == 0 && AllowedTenants.Length == 0 && AllowedDomains.Length == 0 && AllowedEmails.Length == 0)
+        {
+            throw new InvalidOperationException(
+                "Constrained auto-provisioning requires at least one admission constraint.");
+        }
+    }
+
+    public bool Allows(string issuer, string tenant, string email, bool emailVerified)
+    {
+        if (RequireVerifiedEmail && !emailVerified)
+        {
+            return false;
+        }
+
+        var domain = email.LastIndexOf('@') is var at && at >= 0 ? email[(at + 1)..] : string.Empty;
+        return Matches(AllowedIssuers, issuer) && Matches(AllowedTenants, tenant) &&
+               Matches(AllowedDomains, domain) && Matches(AllowedEmails, email);
+    }
+
+    private static bool Matches(IEnumerable<string> constraints, string value)
+    {
+        var values = constraints.Where(value => !string.IsNullOrWhiteSpace(value)).ToArray();
+        return values.Length == 0 || values.Contains(value, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/TerraformRegistry/appsettings.json
+++ b/TerraformRegistry/appsettings.json
@@ -81,6 +81,14 @@
       }
     }
   },
+  "UserAdmission": {
+    "Mode": "Closed",
+    "AllowedIssuers": [],
+    "AllowedTenants": [],
+    "AllowedDomains": [],
+    "AllowedEmails": [],
+    "RequireVerifiedEmail": true
+  },
   "EnvironmentVariables": {
     "Comment": "The following environment variables can be used for configuration:",
     "TF_REG_BaseUrl": "Base URL for the Terraform Registry",


### PR DESCRIPTION
## P2-ADMISSION — IAM-002, IAM-012

Base: `remediation/phase/2-bounded-ingestion-identity` at `fdfd53931f6bbc2240d3a1c3883047384669aac3`.

Implements explicit closed-by-default OIDC admission with constrained issuer/tenant/domain/email policy, plus a durable active-user state. Disabled or offboarded identities are denied immediately through API keys, bearer/session JWTs, portal cookies, and Terraform login authorization.

Schema migrations: PostgreSQL `019_user_admission_state.sql`; SQLite `017_user_admission_state.sql`. Existing accounts stay active on upgrade.

Compatibility: no wire change; new production configuration is closed by default. Azure/GitHub claim data that is unavailable is represented as absent and fails closed when an operator configures the corresponding constraint.

Verification:
- `dotnet build terraform-registry.sln --no-restore --configuration Release`
- `dotnet test ... --filter FullyQualifiedName~ApiKeyExpirationTests` — 7 passed
- `dotnet test ... --filter FullyQualifiedName~OidcSecurityTests` — 10 passed
- `dotnet test ... --filter FullyQualifiedName~UserAdmissionOptionsTests` — 5 passed
- `git diff --check`

Non-goals: namespace ownership/ACL and high-impact permission separation are owned by P2-ACL; durable authorization codes are owned by P2-AUTH-CODES.