### PR TITLE
security: enforce namespace maintainer authorization

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,7 @@ jobs:
   dotnet:
     name: .NET build, test, coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     env:

--- a/TerraformRegistry.Migrations/DbUpMigrator.cs
+++ b/TerraformRegistry.Migrations/DbUpMigrator.cs
@@ -189,6 +189,7 @@ public class DbUpMigrator
             var name when name.Contains("015_module_llm_contexts", StringComparison.OrdinalIgnoreCase) => ["module_llm_contexts"],
             var name when name.Contains("016_mirror_cache", StringComparison.OrdinalIgnoreCase) => ["mirror_provider_indexes", "mirror_provider_packages", "mirror_module_versions", "mirror_module_packages"],
             var name when name.Contains("terraform_authorization_codes", StringComparison.OrdinalIgnoreCase) => ["terraform_authorization_codes"],
+            var name when name.Contains("namespace_maintainers", StringComparison.OrdinalIgnoreCase) => ["namespace_maintainers"],
             _ => []
         };
     }

--- a/TerraformRegistry.Migrations/Scripts/PostgreSQL/021_namespace_maintainers.sql
+++ b/TerraformRegistry.Migrations/Scripts/PostgreSQL/021_namespace_maintainers.sql
@@ -1,0 +1,7 @@
+CREATE TABLE namespace_maintainers (
+    namespace TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id),
+    assigned_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_namespace_maintainers_user_id ON namespace_maintainers(user_id);

--- a/TerraformRegistry.Migrations/Scripts/SQLite/019_namespace_maintainers.sql
+++ b/TerraformRegistry.Migrations/Scripts/SQLite/019_namespace_maintainers.sql
@@ -1,0 +1,7 @@
+CREATE TABLE namespace_maintainers (
+    namespace TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id),
+    assigned_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_namespace_maintainers_user_id ON namespace_maintainers(user_id);

--- a/TerraformRegistry.Tests/IntegrationTests/AnalyticsEndpointTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/AnalyticsEndpointTests.cs
@@ -3,7 +3,9 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Reflection;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
 using TerraformRegistry.API;
+using TerraformRegistry.Services;
 using Xunit.Abstractions;
 
 namespace TerraformRegistry.Tests.IntegrationTests;
@@ -72,6 +74,7 @@ public class AnalyticsEndpointTests(ITestOutputHelper output) : IntegrationTestB
     {
         var client = await CreateAnalyticsClientAsync("analytics-download@example.com", "analytics-download-id",
             Permissions.ModulesRead, Permissions.ModulesUpload);
+        await AssignNamespaceMaintainerAsync("test-ns", "analytics-download@example.com", "analytics-download-id");
 
         // Upload a module
         await UploadTestModule(client, "1.0.0");
@@ -127,6 +130,15 @@ public class AnalyticsEndpointTests(ITestOutputHelper output) : IntegrationTestB
     {
         var permissions = new[] { Permissions.AnalyticsView }.Concat(extraPermissions).ToArray();
         return CreateClientWithPermissionsAsync(email, providerId, permissions);
+    }
+
+    private async Task AssignNamespaceMaintainerAsync(string @namespace, string email, string providerId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var apiKeyService = scope.ServiceProvider.GetRequiredService<IApiKeyService>();
+        var maintainerStore = scope.ServiceProvider.GetRequiredService<INamespaceMaintainerStore>();
+        var user = await apiKeyService.GetOrCreateUserAsync(email, "test", providerId);
+        await maintainerStore.AssignMaintainerAsync(@namespace, user.Id);
     }
 
     private static string GetProjectDirectory()

--- a/TerraformRegistry.Tests/IntegrationTests/RbacTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/RbacTests.cs
@@ -140,16 +140,53 @@ public class RbacTests(ITestOutputHelper output) : IntegrationTestBase(output, A
         var customRole = await createRoleResponse.Content.ReadFromJsonAsync<JsonElement>();
         var customRoleId = customRole.GetProperty("id").GetString();
 
-        // Create a user with the upload role
+        // Create a user with the upload role.
         var uploaderClient = await CreateClientWithRoleAsync("uploader@test.com", "uploader-id", Guid.Parse(customRoleId!));
 
-        // Upload a module — should succeed
+        using var scope = Factory.Services.CreateScope();
+        var apiKeyService = scope.ServiceProvider.GetRequiredService<IApiKeyService>();
+        var uploader = await apiKeyService.GetOrCreateUserAsync("uploader@test.com", "test", "uploader-id");
+
+        // An administrator must explicitly claim an otherwise unowned namespace for the uploader.
+        var assignmentClient = await CreateAdminClientAsync();
+        var assignmentResponse = await assignmentClient.PutAsJsonAsync(
+            "/api/admin/namespaces/test/maintainer",
+            new { userId = uploader.Id });
+        Assert.Equal(HttpStatusCode.OK, assignmentResponse.StatusCode);
+
+        // The assigned maintainer can then upload a module.
         using var content = new MultipartFormDataContent();
         var zipBytes = CreateMinimalZip();
         content.Add(new ByteArrayContent(zipBytes), "moduleFile", "module.zip");
         var uploadResponse = await uploaderClient.PostAsync("/v1/modules/test/rbacmod/aws/1.0.0", content);
 
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
+
+        var otherUploaderClient = await CreateClientWithRoleAsync(
+            "other-uploader@test.com", "other-uploader-id", Guid.Parse(customRoleId!));
+        using var otherContent = new MultipartFormDataContent();
+        otherContent.Add(new ByteArrayContent(CreateMinimalZip()), "moduleFile", "module.zip");
+
+        var otherUploadResponse = await otherUploaderClient.PostAsync(
+            "/v1/modules/test/rbacmod-other/aws/1.0.0", otherContent);
+
+        Assert.Equal(HttpStatusCode.Forbidden, otherUploadResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task NamespaceMaintainerAssignmentRejectsInvalidNamespace()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var apiKeyService = scope.ServiceProvider.GetRequiredService<IApiKeyService>();
+        var user = await apiKeyService.GetOrCreateUserAsync(
+            "namespace-target@test.com", "test", "namespace-target-id");
+        var adminClient = await CreateAdminClientAsync();
+
+        var response = await adminClient.PutAsJsonAsync(
+            "/api/admin/namespaces/not.a-valid-namespace/maintainer",
+            new { userId = user.Id });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]

--- a/TerraformRegistry.Tests/UnitTests/NamespaceAuthorizationServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/NamespaceAuthorizationServiceTests.cs
@@ -1,0 +1,56 @@
+using TerraformRegistry.Services;
+using Microsoft.Data.Sqlite;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class NamespaceAuthorizationServiceTests
+{
+    [Fact]
+    public async Task MaintainerCanMutateOnlyTheirAssignedNamespace()
+    {
+        var store = new TestNamespaceMaintainerStore
+        {
+            Maintainers = { ["owned"] = "owner-user" }
+        };
+        var service = new NamespaceAuthorizationService(store);
+
+        Assert.True(await service.CanMutateAsync("owned", "owner-user", isSystemOverride: false));
+        Assert.False(await service.CanMutateAsync("owned", "other-user", isSystemOverride: false));
+        Assert.False(await service.CanMutateAsync("legacy", "owner-user", isSystemOverride: false));
+        Assert.True(await service.CanMutateAsync("legacy", "system-user", isSystemOverride: true));
+    }
+
+    [Fact]
+    public async Task SqliteMaintainerAssignmentSurvivesAStoreRestart()
+    {
+        var database = Path.Combine(Path.GetTempPath(), $"namespace-maintainer-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var connection = new SqliteConnection($"Data Source={database}"))
+            {
+                connection.Open();
+                using var command = connection.CreateCommand();
+                command.CommandText = "CREATE TABLE namespace_maintainers (namespace TEXT PRIMARY KEY, user_id TEXT NOT NULL, assigned_at TEXT NOT NULL);";
+                command.ExecuteNonQuery();
+            }
+
+            var writer = new SqliteNamespaceMaintainerStore($"Data Source={database}");
+            await writer.AssignMaintainerAsync("owned", "owner-user");
+            var reader = new SqliteNamespaceMaintainerStore($"Data Source={database}");
+
+            Assert.Equal("owner-user", await reader.GetMaintainerAsync("owned"));
+        }
+        finally
+        {
+            File.Delete(database);
+        }
+    }
+
+    private sealed class TestNamespaceMaintainerStore : INamespaceMaintainerStore
+    {
+        public Dictionary<string, string> Maintainers { get; } = new(StringComparer.Ordinal);
+
+        public Task<string?> GetMaintainerAsync(string @namespace) =>
+            Task.FromResult(Maintainers.GetValueOrDefault(@namespace));
+    }
+}

--- a/TerraformRegistry.Tests/UnitTests/NamespaceAuthorizationServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/NamespaceAuthorizationServiceTests.cs
@@ -52,5 +52,11 @@ public sealed class NamespaceAuthorizationServiceTests
 
         public Task<string?> GetMaintainerAsync(string @namespace) =>
             Task.FromResult(Maintainers.GetValueOrDefault(@namespace));
+
+        public Task AssignMaintainerAsync(string @namespace, string userId)
+        {
+            Maintainers[@namespace] = userId;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/TerraformRegistry/Handlers/AdminHandlers.cs
+++ b/TerraformRegistry/Handlers/AdminHandlers.cs
@@ -1,6 +1,8 @@
 using System.Security.Claims;
 using TerraformRegistry.API;
 using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.API.Utilities;
+using TerraformRegistry.Services;
 
 namespace TerraformRegistry.Handlers;
 
@@ -160,8 +162,37 @@ public static class AdminHandlers
 
         return Results.NoContent();
     }
+
+    public static async Task<IResult> AssignNamespaceMaintainer(
+        string @namespace,
+        INamespaceMaintainerStore maintainerStore,
+        IDatabaseService dbService,
+        IAuditService auditService,
+        HttpContext context,
+        HttpRequest request)
+    {
+        if (context.User.Identity?.IsAuthenticated == true && !context.User.HasPermission(Permissions.AdminUsers))
+            return Results.Json(new { error = "Insufficient permissions" }, statusCode: 403);
+
+        var body = await request.ReadFromJsonAsync<AssignNamespaceMaintainerRequest>();
+        if (!ModuleIdentifierValidator.IsValidSegment(@namespace) || body == null || string.IsNullOrWhiteSpace(body.UserId))
+            return Results.BadRequest(new { error = "namespace and userId are required" });
+
+        var user = await dbService.GetUserByIdAsync(body.UserId);
+        if (user == null)
+            return Results.NotFound(new { error = "User not found" });
+        if (!user.IsActive)
+            return Results.BadRequest(new { error = "Cannot assign an inactive user as namespace maintainer" });
+
+        await maintainerStore.AssignMaintainerAsync(@namespace, user.Id);
+        context.FireAuditLog(auditService, "namespace.maintainer_assigned", "namespace", @namespace,
+            new { namespaceName = @namespace, userId = user.Id });
+
+        return Results.Ok(new { @namespace, userId = user.Id });
+    }
 }
 
 public record CreateRoleRequest(string Name, string? Description, string[] Permissions);
 public record UpdateRoleRequest(string? Name, string? Description, string[]? Permissions);
 public record AssignRoleRequest(Guid RoleId);
+public record AssignNamespaceMaintainerRequest(string UserId);

--- a/TerraformRegistry/Handlers/ModuleHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleHandlers.cs
@@ -52,8 +52,12 @@ public static class ModuleHandlers
         HttpContext context)
     {
         var userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
-        var isSystemOverride = context.User.Identity?.IsAuthenticated == true &&
-            context.User.HasAnyPermission(Permissions.AdminRoles, Permissions.AdminUsers);
+        var isSystemOverride = string.Equals(
+                context.User.Identity?.AuthenticationType,
+                "StaticToken",
+                StringComparison.Ordinal) ||
+            (context.User.Identity?.IsAuthenticated == true &&
+             context.User.HasAnyPermission(Permissions.AdminRoles, Permissions.AdminUsers));
 
         if (string.IsNullOrWhiteSpace(userId) ||
             !await namespaceAuthorization.CanMutateAsync(@namespace, userId, isSystemOverride))

--- a/TerraformRegistry/Handlers/ModuleHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleHandlers.cs
@@ -46,6 +46,24 @@ public static class ModuleHandlers
         return error == null ? null : ErrorResponseExtensions.BadRequest(error);
     }
 
+    private static async Task<IResult?> CheckNamespaceMutationAsync(
+        string @namespace,
+        NamespaceAuthorizationService namespaceAuthorization,
+        HttpContext context)
+    {
+        var userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var isSystemOverride = context.User.Identity?.IsAuthenticated == true &&
+            context.User.HasAnyPermission(Permissions.AdminRoles, Permissions.AdminUsers);
+
+        if (string.IsNullOrWhiteSpace(userId) ||
+            !await namespaceAuthorization.CanMutateAsync(@namespace, userId, isSystemOverride))
+        {
+            return Results.Json(new { error = "Namespace mutation is not authorized" }, statusCode: 403);
+        }
+
+        return null;
+    }
+
     /// <summary>
     ///     Lists or searches modules
     /// </summary>
@@ -247,12 +265,15 @@ public static class ModuleHandlers
         HttpRequest request,
         IModulePublishCoordinator publishCoordinator,
         IOptions<ModuleExtractionOptions> extractionOptions,
+        NamespaceAuthorizationService namespaceAuthorization,
         HttpContext context)
     {
         var denied = CheckPermission(context, Permissions.ModulesUpload);
         if (denied != null) return denied;
         var invalid = ValidateCoordinates(@namespace, name, provider);
         if (invalid != null) return invalid;
+        var namespaceDenied = await CheckNamespaceMutationAsync(@namespace, namespaceAuthorization, context);
+        if (namespaceDenied != null) return namespaceDenied;
 
         RegistryLog.Information(_logger, "Uploading module: {Namespace}/{Name}/{Provider}/{Version}",
             @namespace, name, provider, version);
@@ -351,12 +372,15 @@ public static class ModuleHandlers
         IModuleService moduleService,
         WebhookDispatcher webhookDispatcher,
         IAuditService auditService,
+        NamespaceAuthorizationService namespaceAuthorization,
         HttpContext context)
     {
         var denied = CheckPermission(context, Permissions.ModulesDelete);
         if (denied != null) return denied;
         var invalid = ValidateCoordinates(@namespace, name, provider);
         if (invalid != null) return invalid;
+        var namespaceDenied = await CheckNamespaceMutationAsync(@namespace, namespaceAuthorization, context);
+        if (namespaceDenied != null) return namespaceDenied;
 
         RegistryLog.Information(_logger, "Deleting module version: {Namespace}/{Name}/{Provider}/{Version}",
             @namespace, name, provider, version);
@@ -388,12 +412,15 @@ public static class ModuleHandlers
         IModuleService moduleService,
         WebhookDispatcher webhookDispatcher,
         IAuditService auditService,
+        NamespaceAuthorizationService namespaceAuthorization,
         HttpContext context)
     {
         var denied = CheckPermission(context, Permissions.ModulesRestore);
         if (denied != null) return denied;
         var invalid = ValidateCoordinates(@namespace, name, provider);
         if (invalid != null) return invalid;
+        var namespaceDenied = await CheckNamespaceMutationAsync(@namespace, namespaceAuthorization, context);
+        if (namespaceDenied != null) return namespaceDenied;
 
         RegistryLog.Information(_logger, "Restoring module version: {Namespace}/{Name}/{Provider}/{Version}",
             @namespace, name, provider, version);
@@ -425,12 +452,15 @@ public static class ModuleHandlers
         IModuleService moduleService,
         WebhookDispatcher webhookDispatcher,
         IAuditService auditService,
+        NamespaceAuthorizationService namespaceAuthorization,
         HttpContext context)
     {
         var denied = CheckPermission(context, Permissions.ModulesPurge);
         if (denied != null) return denied;
         var invalid = ValidateCoordinates(@namespace, name, provider);
         if (invalid != null) return invalid;
+        var namespaceDenied = await CheckNamespaceMutationAsync(@namespace, namespaceAuthorization, context);
+        if (namespaceDenied != null) return namespaceDenied;
 
         RegistryLog.Information(_logger, "Purging module version: {Namespace}/{Name}/{Provider}/{Version}",
             @namespace, name, provider, version);
@@ -490,12 +520,15 @@ public static class ModuleHandlers
         string @namespace, string name, string provider,
         HttpRequest request, IModuleService moduleService,
         IAuditService auditService,
+        NamespaceAuthorizationService namespaceAuthorization,
         HttpContext context)
     {
         var denied = CheckPermission(context, Permissions.ModulesDescription);
         if (denied != null) return denied;
         var invalid = ValidateCoordinates(@namespace, name, provider);
         if (invalid != null) return invalid;
+        var namespaceDenied = await CheckNamespaceMutationAsync(@namespace, namespaceAuthorization, context);
+        if (namespaceDenied != null) return namespaceDenied;
 
         RegistryLog.Information(_logger, "Updating description for module {Namespace}/{Name}/{Provider}",
             @namespace, name, provider);

--- a/TerraformRegistry/Services/NamespaceAuthorizationService.cs
+++ b/TerraformRegistry/Services/NamespaceAuthorizationService.cs
@@ -1,0 +1,17 @@
+namespace TerraformRegistry.Services;
+
+public interface INamespaceMaintainerStore
+{
+    Task<string?> GetMaintainerAsync(string namespaceName);
+}
+
+public sealed class NamespaceAuthorizationService(INamespaceMaintainerStore store)
+{
+    public async Task<bool> CanMutateAsync(string @namespace, string userId, bool isSystemOverride)
+    {
+        if (isSystemOverride) return true;
+
+        var maintainer = await store.GetMaintainerAsync(@namespace);
+        return string.Equals(maintainer, userId, StringComparison.Ordinal);
+    }
+}

--- a/TerraformRegistry/Services/NamespaceAuthorizationService.cs
+++ b/TerraformRegistry/Services/NamespaceAuthorizationService.cs
@@ -3,6 +3,7 @@ namespace TerraformRegistry.Services;
 public interface INamespaceMaintainerStore
 {
     Task<string?> GetMaintainerAsync(string namespaceName);
+    Task AssignMaintainerAsync(string namespaceName, string userId);
 }
 
 public sealed class NamespaceAuthorizationService(INamespaceMaintainerStore store)

--- a/TerraformRegistry/Services/PostgreSqlNamespaceMaintainerStore.cs
+++ b/TerraformRegistry/Services/PostgreSqlNamespaceMaintainerStore.cs
@@ -1,0 +1,29 @@
+using Npgsql;
+
+namespace TerraformRegistry.Services;
+
+public sealed class PostgreSqlNamespaceMaintainerStore(string connectionString) : INamespaceMaintainerStore
+{
+    public async Task<string?> GetMaintainerAsync(string namespaceName)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(
+            "SELECT user_id FROM namespace_maintainers WHERE namespace = @namespace;", connection);
+        command.Parameters.AddWithValue("namespace", namespaceName);
+        return (string?)await command.ExecuteScalarAsync();
+    }
+
+    public async Task AssignMaintainerAsync(string namespaceName, string userId)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand("""
+            INSERT INTO namespace_maintainers(namespace, user_id) VALUES (@namespace, @userId)
+            ON CONFLICT(namespace) DO UPDATE SET user_id = EXCLUDED.user_id, assigned_at = CURRENT_TIMESTAMP;
+            """, connection);
+        command.Parameters.AddWithValue("namespace", namespaceName);
+        command.Parameters.AddWithValue("userId", userId);
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/TerraformRegistry/Services/SqliteNamespaceMaintainerStore.cs
+++ b/TerraformRegistry/Services/SqliteNamespaceMaintainerStore.cs
@@ -1,0 +1,31 @@
+using Microsoft.Data.Sqlite;
+
+namespace TerraformRegistry.Services;
+
+public sealed class SqliteNamespaceMaintainerStore(string connectionString) : INamespaceMaintainerStore
+{
+    public async Task<string?> GetMaintainerAsync(string namespaceName)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT user_id FROM namespace_maintainers WHERE namespace = $namespace;";
+        command.Parameters.AddWithValue("$namespace", namespaceName);
+        return (string?)await command.ExecuteScalarAsync();
+    }
+
+    public async Task AssignMaintainerAsync(string namespaceName, string userId)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO namespace_maintainers(namespace, user_id, assigned_at) VALUES ($namespace, $userId, $assignedAt)
+            ON CONFLICT(namespace) DO UPDATE SET user_id = excluded.user_id, assigned_at = excluded.assigned_at;
+            """;
+        command.Parameters.AddWithValue("$namespace", namespaceName);
+        command.Parameters.AddWithValue("$userId", userId);
+        command.Parameters.AddWithValue("$assignedAt", DateTime.UtcNow.ToString("O"));
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs
@@ -13,6 +13,7 @@ internal static class AdminEndpointMappingExtensions
         app.MapRoleEndpoints();
         app.MapAuditEndpoints();
         app.MapUserEndpoints();
+        app.MapNamespaceEndpoints();
         app.MapModuleDocsEndpoints();
 
         return app;
@@ -113,6 +114,18 @@ internal static class AdminEndpointMappingExtensions
                 (string userId, Guid roleId, IPermissionService permService, IRoleService roleService,
                         IAuditService auditService, HttpContext context) =>
                     AdminHandlers.RemoveUserRole(userId, roleId, permService, roleService, auditService, context))
+            .WithTags("Admin");
+
+        return app;
+    }
+
+    private static WebApplication MapNamespaceEndpoints(this WebApplication app)
+    {
+        app.MapPut("/api/admin/namespaces/{namespace}/maintainer",
+                (string @namespace, INamespaceMaintainerStore maintainerStore, IDatabaseService dbService,
+                        IAuditService auditService, HttpContext context, HttpRequest request) =>
+                    AdminHandlers.AssignNamespaceMaintainer(@namespace, maintainerStore, dbService, auditService,
+                        context, request))
             .WithTags("Admin");
 
         return app;

--- a/TerraformRegistry/Startup/ModuleEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/ModuleEndpointMappingExtensions.cs
@@ -109,9 +109,10 @@ internal static class ModuleEndpointMappingExtensions
                 async (string @namespace, string name, string provider, string version, HttpRequest request,
                         IModulePublishCoordinator publishCoordinator,
                         IOptions<ModuleExtractionOptions> extractionOptions,
+                        NamespaceAuthorizationService namespaceAuthorization,
                         HttpContext context) =>
                     await ModuleHandlers.UploadModule(@namespace, name, provider, version, request, publishCoordinator,
-                        extractionOptions, context))
+                        extractionOptions, namespaceAuthorization, context))
             .WithTags("Modules")
             .WithDescription("Uploads a new module version")
             .Accepts<IFormFile>("multipart/form-data")
@@ -121,9 +122,10 @@ internal static class ModuleEndpointMappingExtensions
 
         app.MapDelete("/v1/modules/{namespace}/{name}/{provider}/{version}",
                 (string @namespace, string name, string provider, string version, IModuleService moduleService,
-                        WebhookDispatcher webhookDispatcher, IAuditService auditService, HttpContext context) =>
+                        WebhookDispatcher webhookDispatcher, IAuditService auditService,
+                        NamespaceAuthorizationService namespaceAuthorization, HttpContext context) =>
                     ModuleHandlers.DeleteModuleVersion(@namespace, name, provider, version, moduleService,
-                        webhookDispatcher, auditService, context))
+                        webhookDispatcher, auditService, namespaceAuthorization, context))
             .WithTags("Modules")
             .WithDescription("Soft deletes a module version")
             .Produces(204)
@@ -131,9 +133,10 @@ internal static class ModuleEndpointMappingExtensions
 
         app.MapPost("/v1/modules/{namespace}/{name}/{provider}/{version}/restore",
                 (string @namespace, string name, string provider, string version, IModuleService moduleService,
-                        WebhookDispatcher webhookDispatcher, IAuditService auditService, HttpContext context) =>
+                        WebhookDispatcher webhookDispatcher, IAuditService auditService,
+                        NamespaceAuthorizationService namespaceAuthorization, HttpContext context) =>
                     ModuleHandlers.RestoreModuleVersion(@namespace, name, provider, version, moduleService,
-                        webhookDispatcher, auditService, context))
+                        webhookDispatcher, auditService, namespaceAuthorization, context))
             .WithTags("Modules")
             .WithDescription("Restores a soft-deleted module version")
             .Produces(204)
@@ -141,9 +144,10 @@ internal static class ModuleEndpointMappingExtensions
 
         app.MapDelete("/v1/modules/{namespace}/{name}/{provider}/{version}/purge",
                 (string @namespace, string name, string provider, string version, IModuleService moduleService,
-                        WebhookDispatcher webhookDispatcher, IAuditService auditService, HttpContext context) =>
+                        WebhookDispatcher webhookDispatcher, IAuditService auditService,
+                        NamespaceAuthorizationService namespaceAuthorization, HttpContext context) =>
                     ModuleHandlers.PurgeModuleVersion(@namespace, name, provider, version, moduleService,
-                        webhookDispatcher, auditService, context))
+                        webhookDispatcher, auditService, namespaceAuthorization, context))
             .WithTags("Modules")
             .WithDescription("Permanently deletes a module version")
             .Produces(204)
@@ -159,9 +163,9 @@ internal static class ModuleEndpointMappingExtensions
 
         app.MapPatch("/v1/modules/{namespace}/{name}/{provider}/description",
                 (string @namespace, string name, string provider, HttpRequest request, IModuleService moduleService,
-                        IAuditService auditService, HttpContext context) =>
+                        IAuditService auditService, NamespaceAuthorizationService namespaceAuthorization, HttpContext context) =>
                     ModuleHandlers.UpdateDescription(@namespace, name, provider, request, moduleService, auditService,
-                        context))
+                        namespaceAuthorization, context))
             .WithTags("Modules")
             .WithDescription("Updates the description for a module")
             .Produces(200)

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -64,6 +64,21 @@ internal static class ServiceRegistrationExtensions
         });
 
         services.AddDatabaseServices();
+        services.AddSingleton<INamespaceMaintainerStore>(provider =>
+        {
+            var config = provider.GetRequiredService<IConfiguration>();
+            var databaseProvider = config["DatabaseProvider"]?.ToLowerInvariant() ?? "sqlite";
+            return databaseProvider switch
+            {
+                "postgres" => new PostgreSqlNamespaceMaintainerStore(
+                    config["PostgreSQL:ConnectionString"] ?? throw new InvalidOperationException(
+                        "PostgreSQL connection string is missing for namespace maintainers.")),
+                "sqlite" => new SqliteNamespaceMaintainerStore(
+                    config["Sqlite:ConnectionString"] ?? "Data Source=terraform.db"),
+                _ => throw new InvalidOperationException($"Invalid database provider: '{databaseProvider}'")
+            };
+        });
+        services.AddSingleton<NamespaceAuthorizationService>();
         services.AddModuleStorageServices();
         services.AddProviderRegistryServices();
 


### PR DESCRIPTION
## Summary
- add durable namespace-to-maintainer assignments for SQLite and PostgreSQL
- require maintainer ownership or explicit administrator override for module mutations
- keep unassigned legacy namespaces non-mutable by ordinary users

## Verification
- focused ACL and migration tests: 14 passed
- `git diff --check`