### PR TITLE
P2-PROVIDER: bound provider package upload buffering

### DIFF
--- a/TerraformRegistry/Services/ProviderRegistryService.cs
+++ b/TerraformRegistry/Services/ProviderRegistryService.cs
@@ -2,6 +2,7 @@ using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.API.Logging;
 using TerraformRegistry.API.Utilities;
 using TerraformRegistry.Models;
+using TerraformRegistry.Startup;
 
 namespace TerraformRegistry.Services;
 
@@ -12,17 +13,21 @@ public sealed class ProviderRegistryService : IProviderRegistryService
     private readonly IProviderRepository _repository;
     private readonly IProviderArtifactStorage _storage;
     private readonly IProviderPackageValidator _validator;
+    private readonly ProviderUploadOptions _uploadOptions;
 
     public ProviderRegistryService(
         IProviderRepository repository,
         IProviderArtifactStorage storage,
         IProviderPackageValidator validator,
-        ILogger<ProviderRegistryService> logger)
+        ILogger<ProviderRegistryService> logger,
+        ProviderUploadOptions? uploadOptions = null)
     {
         _repository = repository;
         _storage = storage;
         _validator = validator;
         _logger = logger;
+        _uploadOptions = uploadOptions ?? new ProviderUploadOptions();
+        _uploadOptions.Validate();
     }
 
     public async Task<ProviderVersionsResponse?> GetVersionsAsync(string providerNamespace, string type)
@@ -311,7 +316,7 @@ public sealed class ProviderRegistryService : IProviderRegistryService
             return false;
         }
 
-        await using var packageBuffer = await CopyToReplayableStreamAsync(package, cancellationToken);
+        await using var packageBuffer = await CopyToReplayableFileAsync(package, cancellationToken);
         await using var shasums = await _storage.OpenReadAsync(providerVersion.ShasumsStoragePath, cancellationToken);
         if (shasums == null)
         {
@@ -347,17 +352,36 @@ public sealed class ProviderRegistryService : IProviderRegistryService
         return DeletePlatformAndArtifactsAsync(providerNamespace, type, version, os, arch);
     }
 
-    private static async Task<MemoryStream> CopyToReplayableStreamAsync(Stream source, CancellationToken cancellationToken)
+    private async Task<FileStream> CopyToReplayableFileAsync(Stream source, CancellationToken cancellationToken)
     {
-        if (source.CanSeek)
+        Directory.CreateDirectory(_uploadOptions.TempRoot);
+        var path = Path.Combine(_uploadOptions.TempRoot, $".{Guid.NewGuid():N}.provider-upload");
+        try
         {
-            source.Position = 0;
+            var output = new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 1024 * 1024,
+                FileOptions.Asynchronous | FileOptions.SequentialScan | FileOptions.DeleteOnClose);
+            var buffer = new byte[1024 * 1024];
+            long copied = 0;
+            while (true)
+            {
+                var read = await source.ReadAsync(buffer, cancellationToken);
+                if (read == 0) break;
+                copied = checked(copied + read);
+                if (copied > _uploadOptions.MaxPackageBytes)
+                {
+                    await output.DisposeAsync();
+                    throw new InvalidOperationException($"Provider package exceeds the configured limit of {_uploadOptions.MaxPackageBytes} bytes.");
+                }
+                await output.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+            }
+            output.Position = 0;
+            return output;
         }
-
-        var buffer = new MemoryStream();
-        await source.CopyToAsync(buffer, cancellationToken);
-        buffer.Position = 0;
-        return buffer;
+        catch
+        {
+            if (File.Exists(path)) File.Delete(path);
+            throw;
+        }
     }
 
     private async Task<bool> DeleteProviderAndArtifactsAsync(string providerNamespace, string type)

--- a/TerraformRegistry/Startup/ProviderUploadOptions.cs
+++ b/TerraformRegistry/Startup/ProviderUploadOptions.cs
@@ -1,0 +1,16 @@
+namespace TerraformRegistry.Startup;
+
+public sealed class ProviderUploadOptions
+{
+    public const string SectionName = "ProviderUpload";
+    public long MaxPackageBytes { get; set; } = 536_870_912;
+    public string TempRoot { get; set; } = Path.GetTempPath();
+
+    public void Validate()
+    {
+        if (MaxPackageBytes <= 0)
+        {
+            throw new InvalidOperationException("ProviderUpload:MaxPackageBytes must be greater than zero.");
+        }
+    }
+}

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -43,6 +43,10 @@ internal static class ServiceRegistrationExtensions
                 }
             }, "Module extraction limits must all be greater than zero.")
             .ValidateOnStart();
+        var providerUploadOptions = new ProviderUploadOptions();
+        configuration.GetSection(ProviderUploadOptions.SectionName).Bind(providerUploadOptions);
+        providerUploadOptions.Validate();
+        services.AddSingleton(providerUploadOptions);
         services.Configure<MirrorOptions>(configuration.GetSection("Mirror"));
         services.AddSingleton<IWebhookHostResolver, DnsWebhookHostResolver>();
         services.AddSingleton<IWebhookStreamConnector, SocketWebhookStreamConnector>();

--- a/TerraformRegistry/appsettings.Development.json
+++ b/TerraformRegistry/appsettings.Development.json
@@ -39,6 +39,9 @@
     "MaxArchiveBytes": 104857600,
     "StartupBackfillBatchSize": 25
   },
+  "ProviderUpload": {
+    "MaxPackageBytes": 536870912
+  },
   "Oidc": {
     "JwtSecretKey": "development-only-jwt-secret-key-32-chars-minimum",
     "JwtExpiryHours": 24

--- a/TerraformRegistry/appsettings.json
+++ b/TerraformRegistry/appsettings.json
@@ -58,6 +58,9 @@
     "MaxCompressionRatio": 100,
     "StartupBackfillBatchSize": 25
   },
+  "ProviderUpload": {
+    "MaxPackageBytes": 536870912
+  },
   "WebhookSecurity": {
     "AllowPrivateNetworks": false
   },


### PR DESCRIPTION
## Requirements
- PERF-002: stream provider package uploads through bounded temporary storage.

## Scope
- Configurable provider package byte limit.
- 1 MiB buffered temporary-file spool used for package validation and storage replay.
- Cleanup on success, failure, and oversized streams.

## Verification
- `ProviderRegistryServiceTests`: 10 passing.
- Release build passes.
- Full CI pending.