### PR TITLE
ci: prevent storage emulator readiness pipefail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,6 +162,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Verify storage emulator harness scripts
+        run: |
+          bash scripts/remediation/storage-emulators/test-lifecycle.sh
+          bash scripts/remediation/storage-emulators/test-ci-workflow.sh
+          bash scripts/remediation/storage-emulators/test-smoke-script.sh
+
       - name: Run Azurite and MinIO Terraform contract smoke
         run: >-
           bash scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh

--- a/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
+++ b/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
@@ -50,10 +50,10 @@ run_provider() {
 
   app="$(docker compose --project-name "$project" --project-directory "$HOME_DIR" -f "$HOME_DIR/compose.yaml" ps -q app)"
   for _ in $(seq 1 120); do
-    if docker logs "$app" 2>&1 | grep -q 'Application started'; then break; fi
+    if [[ "$(docker logs "$app" 2>&1)" == *"Application started"* ]]; then break; fi
     sleep 1
   done
-  docker logs "$app" 2>&1 | grep -q 'Application started'
+  [[ "$(docker logs "$app" 2>&1)" == *"Application started"* ]]
 
   unzip -q "$ROOT/TerraformRegistry.Tests/TestData/test-module.zip" -d "$fixture/module"
   tar -C "$fixture/module" -czf "$fixture/test-module.tar.gz" .

--- a/scripts/remediation/storage-emulators/test-ci-workflow.sh
+++ b/scripts/remediation/storage-emulators/test-ci-workflow.sh
@@ -5,5 +5,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 WORKFLOW="$ROOT/.github/workflows/ci.yaml"
 
 grep -Eq '^  storage-emulator-contract:' "$WORKFLOW"
-grep -Fq 'phase-1-storage-emulator-terraform-smoke.sh --provider all' "$WORKFLOW"
+grep -Fq 'phase-1-storage-emulator-terraform-smoke.sh' "$WORKFLOW"
+grep -Fq -- '--provider all' "$WORKFLOW"
 grep -Fq 'if: failure()' "$WORKFLOW"

--- a/scripts/remediation/storage-emulators/test-smoke-script.sh
+++ b/scripts/remediation/storage-emulators/test-smoke-script.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SMOKE="$ROOT/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh"
+
+if grep -Eq 'docker logs .*\| grep -q' "$SMOKE"; then
+  echo 'Readiness checks must not pipe docker logs into grep under pipefail.' >&2
+  exit 1
+fi
+
+grep -Fq '[[ "$(docker logs "$app" 2>&1)" == *"Application started"* ]]' "$SMOKE"


### PR DESCRIPTION
Fixes the storage-emulator contract job returning exit 141 when `grep -q` closes the `docker logs` pipe under `pipefail`.

Adds CI-run harness script contracts and verifies the full Azurite/MinIO Terraform smoke locally.

Verification:
- `bash scripts/remediation/storage-emulators/test-lifecycle.sh`
- `bash scripts/remediation/storage-emulators/test-ci-workflow.sh`
- `bash scripts/remediation/storage-emulators/test-smoke-script.sh`
- `bash scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh --provider all --home "$HOME/.terraform-registry-storage-test"`