### PR TITLE
fix: report API key verification overload

### DIFF
--- a/TerraformRegistry.Tests/IntegrationTests/ProviderMirrorEndpointTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/ProviderMirrorEndpointTests.cs
@@ -83,6 +83,17 @@ public sealed class ProviderMirrorEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RateLimitedApiKeyReturnsTooManyRequests()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/mirror/providers/registry.terraform.io/hashicorp/aws/index.json");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "rate-limited-token");
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+    }
+
+    [Fact]
     public async Task ProviderVersionReturnsSignedArchiveUrlAndTerraformHashes()
     {
         _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AuthToken);
@@ -282,6 +293,7 @@ public sealed class ProviderMirrorEndpointTests : IAsyncLifetime
                     TokenHash = "hash",
                     Prefix = "mirror"
                 }, false)),
+                "rate-limited-token" => Task.FromResult(new ApiKeyValidationResult(null, false, true)),
                 _ => Task.FromResult(new ApiKeyValidationResult(null, false))
             };
         }

--- a/TerraformRegistry.Tests/UnitTests/ApiKeyServiceSecurityTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ApiKeyServiceSecurityTests.cs
@@ -84,6 +84,31 @@ public sealed class ApiKeyServiceSecurityTests
         Assert.Null(second);
     }
 
+    [Fact]
+    public async Task ValidateApiKeyAsyncMarksVerificationPermitExhaustionAsRateLimited()
+    {
+        var security = new ApiKeySecurityOptions
+        {
+            DigestKey = "test-api-key-digest-key-at-least-thirty-two-characters",
+            VerificationPermitLimit = 1,
+            VerificationWindowSeconds = 60
+        };
+        var database = new Mock<IDatabaseService>();
+        database.Setup(x => x.AddApiKeyAsync(It.IsAny<ApiKey>())).Returns(Task.CompletedTask);
+        var service = new ApiKeyService(database.Object, Mock.Of<ILogger<ApiKeyService>>(), new UserAdmissionOptions(),
+            security, new ApiKeyVerificationGate(security));
+        var (token, key) = await service.CreateApiKeyAsync("user-1", "test");
+        database.Setup(x => x.GetApiKeysByPrefixAsync(key.Prefix)).ReturnsAsync([key]);
+        database.Setup(x => x.GetUserByIdAsync(key.UserId)).ReturnsAsync(new User { Id = key.UserId, IsActive = true });
+        database.Setup(x => x.UpdateApiKeyAsync(key)).Returns(Task.CompletedTask);
+
+        var first = await service.ValidateApiKeyAsync(token);
+        var second = await service.ValidateApiKeyAsync(token);
+
+        Assert.False(first.IsRateLimited);
+        Assert.True(second.IsRateLimited);
+    }
+
     private static ApiKeyService CreateService(Mock<IDatabaseService> database)
     {
         var security = new ApiKeySecurityOptions { DigestKey = "test-api-key-digest-key-at-least-thirty-two-characters" };

--- a/TerraformRegistry.Tests/UnitTests/ApiKeyServiceSecurityTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ApiKeyServiceSecurityTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Diagnostics.Metrics;
 using Konscious.Security.Cryptography;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -75,13 +76,41 @@ public sealed class ApiKeyServiceSecurityTests
             VerificationPermitLimit = 1,
             MaxConcurrentVerificationsPerPartition = 1
         };
-        using var gate = new ApiKeyVerificationGate(options);
+        var measurements = new List<(string Policy, string Partition)>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == "TerraformRegistry.RateLimiting" &&
+                instrument.Name == "terraform_registry.rate_limit.rejections")
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            string? policy = null;
+            string? partition = null;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "policy") policy = tag.Value as string;
+                if (tag.Key == "partition") partition = tag.Value as string;
+            }
+
+            if (policy is not null && partition is not null)
+            {
+                measurements.Add((policy, partition));
+            }
+        });
+        listener.Start();
+        using var metrics = new RegistryRateLimitMetrics();
+        using var gate = new ApiKeyVerificationGate(options, metrics);
 
         using var first = gate.TryEnterPrefix("prefix-1");
         var second = gate.TryEnterPrefix("prefix-1");
 
         Assert.NotNull(first);
         Assert.Null(second);
+        Assert.Contains((RateLimitPolicyNames.ApiKeyVerification, "prefix"), measurements);
     }
 
     [Fact]
@@ -96,7 +125,7 @@ public sealed class ApiKeyServiceSecurityTests
         var database = new Mock<IDatabaseService>();
         database.Setup(x => x.AddApiKeyAsync(It.IsAny<ApiKey>())).Returns(Task.CompletedTask);
         var service = new ApiKeyService(database.Object, Mock.Of<ILogger<ApiKeyService>>(), new UserAdmissionOptions(),
-            security, new ApiKeyVerificationGate(security));
+            security, new ApiKeyVerificationGate(security, new RegistryRateLimitMetrics()));
         var (token, key) = await service.CreateApiKeyAsync("user-1", "test");
         database.Setup(x => x.GetApiKeysByPrefixAsync(key.Prefix)).ReturnsAsync([key]);
         database.Setup(x => x.GetUserByIdAsync(key.UserId)).ReturnsAsync(new User { Id = key.UserId, IsActive = true });
@@ -113,7 +142,7 @@ public sealed class ApiKeyServiceSecurityTests
     {
         var security = new ApiKeySecurityOptions { DigestKey = "test-api-key-digest-key-at-least-thirty-two-characters" };
         return new ApiKeyService(database.Object, Mock.Of<ILogger<ApiKeyService>>(), new UserAdmissionOptions(), security,
-            new ApiKeyVerificationGate(security));
+            new ApiKeyVerificationGate(security, new RegistryRateLimitMetrics()));
     }
 
     private static string CreateLegacyHash(string token)

--- a/TerraformRegistry/Middleware/AuthenticationMiddleware.cs
+++ b/TerraformRegistry/Middleware/AuthenticationMiddleware.cs
@@ -89,6 +89,21 @@ public class AuthenticationMiddleware(
                     var apiKeyService = scope.ServiceProvider.GetRequiredService<IApiKeyService>();
                     var result = await apiKeyService.ValidateApiKeyAsync(token);
 
+                    if (result.IsRateLimited)
+                    {
+                        context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                        context.Response.ContentType = "application/problem+json";
+                        await context.Response.WriteAsJsonAsync(new
+                        {
+                            type = "https://tools.ietf.org/html/rfc6585#section-4",
+                            title = "Too Many Requests",
+                            status = StatusCodes.Status429TooManyRequests,
+                            detail = "API key verification is temporarily rate limited.",
+                            policy = "api-key-verification"
+                        });
+                        return;
+                    }
+
                     if (result.IsExpired)
                     {
                         context.Response.StatusCode = StatusCodes.Status401Unauthorized;

--- a/TerraformRegistry/Services/ApiKeyService.cs
+++ b/TerraformRegistry/Services/ApiKeyService.cs
@@ -77,7 +77,7 @@ public class ApiKeyService(
             if (prefixLease is null)
             {
                 RegistryLog.Warning(logger, "Rejected API key verification because the prefix limit was reached.");
-                return new ApiKeyValidationResult(null, false);
+                return new ApiKeyValidationResult(null, false, true);
             }
 
             var isLegacy = !key.TokenHash.StartsWith("v1:", StringComparison.Ordinal);
@@ -87,7 +87,7 @@ public class ApiKeyService(
                 if (principalLease is null)
                 {
                     RegistryLog.Warning(logger, "Rejected API key verification because the principal limit was reached.");
-                    return new ApiKeyValidationResult(null, false);
+                    return new ApiKeyValidationResult(null, false, true);
                 }
 
                 if (key.ExpiresAt.HasValue && key.ExpiresAt.Value < DateTime.UtcNow)
@@ -314,4 +314,4 @@ public enum ApiKeyUpdateStatus
 
 public record ApiKeyUpdateResult(ApiKeyUpdateStatus Status, ApiKey? Key);
 
-public record ApiKeyValidationResult(ApiKey? Key, bool IsExpired);
+public record ApiKeyValidationResult(ApiKey? Key, bool IsExpired, bool IsRateLimited = false);

--- a/TerraformRegistry/Services/ApiKeyVerificationGate.cs
+++ b/TerraformRegistry/Services/ApiKeyVerificationGate.cs
@@ -3,18 +3,24 @@ using TerraformRegistry.Startup;
 
 namespace TerraformRegistry.Services;
 
-public sealed class ApiKeyVerificationGate(ApiKeySecurityOptions options) : IDisposable
+public sealed class ApiKeyVerificationGate(ApiKeySecurityOptions options, RegistryRateLimitMetrics metrics) : IDisposable
 {
     private readonly ConcurrentDictionary<string, PartitionGate> _prefixes = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, PartitionGate> _principals = new(StringComparer.Ordinal);
 
-    public IDisposable? TryEnterPrefix(string prefix) => TryEnter(_prefixes, prefix);
+    public IDisposable? TryEnterPrefix(string prefix) => TryEnter(_prefixes, prefix, "prefix");
 
-    public IDisposable? TryEnterPrincipal(string userId) => TryEnter(_principals, userId);
+    public IDisposable? TryEnterPrincipal(string userId) => TryEnter(_principals, userId, "principal");
 
-    private Releaser? TryEnter(ConcurrentDictionary<string, PartitionGate> partitions, string key)
+    private Releaser? TryEnter(ConcurrentDictionary<string, PartitionGate> partitions, string key, string partitionCategory)
     {
-        return partitions.GetOrAdd(key, _ => new PartitionGate(options)).TryEnter();
+        var lease = partitions.GetOrAdd(key, _ => new PartitionGate(options)).TryEnter();
+        if (lease is null)
+        {
+            metrics.RecordRejection(RateLimitPolicyNames.ApiKeyVerification, partitionCategory);
+        }
+
+        return lease;
     }
 
     private sealed class PartitionGate(ApiKeySecurityOptions options) : IDisposable


### PR DESCRIPTION
Returns a structured 429 only when API-key verification is rejected by the prefix or principal verification gate. Invalid and expired credentials retain their existing responses. Includes service-level saturation and authenticated middleware regressions.