### PR TITLE
security: attach ingress rate limit policies

### DIFF
--- a/TerraformRegistry/Startup/MirrorEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/MirrorEndpointMappingExtensions.cs
@@ -1,5 +1,6 @@
 using TerraformRegistry.Handlers;
 using TerraformRegistry.Models;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace TerraformRegistry.Startup;
 
@@ -9,18 +10,21 @@ internal static class MirrorEndpointMappingExtensions
     {
         app.MapGet("/mirror/providers/{hostname}/{namespace}/{type}/index.json", MirrorHandlers.GetProviderIndex)
             .WithTags("Mirror")
+            .RequireRateLimiting(RateLimitPolicyNames.MirrorIngress)
             .WithDescription("Gets the Terraform provider network mirror index")
             .Produces<ProviderMirrorIndexResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         app.MapGet("/mirror/providers/{hostname}/{namespace}/{type}/{version}.json", MirrorHandlers.GetProviderVersion)
             .WithTags("Mirror")
+            .RequireRateLimiting(RateLimitPolicyNames.MirrorIngress)
             .WithDescription("Gets Terraform provider network mirror version metadata")
             .Produces<ProviderMirrorVersionResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         app.MapGet("/mirror/providers/{hostname}/{namespace}/{type}/{filename}", MirrorHandlers.GetProviderPackage)
             .WithTags("Mirror")
+            .RequireRateLimiting(RateLimitPolicyNames.MirrorIngress)
             .WithDescription("Downloads a cached Terraform provider package using a signed mirror URL")
             .Produces(StatusCodes.Status200OK, contentType: "application/zip")
             .ProducesProblem(StatusCodes.Status404NotFound);

--- a/TerraformRegistry/Startup/ModuleEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/ModuleEndpointMappingExtensions.cs
@@ -4,6 +4,7 @@ using TerraformRegistry.Models;
 using TerraformRegistry.Services;
 using TerraformRegistry.Services.Publishing;
 using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace TerraformRegistry.Startup;
 
@@ -116,6 +117,7 @@ internal static class ModuleEndpointMappingExtensions
             .WithTags("Modules")
             .WithDescription("Uploads a new module version")
             .Accepts<IFormFile>("multipart/form-data")
+            .RequireRateLimiting(RateLimitPolicyNames.ModuleUpload)
             .ProducesProblem(400)
             .ProducesProblem(409)
             .Produces(201);

--- a/TerraformRegistry/Startup/ProviderEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/ProviderEndpointMappingExtensions.cs
@@ -2,6 +2,7 @@ using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Handlers;
 using TerraformRegistry.Models;
 using TerraformRegistry.Services;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace TerraformRegistry.Startup;
 
@@ -99,20 +100,23 @@ internal static class ProviderEndpointMappingExtensions
                 (string @namespace, string type, string version, IProviderRegistryService service,
                         HttpContext context, HttpRequest request) =>
                     ProviderHandlers.UploadShasums(@namespace, type, version, service, context, request))
-            .WithTags("Providers");
+            .WithTags("Providers")
+            .RequireRateLimiting(RateLimitPolicyNames.ProviderUpload);
 
         app.MapPut("/api/providers/{namespace}/{type}/versions/{version}/shasums.sig",
                 (string @namespace, string type, string version, IProviderRegistryService service,
                         HttpContext context, HttpRequest request) =>
                     ProviderHandlers.UploadShasumsSignature(@namespace, type, version, service, context, request))
-            .WithTags("Providers");
+            .WithTags("Providers")
+            .RequireRateLimiting(RateLimitPolicyNames.ProviderUpload);
 
         app.MapPut("/api/providers/{namespace}/{type}/versions/{version}/platforms/{os}/{arch}/package",
                 (string @namespace, string type, string version, string os, string arch,
                         IProviderRegistryService service, HttpContext context, HttpRequest request) =>
                     ProviderHandlers.UploadPlatformPackage(@namespace, type, version, os, arch, service, context,
                         request))
-            .WithTags("Providers");
+            .WithTags("Providers")
+            .RequireRateLimiting(RateLimitPolicyNames.ProviderUpload);
 
         return app;
     }

--- a/TerraformRegistry/Startup/VcsEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/VcsEndpointMappingExtensions.cs
@@ -1,5 +1,6 @@
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Handlers;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace TerraformRegistry.Startup;
 
@@ -87,7 +88,8 @@ internal static class VcsEndpointMappingExtensions
     {
         app.MapPost("/api/vcs/github/webhook", (IGitHubVcsService githubService, HttpContext context) =>
                 VcsHandlers.HandleGitHubWebhook(githubService, context))
-            .WithTags("VCS");
+            .WithTags("VCS")
+            .RequireRateLimiting(RateLimitPolicyNames.WebhookIngress);
 
         return app;
     }


### PR DESCRIPTION
## Summary
- attach named limits to module/provider uploads, VCS webhook ingress, and mirror endpoints

## Verification
- focused rate-limit and webhook tests: 8 passed
- `git diff --check`