### PR TITLE
security: validate module archives before publication

### DIFF
--- a/TerraformRegistry.Tests/UnitTests/ArchiveWorkspaceFactoryTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ArchiveWorkspaceFactoryTests.cs
@@ -47,4 +47,61 @@ public class ArchiveWorkspaceFactoryTests
         var workspacesRoot = Path.Combine(tempDir.FullName, "workspaces");
         Assert.True(!Directory.Exists(workspacesRoot) || !Directory.EnumerateDirectories(workspacesRoot).Any());
     }
+
+    [Fact]
+    public async Task ArchiveWorkspaceFactoryRejectsExpandedContentOverConfiguredLimit()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        await using var stream = new MemoryStream(TestArchiveBuilder.CreateZipBytes(("module/main.tf", "0123456789")));
+        var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
+        {
+            TempRoot = Path.Combine(tempDir.FullName, "workspaces"),
+            MaxExpandedArchiveBytes = 4
+        });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            factory.CreateAsync(stream, CancellationToken.None));
+
+        Assert.Contains("expanded", exception.Message, StringComparison.OrdinalIgnoreCase);
+        var workspacesRoot = Path.Combine(tempDir.FullName, "workspaces");
+        Assert.True(!Directory.Exists(workspacesRoot) || !Directory.EnumerateDirectories(workspacesRoot).Any());
+    }
+
+    [Fact]
+    public async Task ArchiveWorkspaceFactoryRejectsPathTraversalAndCleansWorkspace()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        await using var stream = new MemoryStream(TestArchiveBuilder.CreateZipBytes(("../outside.tf", "resource {}")));
+        var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
+        {
+            TempRoot = Path.Combine(tempDir.FullName, "workspaces")
+        });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            factory.CreateAsync(stream, CancellationToken.None));
+
+        Assert.Contains("escapes", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(Path.Combine(tempDir.FullName, "outside.tf")));
+        var workspacesRoot = Path.Combine(tempDir.FullName, "workspaces");
+        Assert.True(!Directory.Exists(workspacesRoot) || !Directory.EnumerateDirectories(workspacesRoot).Any());
+    }
+
+    [Fact]
+    public async Task ArchiveWorkspaceFactoryRejectsArchivesOverConfiguredEntryCount()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        await using var stream = new MemoryStream(TestArchiveBuilder.CreateZipBytes(
+            ("module/one.tf", "one"),
+            ("module/two.tf", "two")));
+        var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
+        {
+            TempRoot = Path.Combine(tempDir.FullName, "workspaces"),
+            MaxArchiveEntries = 1
+        });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            factory.CreateAsync(stream, CancellationToken.None));
+
+        Assert.Contains("entry count", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/TerraformRegistry.Tests/UnitTests/ArchiveWorkspaceFactoryTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ArchiveWorkspaceFactoryTests.cs
@@ -30,6 +30,26 @@ public class ArchiveWorkspaceFactoryTests
     }
 
     [Fact]
+    public async Task ArchiveWorkspaceFactoryExtractsEmptyRegularFileFromTarGz()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        var tarGzPath = Path.Combine(tempDir.FullName, "module.tar.gz");
+        await TestArchiveBuilder.CreateTarGzAsync(tarGzPath, ("module/main.tf", string.Empty));
+
+        await using var stream = File.OpenRead(tarGzPath);
+        var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
+        {
+            TempRoot = Path.Combine(tempDir.FullName, "workspaces")
+        });
+
+        await using var workspace = await factory.CreateAsync(stream, CancellationToken.None);
+
+        var file = Path.Combine(workspace.RootPath, "main.tf");
+        Assert.True(File.Exists(file));
+        Assert.Equal(0, new FileInfo(file).Length);
+    }
+
+    [Fact]
     public async Task ArchiveWorkspaceFactoryRejectsArchivesOverConfiguredLimit()
     {
         var tempDir = Directory.CreateTempSubdirectory();

--- a/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
@@ -15,6 +15,36 @@ namespace TerraformRegistry.Tests.UnitTests;
 public class ModulePublishCoordinatorTests
 {
     [Fact]
+    public async Task PublishAsyncDoesNotCreateSideEffectsWhenArchiveValidationFails()
+    {
+        var validator = new Mock<IArchiveIngestionValidator>();
+        validator.Setup(x => x.PrepareAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Archive expanded content exceeds the configured limit."));
+        var moduleService = new Mock<IModuleService>();
+
+        var coordinator = new ModulePublishCoordinator(
+            moduleService.Object,
+            Mock.Of<IModuleExtractionService>(),
+            CreateWebhookDispatcher(),
+            Mock.Of<IAuditService>(),
+            NullLogger<ModulePublishCoordinator>.Instance,
+            validator.Object);
+        await using var content = new MemoryStream([1, 2, 3]);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => coordinator.PublishAsync(new ModulePublishRequest
+        {
+            Namespace = "acme",
+            Name = "network",
+            Provider = "aws",
+            Version = "1.2.3",
+            ModuleContent = content,
+            Metadata = new ModuleArtifactMetadata { Source = new ModuleSourceInfo { Kind = "api-upload" } }
+        }, CancellationToken.None));
+
+        moduleService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
     public async Task PublishAsyncUploadsModuleAndQueuesExtraction()
     {
         var moduleService = new Mock<IModuleService>();
@@ -153,6 +183,22 @@ public class ModulePublishCoordinatorTests
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
             Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+    }
+
+    private static WebhookDispatcher CreateWebhookDispatcher()
+    {
+        var webhookService = new Mock<IWebhookService>();
+        webhookService.Setup(x => x.GetActiveWebhooksForEventAsync("module.published"))
+            .ReturnsAsync(Array.Empty<Webhook>());
+        return new WebhookDispatcher(
+            webhookService.Object,
+            new TestHttpClientFactory(new HttpClient(new StaticOkHandler())),
+            new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build(),
+            new WebhookUrlValidator(
+                Options.Create(new WebhookSecurityOptions { AllowPrivateNetworks = true }),
+                new StaticWebhookHostResolver(IPAddress.Loopback),
+                NullLogger<WebhookUrlValidator>.Instance),
+            NullLogger<WebhookDispatcher>.Instance);
     }
 
     private sealed class TestHttpClientFactory(HttpClient client) : IHttpClientFactory

--- a/TerraformRegistry/Services/ModuleExtraction/ArchiveIngestionValidator.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ArchiveIngestionValidator.cs
@@ -1,0 +1,58 @@
+namespace TerraformRegistry.Services.ModuleExtraction;
+
+public sealed class ArchiveIngestionValidator(
+    IArchiveWorkspaceFactory workspaceFactory,
+    ModuleExtractionOptions options) : IArchiveIngestionValidator
+{
+    private const int BufferSize = 1024 * 1024;
+
+    public async Task<ValidatedArchive> PrepareAsync(Stream archiveStream, CancellationToken cancellationToken)
+    {
+        options.Validate();
+        Directory.CreateDirectory(options.TempRoot);
+        var path = Path.Combine(options.TempRoot, $".{Guid.NewGuid():N}.upload");
+
+        try
+        {
+            await using (var output = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None,
+                             BufferSize, FileOptions.Asynchronous | FileOptions.SequentialScan))
+            {
+                var buffer = new byte[BufferSize];
+                long copied = 0;
+                while (true)
+                {
+                    var read = await archiveStream.ReadAsync(buffer, cancellationToken);
+                    if (read == 0)
+                    {
+                        break;
+                    }
+
+                    copied = checked(copied + read);
+                    if (copied > options.MaxArchiveBytes)
+                    {
+                        throw new InvalidOperationException($"Module archive exceeds the configured limit of {options.MaxArchiveBytes} bytes.");
+                    }
+
+                    await output.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+                }
+            }
+
+            await using (var validationInput = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read,
+                             BufferSize, FileOptions.Asynchronous | FileOptions.SequentialScan))
+            await using (var workspace = await workspaceFactory.CreateAsync(validationInput, cancellationToken))
+            {
+            }
+
+            return new ValidatedArchive(path);
+        }
+        catch
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+
+            throw;
+        }
+    }
+}

--- a/TerraformRegistry/Services/ModuleExtraction/ArchiveWorkspaceFactory.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ArchiveWorkspaceFactory.cs
@@ -6,6 +6,7 @@ namespace TerraformRegistry.Services.ModuleExtraction;
 
 public sealed class ArchiveWorkspaceFactory : IArchiveWorkspaceFactory
 {
+    private const int BufferSize = 1024 * 1024;
     private readonly ModuleExtractionOptions _options;
 
     public ArchiveWorkspaceFactory(IOptions<ModuleExtractionOptions> options) : this(options.Value)
@@ -15,85 +16,223 @@ public sealed class ArchiveWorkspaceFactory : IArchiveWorkspaceFactory
     public ArchiveWorkspaceFactory(ModuleExtractionOptions options)
     {
         _options = options;
+        _options.Validate();
     }
 
     public async Task<ArchiveWorkspace> CreateAsync(Stream archiveStream, CancellationToken cancellationToken)
     {
         var workRoot = Path.Combine(_options.TempRoot, Guid.NewGuid().ToString("N"));
+        var spoolPath = Path.Combine(_options.TempRoot, $".{Guid.NewGuid():N}.archive");
         Directory.CreateDirectory(workRoot);
 
         try
         {
-            var archiveBytes = await ReadAllBytesAsync(archiveStream, _options.MaxArchiveBytes, cancellationToken);
-            if (LooksLikeZip(archiveBytes))
+            await SpoolAsync(archiveStream, spoolPath, cancellationToken);
+            if (await LooksLikeZipAsync(spoolPath, cancellationToken))
             {
-                using var zip = new ZipArchive(new MemoryStream(archiveBytes), ZipArchiveMode.Read);
-                zip.ExtractToDirectory(workRoot, overwriteFiles: true);
+                await ExtractZipAsync(spoolPath, workRoot, cancellationToken);
             }
             else
             {
-                using var gzip = new GZipStream(new MemoryStream(archiveBytes), CompressionMode.Decompress);
-                TarFile.ExtractToDirectory(gzip, workRoot, overwriteFiles: true);
+                await ExtractTarGzAsync(spoolPath, workRoot, cancellationToken);
             }
 
+            File.Delete(spoolPath);
             return new ArchiveWorkspace(workRoot, NormalizeSingleTopLevelFolder(workRoot));
         }
         catch
         {
+            TryDeleteFile(spoolPath);
             if (Directory.Exists(workRoot))
+            {
                 Directory.Delete(workRoot, recursive: true);
+            }
 
             throw;
         }
     }
 
-    private static async Task<byte[]> ReadAllBytesAsync(
-        Stream archiveStream,
-        long maxArchiveBytes,
-        CancellationToken cancellationToken)
+    private async Task SpoolAsync(Stream source, string spoolPath, CancellationToken cancellationToken)
     {
-        if (maxArchiveBytes <= 0)
-        {
-            throw new InvalidOperationException("Module archive size limit must be greater than zero bytes.");
-        }
-
-        using var memory = new MemoryStream();
-        var buffer = new byte[81920];
+        await using var destination = new FileStream(spoolPath, FileMode.CreateNew, FileAccess.Write, FileShare.None,
+            BufferSize, FileOptions.Asynchronous | FileOptions.SequentialScan);
+        var buffer = new byte[BufferSize];
+        long copied = 0;
 
         while (true)
         {
-            var read = await archiveStream.ReadAsync(buffer, cancellationToken);
+            var read = await source.ReadAsync(buffer, cancellationToken);
             if (read == 0)
             {
                 break;
             }
 
-            if (memory.Length + read > maxArchiveBytes)
+            copied = checked(copied + read);
+            if (copied > _options.MaxArchiveBytes)
             {
-                throw new InvalidOperationException(
-                    $"Module archive exceeds the configured limit of {maxArchiveBytes} bytes.");
+                throw new InvalidOperationException($"Module archive exceeds the configured limit of {_options.MaxArchiveBytes} bytes.");
             }
 
-            await memory.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+            await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
         }
-
-        return memory.ToArray();
     }
 
-    private static bool LooksLikeZip(byte[] bytes)
+    private static async Task<bool> LooksLikeZipAsync(string spoolPath, CancellationToken cancellationToken)
     {
-        return bytes.Length >= 4 &&
-               bytes[0] == 0x50 &&
-               bytes[1] == 0x4B &&
-               (bytes[2] == 0x03 || bytes[2] == 0x05 || bytes[2] == 0x07) &&
-               (bytes[3] == 0x04 || bytes[3] == 0x06 || bytes[3] == 0x08);
+        await using var stream = new FileStream(spoolPath, FileMode.Open, FileAccess.Read, FileShare.Read, 4,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+        var header = new byte[4];
+        var read = await stream.ReadAsync(header, cancellationToken);
+        return read == 4 && header[0] == 0x50 && header[1] == 0x4B &&
+               (header[2] == 0x03 || header[2] == 0x05 || header[2] == 0x07) &&
+               (header[3] == 0x04 || header[3] == 0x06 || header[3] == 0x08);
+    }
+
+    private async Task ExtractZipAsync(string spoolPath, string workRoot, CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(spoolPath, FileMode.Open, FileAccess.Read, FileShare.Read, BufferSize,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+        long expandedTotal = 0;
+        var entries = 0;
+
+        foreach (var entry in archive.Entries)
+        {
+            ValidateEntry(entry.FullName, entry.Length, entry.CompressedLength, ref entries, expandedTotal);
+            var destinationPath = GetSafeDestinationPath(workRoot, entry.FullName);
+            if (string.IsNullOrEmpty(entry.Name))
+            {
+                Directory.CreateDirectory(destinationPath);
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            await using var input = entry.Open();
+            await using var output = new FileStream(destinationPath, FileMode.CreateNew, FileAccess.Write, FileShare.None,
+                BufferSize, FileOptions.Asynchronous | FileOptions.SequentialScan);
+            expandedTotal = await CopyEntryAsync(input, output, expandedTotal, cancellationToken);
+        }
+    }
+
+    private async Task ExtractTarGzAsync(string spoolPath, string workRoot, CancellationToken cancellationToken)
+    {
+        await using var archiveFile = new FileStream(spoolPath, FileMode.Open, FileAccess.Read, FileShare.Read, BufferSize,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+        await using var gzip = new GZipStream(archiveFile, CompressionMode.Decompress);
+        using var reader = new TarReader(gzip, leaveOpen: false);
+        long expandedTotal = 0;
+        var entries = 0;
+        var compressedBytes = new FileInfo(spoolPath).Length;
+
+        while (reader.GetNextEntry() is { } entry)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ValidateEntry(entry.Name, entry.Length, compressedBytes, ref entries, expandedTotal);
+            var destinationPath = GetSafeDestinationPath(workRoot, entry.Name);
+            if (entry.EntryType is TarEntryType.Directory)
+            {
+                Directory.CreateDirectory(destinationPath);
+                continue;
+            }
+
+            if (entry.EntryType is not TarEntryType.RegularFile and not TarEntryType.V7RegularFile)
+            {
+                throw new InvalidOperationException("Archive entries must be regular files or directories.");
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            await using var output = new FileStream(destinationPath, FileMode.CreateNew, FileAccess.Write, FileShare.None,
+                BufferSize, FileOptions.Asynchronous | FileOptions.SequentialScan);
+            expandedTotal = await CopyEntryAsync(
+                entry.DataStream ?? throw new InvalidOperationException("Archive entry has no data stream."),
+                output,
+                expandedTotal,
+                cancellationToken);
+        }
+    }
+
+    private void ValidateEntry(string entryName, long entryLength, long compressedLength, ref int entries, long expandedTotal)
+    {
+        if (string.IsNullOrWhiteSpace(entryName))
+        {
+            throw new InvalidOperationException("Archive entry path is required.");
+        }
+
+        entries = checked(entries + 1);
+        if (entries > _options.MaxArchiveEntries)
+        {
+            throw new InvalidOperationException("Archive exceeds the configured entry count limit.");
+        }
+
+        if (entryLength > _options.MaxExpandedEntryBytes)
+        {
+            throw new InvalidOperationException("Archive entry exceeds the configured expanded entry limit.");
+        }
+
+        if (entryLength > 0 && (compressedLength <= 0 || entryLength / Math.Max(1, compressedLength) > _options.MaxCompressionRatio))
+        {
+            throw new InvalidOperationException("Archive entry exceeds the configured compression ratio limit.");
+        }
+
+        if (expandedTotal > _options.MaxExpandedArchiveBytes - entryLength)
+        {
+            throw new InvalidOperationException("Archive expanded content exceeds the configured limit.");
+        }
+    }
+
+    private async Task<long> CopyEntryAsync(Stream input, Stream output, long expandedTotal, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[BufferSize];
+        while (true)
+        {
+            var read = await input.ReadAsync(buffer, cancellationToken);
+            if (read == 0)
+            {
+                return expandedTotal;
+            }
+
+            if (expandedTotal > _options.MaxExpandedArchiveBytes - read)
+            {
+                throw new InvalidOperationException("Archive expanded content exceeds the configured limit.");
+            }
+
+            expandedTotal += read;
+            await output.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+        }
+    }
+
+    private static string GetSafeDestinationPath(string workRoot, string entryName)
+    {
+        if (Path.IsPathRooted(entryName))
+        {
+            throw new InvalidOperationException("Archive entry path must be relative.");
+        }
+
+        var root = Path.GetFullPath(workRoot);
+        var destination = Path.GetFullPath(Path.Combine(root, entryName));
+        if (!destination.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Archive entry path escapes the extraction root.");
+        }
+
+        return destination;
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
     }
 
     private static string NormalizeSingleTopLevelFolder(string workRoot)
     {
         var rootFiles = Directory.EnumerateFiles(workRoot).Take(1).ToList();
         if (rootFiles.Count > 0)
+        {
             return workRoot;
+        }
 
         var rootDirectories = Directory.EnumerateDirectories(workRoot).Take(2).ToList();
         return rootDirectories.Count == 1 ? rootDirectories[0] : workRoot;

--- a/TerraformRegistry/Services/ModuleExtraction/ArchiveWorkspaceFactory.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ArchiveWorkspaceFactory.cs
@@ -144,7 +144,7 @@ public sealed class ArchiveWorkspaceFactory : IArchiveWorkspaceFactory
             await using var output = new FileStream(destinationPath, FileMode.CreateNew, FileAccess.Write, FileShare.None,
                 BufferSize, FileOptions.Asynchronous | FileOptions.SequentialScan);
             expandedTotal = await CopyEntryAsync(
-                entry.DataStream ?? throw new InvalidOperationException("Archive entry has no data stream."),
+                entry.DataStream ?? Stream.Null,
                 output,
                 expandedTotal,
                 cancellationToken);

--- a/TerraformRegistry/Services/ModuleExtraction/IArchiveIngestionValidator.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/IArchiveIngestionValidator.cs
@@ -1,0 +1,6 @@
+namespace TerraformRegistry.Services.ModuleExtraction;
+
+public interface IArchiveIngestionValidator
+{
+    Task<ValidatedArchive> PrepareAsync(Stream archiveStream, CancellationToken cancellationToken);
+}

--- a/TerraformRegistry/Services/ModuleExtraction/ValidatedArchive.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ValidatedArchive.cs
@@ -1,0 +1,16 @@
+namespace TerraformRegistry.Services.ModuleExtraction;
+
+public sealed class ValidatedArchive(string path) : IAsyncDisposable
+{
+    public Stream OpenRead() => new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+    public ValueTask DisposeAsync()
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/TerraformRegistry/Services/ModuleExtractionOptions.cs
+++ b/TerraformRegistry/Services/ModuleExtractionOptions.cs
@@ -3,6 +3,10 @@ namespace TerraformRegistry.Services;
 public class ModuleExtractionOptions
 {
     public const long DefaultMaxArchiveBytes = 100L * 1024L * 1024L;
+    public const long DefaultMaxExpandedArchiveBytes = 1L * 1024L * 1024L * 1024L;
+    public const int DefaultMaxArchiveEntries = 10_000;
+    public const long DefaultMaxExpandedEntryBytes = 256L * 1024L * 1024L;
+    public const int DefaultMaxCompressionRatio = 100;
 
     public bool Enabled { get; set; } = true;
     public string ToolPath { get; set; } = "terraform-config-inspect";
@@ -10,4 +14,17 @@ public class ModuleExtractionOptions
     public string TempRoot { get; set; } = Path.Combine(Path.GetTempPath(), "terraform-registry-extraction");
     public int StartupBackfillBatchSize { get; set; } = 25;
     public long MaxArchiveBytes { get; set; } = DefaultMaxArchiveBytes;
+    public long MaxExpandedArchiveBytes { get; set; } = DefaultMaxExpandedArchiveBytes;
+    public int MaxArchiveEntries { get; set; } = DefaultMaxArchiveEntries;
+    public long MaxExpandedEntryBytes { get; set; } = DefaultMaxExpandedEntryBytes;
+    public int MaxCompressionRatio { get; set; } = DefaultMaxCompressionRatio;
+
+    public void Validate()
+    {
+        if (MaxArchiveBytes <= 0 || MaxExpandedArchiveBytes <= 0 || MaxExpandedEntryBytes <= 0 ||
+            MaxArchiveEntries <= 0 || MaxCompressionRatio <= 0)
+        {
+            throw new InvalidOperationException("Archive ingestion limits must all be greater than zero.");
+        }
+    }
 }

--- a/TerraformRegistry/Services/Publishing/ModulePublishCoordinator.cs
+++ b/TerraformRegistry/Services/Publishing/ModulePublishCoordinator.cs
@@ -9,16 +9,29 @@ public sealed class ModulePublishCoordinator(
     IModuleExtractionService extractionService,
     WebhookDispatcher webhookDispatcher,
     IAuditService auditService,
-    ILogger<ModulePublishCoordinator> logger) : IModulePublishCoordinator
+    ILogger<ModulePublishCoordinator> logger,
+    IArchiveIngestionValidator? archiveValidator = null) : IModulePublishCoordinator
 {
     public async Task<bool> PublishAsync(ModulePublishRequest request, CancellationToken cancellationToken)
+    {
+        if (archiveValidator is not null)
+        {
+            await using var archive = await archiveValidator.PrepareAsync(request.ModuleContent, cancellationToken);
+            await using var content = archive.OpenRead();
+            return await PublishValidatedAsync(request, content, cancellationToken);
+        }
+
+        return await PublishValidatedAsync(request, request.ModuleContent, cancellationToken);
+    }
+
+    private async Task<bool> PublishValidatedAsync(ModulePublishRequest request, Stream content, CancellationToken cancellationToken)
     {
         var uploaded = await moduleService.UploadModuleAsync(
             request.Namespace,
             request.Name,
             request.Provider,
             request.Version,
-            request.ModuleContent,
+            content,
             request.Description,
             request.Replace,
             request.Metadata);

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.API.Logging;
 using TerraformRegistry.AzureBlob;
@@ -27,7 +28,21 @@ internal static class ServiceRegistrationExtensions
         services.AddRegistryRateLimiting(configuration);
         services.Configure<DatabaseRetryOptions>(configuration.GetSection("DatabaseRetry"));
         services.Configure<WebhookSecurityOptions>(configuration.GetSection("WebhookSecurity"));
-        services.Configure<ModuleExtractionOptions>(configuration.GetSection("ModuleExtraction"));
+        services.AddOptions<ModuleExtractionOptions>()
+            .Bind(configuration.GetSection("ModuleExtraction"))
+            .Validate(options =>
+            {
+                try
+                {
+                    options.Validate();
+                    return true;
+                }
+                catch (InvalidOperationException)
+                {
+                    return false;
+                }
+            }, "Module extraction limits must all be greater than zero.")
+            .ValidateOnStart();
         services.Configure<MirrorOptions>(configuration.GetSection("Mirror"));
         services.AddSingleton<IWebhookHostResolver, DnsWebhookHostResolver>();
         services.AddSingleton<IWebhookStreamConnector, SocketWebhookStreamConnector>();
@@ -338,6 +353,9 @@ internal static class ServiceRegistrationExtensions
     private static IServiceCollection AddModuleExtractionServices(this IServiceCollection services)
     {
         services.AddSingleton<IArchiveWorkspaceFactory, ArchiveWorkspaceFactory>();
+        services.AddSingleton<IArchiveIngestionValidator>(provider => new ArchiveIngestionValidator(
+            provider.GetRequiredService<IArchiveWorkspaceFactory>(),
+            provider.GetRequiredService<IOptions<ModuleExtractionOptions>>().Value));
         services.AddSingleton<IProcessRunner, ProcessRunner>();
         services.AddSingleton<ReadmeDiscoveryService>();
         services.AddSingleton<ExampleDiscoveryService>();

--- a/TerraformRegistry/appsettings.json
+++ b/TerraformRegistry/appsettings.json
@@ -52,6 +52,10 @@
     "ToolPath": "terraform-config-inspect",
     "TimeoutSeconds": 15,
     "MaxArchiveBytes": 104857600,
+    "MaxExpandedArchiveBytes": 1073741824,
+    "MaxArchiveEntries": 10000,
+    "MaxExpandedEntryBytes": 268435456,
+    "MaxCompressionRatio": 100,
     "StartupBackfillBatchSize": 25
   },
   "WebhookSecurity": {


### PR DESCRIPTION
## P2-ARCHIVE — MOD-005, ING-001

Base: `remediation/phase/2-bounded-ingestion-identity` at `fdfd53931f6bbc2240d3a1c3883047384669aac3`. Independent Phase 2 leaf; no schema dependency.

Adds a validated replayable spool for module publication (API and VCS coordinator calls), with bounded streaming to temporary storage and validation before storage/catalog/webhook/audit side effects. ZIP and tar.gz extraction enforce compressed/expanded/archive-entry/per-entry/compression-ratio/path traversal limits.

Configuration defaults: 100 MiB compressed, 1 GiB expanded, 10,000 entries, 256 MiB entry, 100:1 ratio. Values validate at startup.

Verification:
- `dotnet test ... --filter FullyQualifiedName~ArchiveWorkspaceFactoryTests|FullyQualifiedName~ModulePublishCoordinatorTests` — 8 passed
- `dotnet build terraform-registry.sln --no-restore --configuration Release`
- `git diff --check`

Non-goals: durable extraction queues/workers are Phase 3; atomic storage publication is Phase 3.