### PR TITLE
security: harden VCS webhook ingress

### DIFF
--- a/TerraformRegistry.API/Interfaces/IGitHubVcsService.cs
+++ b/TerraformRegistry.API/Interfaces/IGitHubVcsService.cs
@@ -7,7 +7,8 @@ public interface IGitHubVcsService
     Task<(string Status, string? Reason, string? Version)> HandleWebhookAsync(
         string? signatureHeader,
         string? eventHeader,
-        string body);
+        string body,
+        CancellationToken cancellationToken);
 
     Task<SyncVcsSourceResult> SyncSourceAsync(
         Guid sourceId,

--- a/TerraformRegistry.Tests/IntegrationTests/VcsSourceTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/VcsSourceTests.cs
@@ -431,7 +431,7 @@ public class VcsSourceTests(ITestOutputHelper output) : IntegrationTestBase(outp
         request.Headers.Add("X-Hub-Signature-256", "sha256=invalidsignature");
 
         var response = await client.SendAsync(request);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
         var body = await response.Content.ReadAsStringAsync();
         Assert.Contains("Signature verification failed", body, StringComparison.OrdinalIgnoreCase);
@@ -571,7 +571,7 @@ public class VcsSourceTests(ITestOutputHelper output) : IntegrationTestBase(outp
 
     private sealed class FakeGitHubVcsService(Func<SyncRequest, Task<SyncVcsSourceResult>> syncHandler) : IGitHubVcsService
     {
-        public Task<(string Status, string? Reason, string? Version)> HandleWebhookAsync(string? signatureHeader, string? eventHeader, string body) =>
+        public Task<(string Status, string? Reason, string? Version)> HandleWebhookAsync(string? signatureHeader, string? eventHeader, string body, CancellationToken cancellationToken) =>
             Task.FromResult<(string Status, string? Reason, string? Version)>(("skipped", null, null));
 
         public Task<SyncVcsSourceResult> SyncSourceAsync(Guid sourceId, string? requestedTag, bool replace, string? actorUserId, CancellationToken cancellationToken) =>

--- a/TerraformRegistry.Tests/UnitTests/VcsWebhookHandlersTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/VcsWebhookHandlersTests.cs
@@ -1,0 +1,26 @@
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Handlers;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class VcsWebhookHandlersTests
+{
+    [Fact]
+    public async Task HandleGitHubWebhookRejectsBodyLargerThanOneMiBWithoutCallingVcsService()
+    {
+        var service = new Mock<IGitHubVcsService>(MockBehavior.Strict);
+        var context = new DefaultHttpContext();
+        context.RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider();
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(new string('x', 1024 * 1024 + 1)));
+
+        var result = await VcsHandlers.HandleGitHubWebhook(service.Object, context);
+
+        await result.ExecuteAsync(context);
+        Assert.Equal(StatusCodes.Status413PayloadTooLarge, context.Response.StatusCode);
+        service.VerifyNoOtherCalls();
+    }
+}

--- a/TerraformRegistry/Handlers/VcsHandlers.cs
+++ b/TerraformRegistry/Handlers/VcsHandlers.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using System.Text;
 using TerraformRegistry.API;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Models;
@@ -286,14 +287,41 @@ public static class VcsHandlers
 
     public static async Task<IResult> HandleGitHubWebhook(IGitHubVcsService githubService, HttpContext context)
     {
-        context.Request.EnableBuffering();
-        using var reader = new StreamReader(context.Request.Body);
-        var body = await reader.ReadToEndAsync();
+        const int maxBodyBytes = 1024 * 1024;
+        if (context.Request.ContentLength > maxBodyBytes)
+            return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+
+        await using var bodyBuffer = new MemoryStream();
+        var buffer = new byte[81920];
+        var totalBytes = 0;
+        while (true)
+        {
+            var read = await context.Request.Body.ReadAsync(buffer, context.RequestAborted);
+            if (read == 0) break;
+            totalBytes += read;
+            if (totalBytes > maxBodyBytes)
+                return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+            await bodyBuffer.WriteAsync(buffer.AsMemory(0, read), context.RequestAborted);
+        }
+
+        var body = Encoding.UTF8.GetString(bodyBuffer.GetBuffer(), 0, (int)bodyBuffer.Length);
 
         var signature = context.Request.Headers["X-Hub-Signature-256"].FirstOrDefault();
         var eventType = context.Request.Headers["X-GitHub-Event"].FirstOrDefault();
 
-        var (status, reason, version) = await githubService.HandleWebhookAsync(signature, eventType, body);
+        var (status, reason, version) = await githubService.HandleWebhookAsync(
+            signature, eventType, body, context.RequestAborted);
+        if (status == "error" && reason is not null &&
+            (reason.StartsWith("Missing ", StringComparison.Ordinal) ||
+             reason.StartsWith("Invalid JSON", StringComparison.Ordinal) ||
+             reason.StartsWith("Signature verification failed", StringComparison.Ordinal)))
+        {
+            return Results.Json(new { status, reason, version }, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (status == "error")
+            return Results.Json(new { status, reason, version }, statusCode: StatusCodes.Status502BadGateway);
+
         return Results.Ok(new { status, reason, version });
     }
 }

--- a/TerraformRegistry/Services/GitHubVcsService.cs
+++ b/TerraformRegistry/Services/GitHubVcsService.cs
@@ -60,7 +60,7 @@ public class GitHubVcsService : IGitHubVcsService
     }
 
     public async Task<(string Status, string? Reason, string? Version)> HandleWebhookAsync(
-        string? signatureHeader, string? eventHeader, string body)
+        string? signatureHeader, string? eventHeader, string body, CancellationToken cancellationToken)
     {
         if (eventHeader != "push")
         {
@@ -173,7 +173,7 @@ public class GitHubVcsService : IGitHubVcsService
         HttpResponseMessage response;
         try
         {
-            response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -186,7 +186,7 @@ public class GitHubVcsService : IGitHubVcsService
             return ("error", $"GitHub API returned {(int)response.StatusCode} for tarball download", null);
         }
 
-        await using var tarballStream = await response.Content.ReadAsStreamAsync();
+        await using var tarballStream = await response.Content.ReadAsStreamAsync(cancellationToken);
         var uploaded = await _publishCoordinator.PublishAsync(new ModulePublishRequest
         {
             Namespace = vcsSource.Namespace,
@@ -209,7 +209,7 @@ public class GitHubVcsService : IGitHubVcsService
                     Ref = $"refs/tags/{tag}"
                 }
             }
-        }, CancellationToken.None);
+        }, cancellationToken);
 
         if (!uploaded)
         {


### PR DESCRIPTION
## Summary
- enforce a 1 MiB webhook body limit before VCS processing
- return 4xx for malformed/signature-invalid webhooks and retryable 502 for transient processing failures
- propagate request cancellation through webhook GitHub download and publication

## Verification
- focused VCS ingress tests: 2 passed
- `slopwatch analyze --no-baseline`: only 4 pre-existing findings