### PR TITLE
fix: enforce configured ingress concurrency limits

### DIFF
--- a/TerraformRegistry.Tests/UnitTests/RateLimitOptionsTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/RateLimitOptionsTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -64,6 +65,23 @@ public sealed class RateLimitOptionsTests
         var exception = Assert.Throws<InvalidOperationException>(policy.Validate);
 
         Assert.Contains("PermitLimit", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PolicyLimiterEnforcesConfiguredConcurrencyLimit()
+    {
+        var policy = new RegistryRateLimitPolicyOptions
+        {
+            PermitLimit = 2,
+            WindowSeconds = 60,
+            ConcurrencyLimit = 1
+        };
+        using var limiter = RegistryRateLimiterFactory.Create(policy);
+        using var first = limiter.AttemptAcquire();
+        using var second = limiter.AttemptAcquire();
+
+        Assert.True(first.IsAcquired);
+        Assert.False(second.IsAcquired);
     }
 
     [Fact]

--- a/TerraformRegistry/Startup/RegistryRateLimitingExtensions.cs
+++ b/TerraformRegistry/Startup/RegistryRateLimitingExtensions.cs
@@ -24,6 +24,25 @@ public sealed class RegistryRateLimitMetrics : IDisposable
     public void Dispose() => _meter.Dispose();
 }
 
+public static class RegistryRateLimiterFactory
+{
+    public static RateLimiter Create(RegistryRateLimitPolicyOptions policy) => RateLimiter.CreateChained(
+        new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = policy.PermitLimit,
+            Window = TimeSpan.FromSeconds(policy.WindowSeconds),
+            QueueLimit = policy.QueueLimit,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            AutoReplenishment = true
+        }),
+        new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+        {
+            PermitLimit = policy.ConcurrencyLimit,
+            QueueLimit = policy.QueueLimit,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst
+        }));
+}
+
 public static class RegistryRateLimitingExtensions
 {
     private const string PolicyItemKey = "terraform-registry.rate-limit-policy";
@@ -64,14 +83,7 @@ public static class RegistryRateLimitingExtensions
                 {
                     httpContext.Items[PolicyItemKey] = name;
                     var partition = RateLimitPartitionKey.For(httpContext);
-                    return RateLimitPartition.GetFixedWindowLimiter(partition, _ => new FixedWindowRateLimiterOptions
-                    {
-                        PermitLimit = policy.PermitLimit,
-                        Window = TimeSpan.FromSeconds(policy.WindowSeconds),
-                        QueueLimit = policy.QueueLimit,
-                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-                        AutoReplenishment = true
-                    });
+                    return RateLimitPartition.Get(partition, _ => RegistryRateLimiterFactory.Create(policy));
                 });
             }
         });

--- a/TerraformRegistry/Startup/RegistryRateLimitingExtensions.cs
+++ b/TerraformRegistry/Startup/RegistryRateLimitingExtensions.cs
@@ -26,21 +26,50 @@ public sealed class RegistryRateLimitMetrics : IDisposable
 
 public static class RegistryRateLimiterFactory
 {
-    public static RateLimiter Create(RegistryRateLimitPolicyOptions policy) => RateLimiter.CreateChained(
-        new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+    public static RateLimiter Create(RegistryRateLimitPolicyOptions policy)
+    {
+        var fixedWindow = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
         {
             PermitLimit = policy.PermitLimit,
             Window = TimeSpan.FromSeconds(policy.WindowSeconds),
             QueueLimit = policy.QueueLimit,
             QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
             AutoReplenishment = true
-        }),
-        new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+        });
+        var concurrency = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
         {
             PermitLimit = policy.ConcurrencyLimit,
             QueueLimit = policy.QueueLimit,
             QueueProcessingOrder = QueueProcessingOrder.OldestFirst
-        }));
+        });
+        return new OwnedRateLimiter(RateLimiter.CreateChained([fixedWindow, concurrency]), fixedWindow, concurrency);
+    }
+
+    private sealed class OwnedRateLimiter(RateLimiter inner, params RateLimiter[] owned) : RateLimiter
+    {
+        public override TimeSpan? IdleDuration => inner.IdleDuration;
+
+        public override RateLimiterStatistics? GetStatistics() => inner.GetStatistics();
+
+        protected override RateLimitLease AttemptAcquireCore(int permitCount) => inner.AttemptAcquire(permitCount);
+
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken) =>
+            inner.AcquireAsync(permitCount, cancellationToken);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                inner.Dispose();
+                foreach (var limiter in owned)
+                {
+                    limiter.Dispose();
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+    }
 }
 
 public static class RegistryRateLimitingExtensions


### PR DESCRIPTION
Repairs the Phase 2 rate-limit foundation so each named ingress partition chains its fixed-window permit budget with the configured concurrency limit. Includes a regression test proving concurrency rejection when permit budget remains available.