### PR TITLE
P2-APIKEY: versioned API-key digests and bounded verification

### DIFF
--- a/TerraformRegistry.Tests/IntegrationTests/IntegrationTestBase.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/IntegrationTestBase.cs
@@ -69,6 +69,7 @@ public abstract class IntegrationTestBase : IAsyncLifetime
                         ["ProviderStoragePath"] = providerStoragePath,
                         ["PORT"] = "0",
                         ["AuthorizationToken"] = _authToken,
+                        ["ApiKeySecurity:DigestKey"] = "integration-test-api-key-digest-key-32-chars-minimum",
                         ["UserAdmission:Mode"] = "ConstrainedAutoProvision",
                         ["UserAdmission:AllowedDomains:0"] = "example.com",
                         ["Oidc:JwtSecretKey"] = "integration-test-jwt-secret-key-32-chars-minimum"

--- a/TerraformRegistry.Tests/IntegrationTests/S3StartupTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/S3StartupTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Models;
 using TerraformRegistry.S3;
+using TerraformRegistry.Startup;
 
 namespace TerraformRegistry.Tests.IntegrationTests;
 
@@ -44,6 +45,7 @@ public class S3StartupTests
                         config.AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
                         {
                             ["AuthorizationToken"] = "startup-test-auth-token",
+                            ["ApiKeySecurity:DigestKey"] = "startup-test-api-key-digest-key-32-chars-minimum",
                             ["DatabaseProvider"] = "sqlite",
                             ["Sqlite:ConnectionString"] = $"Data Source={Path.Join(tempDir, "startup-test.db")}",
                             ["StorageProvider"] = "s3",
@@ -55,6 +57,11 @@ public class S3StartupTests
                     builder.ConfigureServices(services =>
                     {
                         services.RemoveAll<OidcOptions>();
+                        services.RemoveAll<ApiKeySecurityOptions>();
+                        services.AddSingleton(new ApiKeySecurityOptions
+                        {
+                            DigestKey = "startup-test-api-key-digest-key-32-chars-minimum"
+                        });
                         services.AddSingleton(new OidcOptions
                         {
                             JwtSecretKey = "startup-test-jwt-secret-key-32-chars-minimum",
@@ -95,6 +102,7 @@ public class S3StartupTests
                         config.AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
                         {
                             ["AuthorizationToken"] = "startup-test-auth-token",
+                            ["ApiKeySecurity:DigestKey"] = "startup-test-api-key-digest-key-32-chars-minimum",
                             ["DatabaseProvider"] = "sqlite",
                             ["Sqlite:ConnectionString"] = $"Data Source={Path.Join(tempDir, "startup-test.db")}",
                             ["StorageProvider"] = "s3",
@@ -105,6 +113,11 @@ public class S3StartupTests
                     builder.ConfigureServices(services =>
                     {
                         services.RemoveAll<OidcOptions>();
+                        services.RemoveAll<ApiKeySecurityOptions>();
+                        services.AddSingleton(new ApiKeySecurityOptions
+                        {
+                            DigestKey = "startup-test-api-key-digest-key-32-chars-minimum"
+                        });
                         services.AddSingleton(new OidcOptions
                         {
                             JwtSecretKey = "startup-test-jwt-secret-key-32-chars-minimum",

--- a/TerraformRegistry.Tests/UnitTests/ApiKeyServiceSecurityTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ApiKeyServiceSecurityTests.cs
@@ -1,0 +1,106 @@
+using System.Security.Cryptography;
+using System.Text;
+using Konscious.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+using TerraformRegistry.Services;
+using TerraformRegistry.Startup;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class ApiKeyServiceSecurityTests
+{
+    [Fact]
+    public async Task CreateApiKeyAsyncStoresVersionedDigestInsteadOfArgon2Hash()
+    {
+        var database = new Mock<IDatabaseService>();
+        database.Setup(x => x.AddApiKeyAsync(It.IsAny<ApiKey>())).Returns(Task.CompletedTask);
+        var service = CreateService(database);
+
+        var (_, key) = await service.CreateApiKeyAsync("user-1", "test");
+
+        Assert.StartsWith("v1:", key.TokenHash, StringComparison.Ordinal);
+        database.Verify(x => x.AddApiKeyAsync(key), Times.Once);
+    }
+
+    [Fact]
+    public async Task ValidateApiKeyAsyncUpgradesLegacyArgon2HashAfterSuccessfulVerification()
+    {
+        const string token = "12345678legacy-api-key-token";
+        var key = new ApiKey
+        {
+            Id = Guid.NewGuid(),
+            UserId = "user-1",
+            Prefix = token[..8],
+            TokenHash = CreateLegacyHash(token)
+        };
+        var database = new Mock<IDatabaseService>();
+        database.Setup(x => x.GetApiKeysByPrefixAsync(key.Prefix)).ReturnsAsync([key]);
+        database.Setup(x => x.GetUserByIdAsync(key.UserId)).ReturnsAsync(new User { Id = key.UserId, IsActive = true });
+        database.Setup(x => x.UpdateApiKeyAsync(key)).Returns(Task.CompletedTask);
+        var service = CreateService(database);
+
+        var result = await service.ValidateApiKeyAsync(token);
+
+        Assert.Same(key, result.Key);
+        Assert.StartsWith("v1:", key.TokenHash, StringComparison.Ordinal);
+        database.Verify(x => x.UpdateApiKeyAsync(key), Times.Once);
+    }
+
+    [Fact]
+    public async Task ValidateApiKeyAsyncCoalescesLastUsedWritesWithinConfiguredInterval()
+    {
+        var database = new Mock<IDatabaseService>();
+        database.Setup(x => x.AddApiKeyAsync(It.IsAny<ApiKey>())).Returns(Task.CompletedTask);
+        var service = CreateService(database);
+        var (token, key) = await service.CreateApiKeyAsync("user-1", "test");
+        database.Setup(x => x.GetApiKeysByPrefixAsync(key.Prefix)).ReturnsAsync([key]);
+        database.Setup(x => x.GetUserByIdAsync(key.UserId)).ReturnsAsync(new User { Id = key.UserId, IsActive = true });
+        database.Setup(x => x.UpdateApiKeyAsync(key)).Returns(Task.CompletedTask);
+
+        await service.ValidateApiKeyAsync(token);
+        await service.ValidateApiKeyAsync(token);
+
+        database.Verify(x => x.UpdateApiKeyAsync(key), Times.Once);
+    }
+
+    [Fact]
+    public void VerificationGateRejectsRequestsBeyondPerPrefixRateLimit()
+    {
+        var options = new ApiKeySecurityOptions
+        {
+            DigestKey = "test-api-key-digest-key-at-least-thirty-two-characters",
+            VerificationPermitLimit = 1,
+            MaxConcurrentVerificationsPerPartition = 1
+        };
+        using var gate = new ApiKeyVerificationGate(options);
+
+        using var first = gate.TryEnterPrefix("prefix-1");
+        var second = gate.TryEnterPrefix("prefix-1");
+
+        Assert.NotNull(first);
+        Assert.Null(second);
+    }
+
+    private static ApiKeyService CreateService(Mock<IDatabaseService> database)
+    {
+        var security = new ApiKeySecurityOptions { DigestKey = "test-api-key-digest-key-at-least-thirty-two-characters" };
+        return new ApiKeyService(database.Object, Mock.Of<ILogger<ApiKeyService>>(), new UserAdmissionOptions(), security,
+            new ApiKeyVerificationGate(security));
+    }
+
+    private static string CreateLegacyHash(string token)
+    {
+        var salt = RandomNumberGenerator.GetBytes(16);
+        using var argon2 = new Argon2id(Encoding.UTF8.GetBytes(token))
+        {
+            Salt = salt,
+            DegreeOfParallelism = 2,
+            MemorySize = 65536,
+            Iterations = 4
+        };
+        return $"{Convert.ToBase64String(salt)}${Convert.ToBase64String(argon2.GetBytes(32))}";
+    }
+}

--- a/TerraformRegistry/Program.cs
+++ b/TerraformRegistry/Program.cs
@@ -117,6 +117,14 @@ if (Directory.Exists(webFolderPath))
 
 // Portal authentication middleware (validates JWT sessions for portal routes)
 var jwtService = app.Services.GetRequiredService<JwtService>();
+var apiKeySecurityOptions = app.Services.GetRequiredService<ApiKeySecurityOptions>();
+if (!app.Environment.IsDevelopment() && !app.Environment.IsEnvironment("Test") &&
+    apiKeySecurityOptions.DigestKey == "configure-a-unique-api-key-digest-key-before-production")
+{
+    throw new InvalidOperationException(
+        "ApiKeySecurity:DigestKey is set to the default placeholder. Configure a unique secret before running outside Development/Test.");
+}
+apiKeySecurityOptions.ValidateDigestKey();
 app.UseMiddleware<PortalAuthenticationMiddleware>(jwtService);
 
 // API key authentication middleware (for /v1/* routes used by Terraform CLI)

--- a/TerraformRegistry/Services/ApiKeyService.cs
+++ b/TerraformRegistry/Services/ApiKeyService.cs
@@ -11,7 +11,9 @@ namespace TerraformRegistry.Services;
 public class ApiKeyService(
     IDatabaseService dbService,
     ILogger<ApiKeyService> logger,
-    UserAdmissionOptions userAdmissionOptions) : IApiKeyService
+    UserAdmissionOptions userAdmissionOptions,
+    ApiKeySecurityOptions securityOptions,
+    ApiKeyVerificationGate verificationGate) : IApiKeyService
 {
     private const int TokenLength = 32;
     // private const string TokenPrefix = "tf-"; // Removed prefix requirement
@@ -36,8 +38,7 @@ public class ApiKeyService(
             .Replace("+", "-", StringComparison.Ordinal).Replace("/", "_", StringComparison.Ordinal).Replace("=", "", StringComparison.Ordinal); // URL-safe base64
         var rawToken = tokenCore; // No prefix
 
-        // Hash token using Argon2id
-        var tokenHash = HashToken(rawToken);
+        var tokenHash = CreateDigest(rawToken);
 
         var apiKey = new ApiKey
         {
@@ -72,8 +73,23 @@ public class ApiKeyService(
 
         foreach (var key in candidates)
         {
-            if (VerifyHash(rawToken, key.TokenHash))
+            using var prefixLease = verificationGate.TryEnterPrefix(key.Prefix);
+            if (prefixLease is null)
             {
+                RegistryLog.Warning(logger, "Rejected API key verification because the prefix limit was reached.");
+                return new ApiKeyValidationResult(null, false);
+            }
+
+            var isLegacy = !key.TokenHash.StartsWith("v1:", StringComparison.Ordinal);
+            if (VerifyToken(rawToken, key.TokenHash))
+            {
+                using var principalLease = verificationGate.TryEnterPrincipal(key.UserId);
+                if (principalLease is null)
+                {
+                    RegistryLog.Warning(logger, "Rejected API key verification because the principal limit was reached.");
+                    return new ApiKeyValidationResult(null, false);
+                }
+
                 if (key.ExpiresAt.HasValue && key.ExpiresAt.Value < DateTime.UtcNow)
                 {
                     return new ApiKeyValidationResult(null, true);
@@ -86,8 +102,19 @@ public class ApiKeyService(
                     return new ApiKeyValidationResult(null, false);
                 }
 
-                key.LastUsedAt = DateTime.UtcNow;
-                await dbService.UpdateApiKeyAsync(key);
+                var now = DateTime.UtcNow;
+                var upgradeNeeded = isLegacy;
+                if (upgradeNeeded)
+                {
+                    key.TokenHash = CreateDigest(rawToken);
+                }
+
+                if (upgradeNeeded || !key.LastUsedAt.HasValue ||
+                    now - key.LastUsedAt.Value >= TimeSpan.FromSeconds(securityOptions.LastUsedUpdateIntervalSeconds))
+                {
+                    key.LastUsedAt = now;
+                    await dbService.UpdateApiKeyAsync(key);
+                }
                 return new ApiKeyValidationResult(key, false);
             }
         }
@@ -234,27 +261,25 @@ public class ApiKeyService(
         return email.Trim().ToLowerInvariant();
     }
 
-    private static string HashToken(string password)
+    private string CreateDigest(string token)
     {
-        // Salt is randomly generated, but for stateless verification we usually store salt with hash.
-        // Simpler Argon2 wrappers often handle "$argon2id$..." format strings containing params, salt, and hash.
-        // Konscious.Security.Cryptography is low level.
-        // Let's use a standard format: SALT(16b) + HASH(32b) -> Base64
-
-        var salt = RandomNumberGenerator.GetBytes(16);
-        using var argon2 = new Argon2id(Encoding.UTF8.GetBytes(password));
-        argon2.Salt = salt;
-        argon2.DegreeOfParallelism = 2; // Core count
-        argon2.MemorySize = 65536; // 64 MB
-        argon2.Iterations = 4;
-
-        var hash = argon2.GetBytes(32);
-
-        // Return format: {salt_base64}${hash_base64}
-        return $"{Convert.ToBase64String(salt)}${Convert.ToBase64String(hash)}";
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(securityOptions.DigestKey));
+        return $"v1:{Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(token)))}";
     }
 
-    private static bool VerifyHash(string password, string storedHash)
+    private bool VerifyToken(string token, string storedHash)
+    {
+        if (storedHash.StartsWith("v1:", StringComparison.Ordinal))
+        {
+            var expected = Encoding.UTF8.GetBytes(CreateDigest(token));
+            var actual = Encoding.UTF8.GetBytes(storedHash);
+            return CryptographicOperations.FixedTimeEquals(expected, actual);
+        }
+
+        return VerifyLegacyHash(token, storedHash);
+    }
+
+    private static bool VerifyLegacyHash(string password, string storedHash)
     {
         try
         {

--- a/TerraformRegistry/Services/ApiKeyVerificationGate.cs
+++ b/TerraformRegistry/Services/ApiKeyVerificationGate.cs
@@ -1,0 +1,76 @@
+using System.Collections.Concurrent;
+using TerraformRegistry.Startup;
+
+namespace TerraformRegistry.Services;
+
+public sealed class ApiKeyVerificationGate(ApiKeySecurityOptions options) : IDisposable
+{
+    private readonly ConcurrentDictionary<string, PartitionGate> _prefixes = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, PartitionGate> _principals = new(StringComparer.Ordinal);
+
+    public IDisposable? TryEnterPrefix(string prefix) => TryEnter(_prefixes, prefix);
+
+    public IDisposable? TryEnterPrincipal(string userId) => TryEnter(_principals, userId);
+
+    private Releaser? TryEnter(ConcurrentDictionary<string, PartitionGate> partitions, string key)
+    {
+        return partitions.GetOrAdd(key, _ => new PartitionGate(options)).TryEnter();
+    }
+
+    private sealed class PartitionGate(ApiKeySecurityOptions options) : IDisposable
+    {
+        private readonly object _sync = new();
+        private readonly SemaphoreSlim _concurrency = new(options.MaxConcurrentVerificationsPerPartition);
+        private DateTime _windowStartedUtc = DateTime.UtcNow;
+        private int _remaining = options.VerificationPermitLimit;
+
+        public Releaser? TryEnter()
+        {
+            if (!_concurrency.Wait(0))
+            {
+                return null;
+            }
+
+            lock (_sync)
+            {
+                var now = DateTime.UtcNow;
+                if (now - _windowStartedUtc >= TimeSpan.FromSeconds(options.VerificationWindowSeconds))
+                {
+                    _windowStartedUtc = now;
+                    _remaining = options.VerificationPermitLimit;
+                }
+
+                if (_remaining > 0)
+                {
+                    _remaining--;
+                    return new Releaser(_concurrency);
+                }
+            }
+
+            _concurrency.Release();
+            return null;
+        }
+
+        public void Dispose() => _concurrency.Dispose();
+    }
+
+    private sealed class Releaser(SemaphoreSlim semaphore) : IDisposable
+    {
+        private SemaphoreSlim? _semaphore = semaphore;
+
+        public void Dispose() => Interlocked.Exchange(ref _semaphore, null)?.Release();
+    }
+
+    public void Dispose()
+    {
+        foreach (var gate in _prefixes.Values)
+        {
+            gate.Dispose();
+        }
+
+        foreach (var gate in _principals.Values)
+        {
+            gate.Dispose();
+        }
+    }
+}

--- a/TerraformRegistry/Startup/ApiKeySecurityOptions.cs
+++ b/TerraformRegistry/Startup/ApiKeySecurityOptions.cs
@@ -1,0 +1,29 @@
+namespace TerraformRegistry.Startup;
+
+public sealed class ApiKeySecurityOptions
+{
+    public const string SectionName = "ApiKeySecurity";
+
+    public string DigestKey { get; set; } = string.Empty;
+    public int VerificationPermitLimit { get; set; } = 60;
+    public int VerificationWindowSeconds { get; set; } = 60;
+    public int MaxConcurrentVerificationsPerPartition { get; set; } = 2;
+    public int LastUsedUpdateIntervalSeconds { get; set; } = 300;
+
+    public void Validate()
+    {
+        if (VerificationPermitLimit <= 0 || VerificationWindowSeconds <= 0 ||
+            MaxConcurrentVerificationsPerPartition <= 0 || LastUsedUpdateIntervalSeconds <= 0)
+        {
+            throw new InvalidOperationException("ApiKeySecurity limits must be greater than zero.");
+        }
+    }
+
+    public void ValidateDigestKey()
+    {
+        if (DigestKey.Length < 32)
+        {
+            throw new InvalidOperationException("ApiKeySecurity:DigestKey must be at least 32 characters.");
+        }
+    }
+}

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -107,6 +107,11 @@ internal static class ServiceRegistrationExtensions
         configuration.GetSection(UserAdmissionOptions.SectionName).Bind(userAdmissionOptions);
         userAdmissionOptions.Validate();
         services.AddSingleton(userAdmissionOptions);
+        var apiKeySecurityOptions = new ApiKeySecurityOptions();
+        configuration.GetSection(ApiKeySecurityOptions.SectionName).Bind(apiKeySecurityOptions);
+        apiKeySecurityOptions.Validate();
+        services.AddSingleton(apiKeySecurityOptions);
+        services.AddSingleton<ApiKeyVerificationGate>();
         services.AddSingleton<JwtService>();
         services.AddSingleton<OAuthService>();
         services.AddSingleton(new TerraformLoginOptions());

--- a/TerraformRegistry/appsettings.Development.json
+++ b/TerraformRegistry/appsettings.Development.json
@@ -43,6 +43,9 @@
     "JwtSecretKey": "development-only-jwt-secret-key-32-chars-minimum",
     "JwtExpiryHours": 24
   },
+  "ApiKeySecurity": {
+    "DigestKey": "development-only-api-key-digest-key-32-chars-minimum"
+  },
   "EnvironmentVariables": {
     "Comment": "The following environment variables can be used for configuration:",
     "TF_REG_BaseUrl": "Base URL for the Terraform Registry",

--- a/TerraformRegistry/appsettings.json
+++ b/TerraformRegistry/appsettings.json
@@ -93,6 +93,9 @@
     "AllowedEmails": [],
     "RequireVerifiedEmail": true
   },
+  "ApiKeySecurity": {
+    "DigestKey": "configure-a-unique-api-key-digest-key-before-production"
+  },
   "EnvironmentVariables": {
     "Comment": "The following environment variables can be used for configuration:",
     "TF_REG_BaseUrl": "Base URL for the Terraform Registry",
@@ -123,6 +126,7 @@
     "TF_REG_ModuleExtraction__TempRoot": "Temporary extraction root (default: OS temp directory)",
     "TF_REG_ModuleExtraction__MaxArchiveBytes": "Maximum accepted module archive size in bytes (default: 104857600)",
     "TF_REG_ModuleExtraction__StartupBackfillBatchSize": "Number of existing modules to queue for extraction at startup (default: 25)",
+    "TF_REG_ApiKeySecurity__DigestKey": "API-key HMAC digest key (minimum 32 characters; required outside Development)",
     "TF_REG_Oidc__JwtSecretKey": "Secret key for signing JWT tokens (minimum 32 characters)",
     "TF_REG_Oidc__Providers__GitHub__ClientId": "GitHub OAuth App Client ID",
     "TF_REG_Oidc__Providers__GitHub__ClientSecret": "GitHub OAuth App Client Secret",


### PR DESCRIPTION
## Requirements
- IAM-006: versioned keyed digests for new API keys; dual verification and upgrade-on-use for legacy Argon2 hashes.
- IAM-007: per-prefix and per-principal concurrency/rate gates; coalesced `last_used_at` writes.

## Scope
- API-key issuance, verification, configuration, and focused tests.

## Non-goals
- Endpoint rate-limit attachment (P2-RATE-ATTACH).
- Database migration; the version is encoded in the existing `token_hash` value.

## Verification
- Focused API-key security tests: 4 passing.
- S3 startup tests: 2 passing.
- Release build passes.
- Full CI pending.