### PR TITLE
security: stateless bounded artifact download tokens

### DIFF
--- a/TerraformRegistry.Tests/IntegrationTests/IntegrationTestBase.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/IntegrationTestBase.cs
@@ -70,6 +70,7 @@ public abstract class IntegrationTestBase : IAsyncLifetime
                         ["PORT"] = "0",
                         ["AuthorizationToken"] = _authToken,
                         ["ApiKeySecurity:DigestKey"] = "integration-test-api-key-digest-key-32-chars-minimum",
+                        ["ArtifactDownloadTokens:SigningKey"] = "integration-test-artifact-download-token-signing-key-32-chars-minimum",
                         ["UserAdmission:Mode"] = "ConstrainedAutoProvision",
                         ["UserAdmission:AllowedDomains:0"] = "example.com",
                         ["Oidc:JwtSecretKey"] = "integration-test-jwt-secret-key-32-chars-minimum"

--- a/TerraformRegistry.Tests/IntegrationTests/S3StartupTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/S3StartupTests.cs
@@ -46,6 +46,7 @@ public class S3StartupTests
                         {
                             ["AuthorizationToken"] = "startup-test-auth-token",
                             ["ApiKeySecurity:DigestKey"] = "startup-test-api-key-digest-key-32-chars-minimum",
+                            ["ArtifactDownloadTokens:SigningKey"] = "startup-test-artifact-download-token-signing-key-32-chars-minimum",
                             ["DatabaseProvider"] = "sqlite",
                             ["Sqlite:ConnectionString"] = $"Data Source={Path.Join(tempDir, "startup-test.db")}",
                             ["StorageProvider"] = "s3",
@@ -103,6 +104,7 @@ public class S3StartupTests
                         {
                             ["AuthorizationToken"] = "startup-test-auth-token",
                             ["ApiKeySecurity:DigestKey"] = "startup-test-api-key-digest-key-32-chars-minimum",
+                            ["ArtifactDownloadTokens:SigningKey"] = "startup-test-artifact-download-token-signing-key-32-chars-minimum",
                             ["DatabaseProvider"] = "sqlite",
                             ["Sqlite:ConnectionString"] = $"Data Source={Path.Join(tempDir, "startup-test.db")}",
                             ["StorageProvider"] = "s3",

--- a/TerraformRegistry.Tests/IntegrationTests/UploadModuleTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/UploadModuleTests.cs
@@ -55,6 +55,35 @@ public class UploadModuleTests(ITestOutputHelper output) : IntegrationTestBase(o
     }
 
     [Fact]
+    public async Task DownloadLinkStreamsArtifactAndRejectsTampering()
+    {
+        var authenticatedClient = Factory.CreateClient(new() { AllowAutoRedirect = false });
+        authenticatedClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AuthToken);
+        using var upload = CreateModuleUploadContent();
+        var uploadResponse = await authenticatedClient.PostAsync(
+            "/v1/modules/test-ns/test-name/test-provider/2.0.0", upload);
+        Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
+
+        var protocolResponse = await authenticatedClient.GetAsync(
+            "/v1/modules/test-ns/test-name/test-provider/2.0.0/download");
+        Assert.Equal(HttpStatusCode.NoContent, protocolResponse.StatusCode);
+        var downloadLink = Assert.Single(protocolResponse.Headers.GetValues("X-Terraform-Get"));
+
+        var downloadResponse = await Factory.CreateClient().GetAsync(downloadLink);
+        Assert.Equal(HttpStatusCode.OK, downloadResponse.StatusCode);
+        Assert.NotEmpty(await downloadResponse.Content.ReadAsByteArrayAsync());
+
+        var tokenEnd = downloadLink.LastIndexOf("&archive=", StringComparison.Ordinal);
+        if (tokenEnd < 0) tokenEnd = downloadLink.Length;
+        var tokenLastCharacter = tokenEnd - 1;
+        var tamperedLink = downloadLink[..tokenLastCharacter] +
+                           (downloadLink[tokenLastCharacter] == 'A' ? 'B' : 'A') +
+                           downloadLink[(tokenLastCharacter + 1)..];
+        var tamperedResponse = await Factory.CreateClient().GetAsync(tamperedLink);
+        Assert.Equal(HttpStatusCode.NotFound, tamperedResponse.StatusCode);
+    }
+
+    [Fact]
     public async Task UploadInvalidModuleCoordinateReturnsBadRequest()
     {
         var client = Factory.CreateClient();

--- a/TerraformRegistry.Tests/UnitTests/ArtifactDownloadTokenServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ArtifactDownloadTokenServiceTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Configuration;
+using TerraformRegistry.Services;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class ArtifactDownloadTokenServiceTests
+{
+    [Fact]
+    public void TokenCreatedByOneInstanceIsValidatedByAnotherInstanceForTheSamePurpose()
+    {
+        var issuer = CreateService();
+        var validator = CreateService();
+
+        var token = issuer.Create("module", "acme/example-aws-1.0.0.zip", TimeSpan.FromMinutes(10));
+
+        Assert.True(validator.TryValidate(token, "module", out var path));
+        Assert.Equal("acme/example-aws-1.0.0.zip", path);
+    }
+
+    [Fact]
+    public void TokenIsUrlSafeAndCannotBeValidatedForAnotherPurpose()
+    {
+        var service = CreateService();
+        var token = service.Create("provider", "acme/example/1.0.0/linux_amd64.zip", TimeSpan.FromMinutes(10));
+
+        Assert.DoesNotContain('+', token);
+        Assert.DoesNotContain('/', token);
+        Assert.DoesNotContain('=', token);
+        Assert.False(service.TryValidate(token, "module", out _));
+    }
+
+    [Fact]
+    public void ExpiredOrTamperedTokenIsRejected()
+    {
+        var service = CreateService();
+        var expired = service.Create("module", "module.zip", TimeSpan.FromSeconds(-1));
+        var valid = service.Create("module", "module.zip", TimeSpan.FromMinutes(10));
+        var tampered = valid[..^1] + (valid[^1] == 'A' ? 'B' : 'A');
+
+        Assert.False(service.TryValidate(expired, "module", out _));
+        Assert.False(service.TryValidate(tampered, "module", out _));
+    }
+
+    [Fact]
+    public void ShortSigningKeyIsRejected()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ArtifactDownloadTokens:SigningKey"] = "short"
+            })
+            .Build();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new ArtifactDownloadTokenService(configuration));
+
+        Assert.Contains("at least 32 characters", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static ArtifactDownloadTokenService CreateService()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ArtifactDownloadTokens:SigningKey"] = "test-signing-key-that-is-long-enough-to-be-safe-0123456789"
+            })
+            .Build();
+        return new ArtifactDownloadTokenService(configuration);
+    }
+}

--- a/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
@@ -23,7 +23,8 @@ public class LocalModuleServiceTests
         var inMemorySettings = new Dictionary<string, string?>
 (StringComparer.Ordinal)
         {
-            { "ModuleStoragePath", testModulePath }
+            { "ModuleStoragePath", testModulePath },
+            { "ArtifactDownloadTokens:SigningKey", "test-signing-key-that-is-long-enough-to-be-safe-0123456789" }
         };
         _configuration = new ConfigurationBuilder().AddInMemoryCollection(inMemorySettings).Build();
         _testModulePath = testModulePath;
@@ -221,7 +222,8 @@ public class LocalModuleServiceTests
     public void TryGetFilePathFromTokenReturnsFalseForInvalidToken()
     {
         // Act
-        var found = LocalModuleService.TryGetFilePathFromToken("notatoken", out var filePath);
+        var service = new LocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);
+        var found = service.TryGetFilePathFromToken("notatoken", out var filePath);
         // Assert
         Assert.False(found);
         Assert.Equal(string.Empty, filePath);

--- a/TerraformRegistry.Tests/UnitTests/LocalProviderArtifactStorageTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LocalProviderArtifactStorageTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using TerraformRegistry.Services;
 
@@ -9,10 +10,7 @@ public class LocalProviderArtifactStorageTests
     public async Task SaveAsyncStoresArtifactInsideProviderStorageRoot()
     {
         using var temp = new TempDirectory();
-        var storage = new LocalProviderArtifactStorage(
-            temp.Path,
-            TimeSpan.FromMinutes(10),
-            NullLogger<LocalProviderArtifactStorage>.Instance);
+        var storage = CreateStorage(temp.Path, TimeSpan.FromMinutes(10));
 
         await using var content = new MemoryStream([1, 2, 3]);
 
@@ -27,10 +25,7 @@ public class LocalProviderArtifactStorageTests
     public async Task OpenReadAsyncReturnsStoredArtifactContent()
     {
         using var temp = new TempDirectory();
-        var storage = new LocalProviderArtifactStorage(
-            temp.Path,
-            TimeSpan.FromMinutes(10),
-            NullLogger<LocalProviderArtifactStorage>.Instance);
+        var storage = CreateStorage(temp.Path, TimeSpan.FromMinutes(10));
         await using var content = new MemoryStream([4, 5, 6]);
         var result = await storage.SaveAsync("acme/example/1.0.0/file.zip", content, CancellationToken.None);
 
@@ -46,10 +41,7 @@ public class LocalProviderArtifactStorageTests
     public async Task CreateDownloadUrlAsyncReturnsTokenForStoredArtifact()
     {
         using var temp = new TempDirectory();
-        var storage = new LocalProviderArtifactStorage(
-            temp.Path,
-            TimeSpan.FromMinutes(10),
-            NullLogger<LocalProviderArtifactStorage>.Instance);
+        var storage = CreateStorage(temp.Path, TimeSpan.FromMinutes(10));
         await using var content = new MemoryStream([1]);
         var result = await storage.SaveAsync("acme/example/1.0.0/file.zip", content, CancellationToken.None);
 
@@ -57,7 +49,7 @@ public class LocalProviderArtifactStorageTests
         var token = tokenUrl.Split("token=", StringSplitOptions.None)[1];
 
         Assert.StartsWith("/provider/download?token=", tokenUrl, StringComparison.Ordinal);
-        Assert.True(LocalProviderArtifactStorage.TryGetFilePathFromToken(token, out var filePath));
+        Assert.True(storage.TryGetFilePathFromToken(token, out var filePath));
         Assert.Equal(Path.GetFullPath(Path.Combine(temp.Path, result.StoragePath)), filePath);
     }
 
@@ -65,26 +57,20 @@ public class LocalProviderArtifactStorageTests
     public async Task OpenTokenAsyncReturnsNullAfterTokenExpires()
     {
         using var temp = new TempDirectory();
-        var storage = new LocalProviderArtifactStorage(
-            temp.Path,
-            TimeSpan.Zero,
-            NullLogger<LocalProviderArtifactStorage>.Instance);
+        var storage = CreateStorage(temp.Path, TimeSpan.Zero);
         await using var content = new MemoryStream([1]);
         var result = await storage.SaveAsync("acme/example/1.0.0/file.zip", content, CancellationToken.None);
 
         var tokenUrl = await storage.CreateDownloadUrlAsync(result.StoragePath, CancellationToken.None);
         var token = tokenUrl.Split("token=", StringSplitOptions.None)[1];
-        Assert.False(LocalProviderArtifactStorage.TryGetFilePathFromToken(token, out _));
+        Assert.False(storage.TryGetFilePathFromToken(token, out _));
     }
 
     [Fact]
     public async Task SaveAsyncRejectsPathsOutsideStorageRoot()
     {
         using var temp = new TempDirectory();
-        var storage = new LocalProviderArtifactStorage(
-            temp.Path,
-            TimeSpan.FromMinutes(10),
-            NullLogger<LocalProviderArtifactStorage>.Instance);
+        var storage = CreateStorage(temp.Path, TimeSpan.FromMinutes(10));
         await using var content = new MemoryStream([1]);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -95,10 +81,7 @@ public class LocalProviderArtifactStorageTests
     public async Task DeleteAsyncRemovesStoredArtifact()
     {
         using var temp = new TempDirectory();
-        var storage = new LocalProviderArtifactStorage(
-            temp.Path,
-            TimeSpan.FromMinutes(10),
-            NullLogger<LocalProviderArtifactStorage>.Instance);
+        var storage = CreateStorage(temp.Path, TimeSpan.FromMinutes(10));
         await using var content = new MemoryStream([1]);
         var result = await storage.SaveAsync("acme/example/1.0.0/file.zip", content, CancellationToken.None);
 
@@ -123,5 +106,20 @@ public class LocalProviderArtifactStorageTests
                 Directory.Delete(Path, true);
             }
         }
+    }
+
+    private static LocalProviderArtifactStorage CreateStorage(string path, TimeSpan lifetime)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ArtifactDownloadTokens:SigningKey"] = "test-signing-key-that-is-long-enough-to-be-safe-0123456789"
+            })
+            .Build();
+        return new LocalProviderArtifactStorage(
+            path,
+            lifetime,
+            NullLogger<LocalProviderArtifactStorage>.Instance,
+            new ArtifactDownloadTokenService(configuration));
     }
 }

--- a/TerraformRegistry/Program.cs
+++ b/TerraformRegistry/Program.cs
@@ -125,6 +125,14 @@ if (!app.Environment.IsDevelopment() && !app.Environment.IsEnvironment("Test") &
         "ApiKeySecurity:DigestKey is set to the default placeholder. Configure a unique secret before running outside Development/Test.");
 }
 apiKeySecurityOptions.ValidateDigestKey();
+var artifactDownloadSigningKey = app.Configuration["ArtifactDownloadTokens:SigningKey"];
+if (!app.Environment.IsDevelopment() && !app.Environment.IsEnvironment("Test") &&
+    artifactDownloadSigningKey == ArtifactDownloadTokenService.ProductionPlaceholder)
+{
+    throw new InvalidOperationException(
+        "ArtifactDownloadTokens:SigningKey is set to the default placeholder. Configure a unique secret before running outside Development/Test.");
+}
+_ = app.Services.GetRequiredService<ArtifactDownloadTokenService>();
 app.UseMiddleware<PortalAuthenticationMiddleware>(jwtService);
 
 // API key authentication middleware (for /v1/* routes used by Terraform CLI)

--- a/TerraformRegistry/Services/ArtifactDownloadTokenService.cs
+++ b/TerraformRegistry/Services/ArtifactDownloadTokenService.cs
@@ -38,6 +38,11 @@ public sealed class ArtifactDownloadTokenService
         {
             var bytes = Decode(parts[0]);
             var signature = Decode(parts[1]);
+            if (!string.Equals(parts[0], Encode(bytes), StringComparison.Ordinal) ||
+                !string.Equals(parts[1], Encode(signature), StringComparison.Ordinal))
+            {
+                return false;
+            }
             using var hmac = new HMACSHA256(_key);
             if (!CryptographicOperations.FixedTimeEquals(signature, hmac.ComputeHash(bytes))) return false;
             var values = Encoding.UTF8.GetString(bytes).Split('\n', 3);

--- a/TerraformRegistry/Services/ArtifactDownloadTokenService.cs
+++ b/TerraformRegistry/Services/ArtifactDownloadTokenService.cs
@@ -1,0 +1,68 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace TerraformRegistry.Services;
+
+public sealed class ArtifactDownloadTokenService
+{
+    public const string ProductionPlaceholder = "configure-a-unique-artifact-download-token-key-before-production";
+
+    private readonly byte[] _key;
+
+    public ArtifactDownloadTokenService(IConfiguration configuration)
+    {
+        var signingKey = configuration["ArtifactDownloadTokens:SigningKey"]
+                         ?? throw new InvalidOperationException("ArtifactDownloadTokens:SigningKey is required.");
+        if (signingKey.Length < 32)
+        {
+            throw new InvalidOperationException("ArtifactDownloadTokens:SigningKey must be at least 32 characters.");
+        }
+
+        _key = Encoding.UTF8.GetBytes(signingKey);
+    }
+
+    public string Create(string purpose, string path, TimeSpan lifetime)
+    {
+        var payload = $"{purpose}\n{DateTimeOffset.UtcNow.Add(lifetime).ToUnixTimeSeconds()}\n{path}";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        using var hmac = new HMACSHA256(_key);
+        return $"{Encode(bytes)}.{Encode(hmac.ComputeHash(bytes))}";
+    }
+
+    public bool TryValidate(string token, string purpose, out string path)
+    {
+        path = string.Empty;
+        var parts = token.Split('.', 2);
+        if (parts.Length != 2) return false;
+        try
+        {
+            var bytes = Decode(parts[0]);
+            var signature = Decode(parts[1]);
+            using var hmac = new HMACSHA256(_key);
+            if (!CryptographicOperations.FixedTimeEquals(signature, hmac.ComputeHash(bytes))) return false;
+            var values = Encoding.UTF8.GetString(bytes).Split('\n', 3);
+            if (values.Length != 3 || values[0] != purpose || !long.TryParse(values[1], out var expiry) ||
+                DateTimeOffset.UtcNow.ToUnixTimeSeconds() >= expiry)
+            {
+                return false;
+            }
+            path = values[2];
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static string Encode(byte[] value) => Convert.ToBase64String(value)
+        .TrimEnd('=')
+        .Replace('+', '-')
+        .Replace('/', '_');
+
+    private static byte[] Decode(string value)
+    {
+        var base64 = value.Replace('-', '+').Replace('_', '/');
+        return Convert.FromBase64String(base64.PadRight(base64.Length + (4 - base64.Length % 4) % 4, '='));
+    }
+}

--- a/TerraformRegistry/Services/LocalModuleService.cs
+++ b/TerraformRegistry/Services/LocalModuleService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.IO.Compression;
 using System.Text.Json;
 using TerraformRegistry.API;
@@ -14,19 +13,19 @@ namespace TerraformRegistry.Services;
 /// </summary>
 public class LocalModuleService : ModuleService
 {
-    // Token storage for download links
-    private static readonly ConcurrentDictionary<string, (string FilePath, DateTime Expiry)> DownloadTokens = new(StringComparer.Ordinal);
     private static readonly TimeSpan TokenLifetime = TimeSpan.FromMinutes(10);
     private readonly IDatabaseService _databaseService;
     private readonly ILogger<LocalModuleService> _logger;
     private readonly string _moduleStoragePath;
     private readonly string _moduleStorageRoot;
+    private readonly ArtifactDownloadTokenService _tokens;
 
     public LocalModuleService(IConfiguration configuration, IDatabaseService databaseService,
-        ILogger<LocalModuleService> logger)
+        ILogger<LocalModuleService> logger, ArtifactDownloadTokenService? tokens = null)
     {
         _databaseService = databaseService;
         _logger = logger;
+        _tokens = tokens ?? new ArtifactDownloadTokenService(configuration);
 
         // Get storage path from configuration, with a reasonable default if not specified
         _moduleStoragePath = configuration["ModuleStoragePath"] ??
@@ -227,9 +226,7 @@ public class LocalModuleService : ModuleService
         }
 
         // Generate a unique token
-        var token = Guid.NewGuid().ToString("N");
-        var expiry = DateTime.UtcNow.Add(TokenLifetime);
-        DownloadTokens[token] = (filePath, expiry);
+        var token = _tokens.Create("module", Path.GetRelativePath(_moduleStorageRoot, filePath), TokenLifetime);
 
         var archiveHint = ModuleArchiveFormat.GetGoGetterHint(moduleStorage);
         return string.IsNullOrEmpty(archiveHint)
@@ -256,20 +253,14 @@ public class LocalModuleService : ModuleService
     }
 
     // Helper for endpoint to validate and retrieve the file path
-    public static bool TryGetFilePathFromToken(string token, out string filePath)
+    public bool TryGetFilePathFromToken(string token, out string filePath)
     {
         filePath = string.Empty;
-        if (!DownloadTokens.TryGetValue(token, out var entry)) return false;
-        if (entry.Expiry > DateTime.UtcNow)
-        {
-            filePath = entry.FilePath;
-            return true;
-        }
-
-        // Expired, remove
-        DownloadTokens.TryRemove(token, out _);
-
-        return false;
+        if (!_tokens.TryValidate(token, "module", out var path)) return false;
+        var candidate = Path.GetFullPath(Path.Combine(_moduleStorageRoot, path));
+        if (!IsInsideStorageRoot(candidate)) return false;
+        filePath = candidate;
+        return true;
     }
 
     /// <summary>

--- a/TerraformRegistry/Services/LocalModuleService.cs
+++ b/TerraformRegistry/Services/LocalModuleService.cs
@@ -257,6 +257,7 @@ public class LocalModuleService : ModuleService
     {
         filePath = string.Empty;
         if (!_tokens.TryValidate(token, "module", out var path)) return false;
+        if (Path.IsPathRooted(path)) return false;
         var candidate = Path.GetFullPath(Path.Combine(_moduleStorageRoot, path));
         if (!IsInsideStorageRoot(candidate)) return false;
         filePath = candidate;

--- a/TerraformRegistry/Services/LocalProviderArtifactStorage.cs
+++ b/TerraformRegistry/Services/LocalProviderArtifactStorage.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.API.Logging;
 
@@ -6,17 +5,17 @@ namespace TerraformRegistry.Services;
 
 public sealed class LocalProviderArtifactStorage : IProviderArtifactStorage
 {
-    private static readonly ConcurrentDictionary<string, (string FilePath, DateTime Expiry)> DownloadTokens =
-        new(StringComparer.Ordinal);
     private readonly ILogger<LocalProviderArtifactStorage> _logger;
     private readonly string _storageRoot;
     private readonly TimeSpan _tokenLifetime;
+    private readonly ArtifactDownloadTokenService _tokens;
 
-    public LocalProviderArtifactStorage(string storageRoot, TimeSpan tokenLifetime, ILogger<LocalProviderArtifactStorage> logger)
+    public LocalProviderArtifactStorage(string storageRoot, TimeSpan tokenLifetime, ILogger<LocalProviderArtifactStorage> logger, ArtifactDownloadTokenService tokens)
     {
         _storageRoot = Path.GetFullPath(storageRoot);
         _tokenLifetime = tokenLifetime;
         _logger = logger;
+        _tokens = tokens;
         Directory.CreateDirectory(_storageRoot);
     }
 
@@ -34,8 +33,7 @@ public sealed class LocalProviderArtifactStorage : IProviderArtifactStorage
     public Task<string> CreateDownloadUrlAsync(string storagePath, CancellationToken cancellationToken)
     {
         var fullPath = GetContainedPath(storagePath);
-        var token = Guid.NewGuid().ToString("N");
-        DownloadTokens[token] = (fullPath, DateTime.UtcNow.Add(_tokenLifetime));
+        var token = _tokens.Create("provider", GetStoragePath(fullPath), _tokenLifetime);
         return Task.FromResult($"/provider/download?token={token}");
     }
 
@@ -75,18 +73,17 @@ public sealed class LocalProviderArtifactStorage : IProviderArtifactStorage
         }
     }
 
-    public static bool TryGetFilePathFromToken(string token, out string filePath)
+
+    public bool TryGetFilePathFromToken(string token, out string filePath)
     {
         filePath = string.Empty;
-        if (!DownloadTokens.TryGetValue(token, out var entry)) return false;
-        if (entry.Expiry <= DateTime.UtcNow)
-        {
-            DownloadTokens.TryRemove(token, out _);
-            return false;
-        }
+        return _tokens.TryValidate(token, "provider", out var path) && TryGetContainedPath(path, out filePath);
+    }
 
-        filePath = entry.FilePath;
-        return true;
+    private bool TryGetContainedPath(string path, out string fullPath)
+    {
+        try { fullPath = GetContainedPath(path); return true; }
+        catch (InvalidOperationException) { fullPath = string.Empty; return false; }
     }
 
     private string GetContainedPath(string storagePath)

--- a/TerraformRegistry/Startup/ModuleEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/ModuleEndpointMappingExtensions.cs
@@ -175,7 +175,8 @@ internal static class ModuleEndpointMappingExtensions
         app.MapGet("/module/download", async context =>
         {
             var token = context.Request.Query["token"].ToString();
-            if (string.IsNullOrEmpty(token) || !LocalModuleService.TryGetFilePathFromToken(token, out var filePath))
+            var moduleService = context.RequestServices.GetRequiredService<IModuleService>() as LocalModuleService;
+            if (string.IsNullOrEmpty(token) || moduleService is null || !moduleService.TryGetFilePathFromToken(token, out var filePath))
             {
                 context.Response.StatusCode = 404;
                 await context.Response.WriteAsync("Invalid or expired download link.");

--- a/TerraformRegistry/Startup/ProviderEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/ProviderEndpointMappingExtensions.cs
@@ -144,7 +144,8 @@ internal static class ProviderEndpointMappingExtensions
         app.MapGet("/provider/download", async context =>
         {
             var token = context.Request.Query["token"].ToString();
-            if (string.IsNullOrEmpty(token) || !LocalProviderArtifactStorage.TryGetFilePathFromToken(token, out var filePath))
+            var storage = context.RequestServices.GetRequiredService<IProviderArtifactStorage>() as LocalProviderArtifactStorage;
+            if (string.IsNullOrEmpty(token) || storage is null || !storage.TryGetFilePathFromToken(token, out var filePath))
             {
                 context.Response.StatusCode = 404;
                 await context.Response.WriteAsync("Invalid or expired download link.");

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -26,6 +26,7 @@ internal static class ServiceRegistrationExtensions
         IConfiguration configuration)
     {
         services.AddRegistryRateLimiting(configuration);
+        services.AddSingleton<ArtifactDownloadTokenService>();
         services.Configure<DatabaseRetryOptions>(configuration.GetSection("DatabaseRetry"));
         services.Configure<WebhookSecurityOptions>(configuration.GetSection("WebhookSecurity"));
         services.AddOptions<ModuleExtractionOptions>()
@@ -209,7 +210,7 @@ internal static class ServiceRegistrationExtensions
                     provider.GetRequiredService<ILogger<S3ModuleService>>(),
                     null,
                     provider.GetRequiredService<IS3ClientFactory>()),
-                "local" => CreateLocalModuleService(config, db, logger),
+                "local" => CreateLocalModuleService(config, db, logger, provider),
                 _ => throw new InvalidOperationException(
                     $"Invalid storage provider specified: '{storageProvider}'. Check configuration.")
             };
@@ -221,7 +222,8 @@ internal static class ServiceRegistrationExtensions
     private static LocalModuleService CreateLocalModuleService(
         IConfiguration config,
         IDatabaseService db,
-        ILogger<LocalModuleService> logger)
+        ILogger<LocalModuleService> logger,
+        IServiceProvider provider)
     {
         var storagePath = config["ModuleStoragePath"];
         if (string.IsNullOrEmpty(storagePath))
@@ -232,7 +234,7 @@ internal static class ServiceRegistrationExtensions
                 "ModuleStoragePath is missing or empty. Please check your configuration.");
         }
 
-        return new LocalModuleService(config, db, logger);
+        return new LocalModuleService(config, db, logger, provider.GetRequiredService<ArtifactDownloadTokenService>());
     }
 
     private static IServiceCollection AddProviderRegistryServices(this IServiceCollection services)
@@ -256,7 +258,8 @@ internal static class ServiceRegistrationExtensions
                 "local" => new LocalProviderArtifactStorage(
                     config["ProviderStoragePath"] ?? Path.Combine(Directory.GetCurrentDirectory(), "providers"),
                     TimeSpan.FromMinutes(expiryMinutes),
-                    provider.GetRequiredService<ILogger<LocalProviderArtifactStorage>>()),
+                    provider.GetRequiredService<ILogger<LocalProviderArtifactStorage>>(),
+                    provider.GetRequiredService<ArtifactDownloadTokenService>()),
                 _ => throw new InvalidOperationException(
                     $"Provider artifact storage is not implemented for StorageProvider '{storageProvider}'.")
             };

--- a/TerraformRegistry/appsettings.Development.json
+++ b/TerraformRegistry/appsettings.Development.json
@@ -49,6 +49,9 @@
   "ApiKeySecurity": {
     "DigestKey": "development-only-api-key-digest-key-32-chars-minimum"
   },
+  "ArtifactDownloadTokens": {
+    "SigningKey": "development-only-artifact-download-token-signing-key-32-chars-minimum"
+  },
   "EnvironmentVariables": {
     "Comment": "The following environment variables can be used for configuration:",
     "TF_REG_BaseUrl": "Base URL for the Terraform Registry",

--- a/TerraformRegistry/appsettings.json
+++ b/TerraformRegistry/appsettings.json
@@ -99,6 +99,9 @@
   "ApiKeySecurity": {
     "DigestKey": "configure-a-unique-api-key-digest-key-before-production"
   },
+  "ArtifactDownloadTokens": {
+    "SigningKey": "configure-a-unique-artifact-download-token-key-before-production"
+  },
   "EnvironmentVariables": {
     "Comment": "The following environment variables can be used for configuration:",
     "TF_REG_BaseUrl": "Base URL for the Terraform Registry",
@@ -130,6 +133,7 @@
     "TF_REG_ModuleExtraction__MaxArchiveBytes": "Maximum accepted module archive size in bytes (default: 104857600)",
     "TF_REG_ModuleExtraction__StartupBackfillBatchSize": "Number of existing modules to queue for extraction at startup (default: 25)",
     "TF_REG_ApiKeySecurity__DigestKey": "API-key HMAC digest key (minimum 32 characters; required outside Development)",
+    "TF_REG_ArtifactDownloadTokens__SigningKey": "Artifact-download HMAC signing key (minimum 32 characters; required outside Development)",
     "TF_REG_Oidc__JwtSecretKey": "Secret key for signing JWT tokens (minimum 32 characters)",
     "TF_REG_Oidc__Providers__GitHub__ClientId": "GitHub OAuth App Client ID",
     "TF_REG_Oidc__Providers__GitHub__ClientSecret": "GitHub OAuth App Client Secret",


### PR DESCRIPTION
Implements IAM-008 for local module and provider artifact downloads.

- replaces process-local token dictionaries with HMAC-signed, Base64URL, purpose-scoped expiring tokens
- validates signing-key strength and rejects the production placeholder
- validates token paths remain under the corresponding storage root
- adds unit and PostgreSQL-backed HTTP regression coverage

Verification:
- `dotnet test terraform-registry.sln -c Release --no-restore` (647 passed)
- `slopwatch analyze --no-baseline` (only 4 pre-existing unrelated findings)
- portable Azurite/MinIO Terraform smoke previously verified locally