### PR TITLE
test: enforce bounded ingestion security gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,6 +211,20 @@ jobs:
       - name: Run portable Phase 1 deployment gate
         run: bash scripts/remediation/gates/phase-1.sh
 
+  bounded-ingestion-security-gate:
+    name: Bounded ingestion security gate
+    if: github.event_name == 'pull_request' && github.head_ref == 'test/audit-p2-security-abuse-gate'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run bounded ingestion security gate
+        run: bash scripts/remediation/gates/bounded-ingestion-security.sh
+
   docker:
     name: Docker build and scan
     needs:

--- a/TerraformRegistry.Tests/UnitTests/ArchiveWorkspaceFactoryTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ArchiveWorkspaceFactoryTests.cs
@@ -124,4 +124,82 @@ public class ArchiveWorkspaceFactoryTests
 
         Assert.Contains("entry count", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public async Task ArchiveWorkspaceFactoryRejectsEntryOverConfiguredExpandedEntryLimit()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        await using var stream = new MemoryStream(TestArchiveBuilder.CreateZipBytes(("module/main.tf", "0123456789")));
+        var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
+        {
+            TempRoot = Path.Combine(tempDir.FullName, "workspaces"),
+            MaxExpandedEntryBytes = 4
+        });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            factory.CreateAsync(stream, CancellationToken.None));
+
+        Assert.Contains("entry", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(Directory.EnumerateDirectories(Path.Combine(tempDir.FullName, "workspaces")));
+    }
+
+    [Fact]
+    public async Task ArchiveWorkspaceFactoryRejectsCompressionBomb()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        await using var stream = new MemoryStream(TestArchiveBuilder.CreateZipBytes(("module/main.tf", new string('a', 16_384))));
+        var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
+        {
+            TempRoot = Path.Combine(tempDir.FullName, "workspaces"),
+            MaxCompressionRatio = 2
+        });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            factory.CreateAsync(stream, CancellationToken.None));
+
+        Assert.Contains("compression ratio", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(Directory.EnumerateDirectories(Path.Combine(tempDir.FullName, "workspaces")));
+    }
+
+    [Fact]
+    public async Task ArchiveWorkspaceFactoryRejectsCorruptArchiveAndCleansWorkspace()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        await using var stream = new MemoryStream([0x1F, 0x8B, 0x08, 0x00, 0xFF]);
+        var workspacesRoot = Path.Combine(tempDir.FullName, "workspaces");
+        var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions { TempRoot = workspacesRoot });
+
+        await Assert.ThrowsAnyAsync<IOException>(() => factory.CreateAsync(stream, CancellationToken.None));
+
+        Assert.True(!Directory.Exists(workspacesRoot) || !Directory.EnumerateDirectories(workspacesRoot).Any());
+    }
+
+    [Fact]
+    public async Task ArchiveWorkspaceFactoryRejectsTruncatedArchiveAndCleansWorkspace()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        var archive = TestArchiveBuilder.CreateZipBytes(("module/main.tf", "resource {}"));
+        await using var stream = new MemoryStream(archive[..^4]);
+        var workspacesRoot = Path.Combine(tempDir.FullName, "workspaces");
+        var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions { TempRoot = workspacesRoot });
+
+        await Assert.ThrowsAnyAsync<InvalidDataException>(() => factory.CreateAsync(stream, CancellationToken.None));
+
+        Assert.True(!Directory.Exists(workspacesRoot) || !Directory.EnumerateDirectories(workspacesRoot).Any());
+    }
+
+    [Fact]
+    public async Task ArchiveWorkspaceFactoryCleansWorkspaceWhenRequestIsCancelled()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        await using var stream = new MemoryStream(TestArchiveBuilder.CreateZipBytes(("module/main.tf", "resource {}")));
+        var workspacesRoot = Path.Combine(tempDir.FullName, "workspaces");
+        var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions { TempRoot = workspacesRoot });
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => factory.CreateAsync(stream, cancellation.Token));
+
+        Assert.True(!Directory.Exists(workspacesRoot) || !Directory.EnumerateDirectories(workspacesRoot).Any());
+    }
 }

--- a/TerraformRegistry.Tests/UnitTests/ArchiveWorkspaceFactoryTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ArchiveWorkspaceFactoryTests.cs
@@ -73,9 +73,10 @@ public class ArchiveWorkspaceFactoryTests
     {
         var tempDir = Directory.CreateTempSubdirectory();
         await using var stream = new MemoryStream(TestArchiveBuilder.CreateZipBytes(("module/main.tf", "0123456789")));
+        var workspacesRoot = tempDir.CreateSubdirectory("workspaces").FullName;
         var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
         {
-            TempRoot = Path.Combine(tempDir.FullName, "workspaces"),
+            TempRoot = workspacesRoot,
             MaxExpandedArchiveBytes = 4
         });
 
@@ -83,7 +84,6 @@ public class ArchiveWorkspaceFactoryTests
             factory.CreateAsync(stream, CancellationToken.None));
 
         Assert.Contains("expanded", exception.Message, StringComparison.OrdinalIgnoreCase);
-        var workspacesRoot = Path.Combine(tempDir.FullName, "workspaces");
         Assert.True(!Directory.Exists(workspacesRoot) || !Directory.EnumerateDirectories(workspacesRoot).Any());
     }
 
@@ -130,9 +130,10 @@ public class ArchiveWorkspaceFactoryTests
     {
         var tempDir = Directory.CreateTempSubdirectory();
         await using var stream = new MemoryStream(TestArchiveBuilder.CreateZipBytes(("module/main.tf", "0123456789")));
+        var workspacesRoot = tempDir.CreateSubdirectory("workspaces").FullName;
         var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
         {
-            TempRoot = Path.Combine(tempDir.FullName, "workspaces"),
+            TempRoot = workspacesRoot,
             MaxExpandedEntryBytes = 4
         });
 
@@ -140,7 +141,7 @@ public class ArchiveWorkspaceFactoryTests
             factory.CreateAsync(stream, CancellationToken.None));
 
         Assert.Contains("entry", exception.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Empty(Directory.EnumerateDirectories(Path.Combine(tempDir.FullName, "workspaces")));
+        Assert.Empty(Directory.EnumerateDirectories(workspacesRoot));
     }
 
     [Fact]
@@ -148,9 +149,10 @@ public class ArchiveWorkspaceFactoryTests
     {
         var tempDir = Directory.CreateTempSubdirectory();
         await using var stream = new MemoryStream(TestArchiveBuilder.CreateZipBytes(("module/main.tf", new string('a', 16_384))));
+        var workspacesRoot = tempDir.CreateSubdirectory("workspaces").FullName;
         var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
         {
-            TempRoot = Path.Combine(tempDir.FullName, "workspaces"),
+            TempRoot = workspacesRoot,
             MaxCompressionRatio = 2
         });
 
@@ -158,7 +160,7 @@ public class ArchiveWorkspaceFactoryTests
             factory.CreateAsync(stream, CancellationToken.None));
 
         Assert.Contains("compression ratio", exception.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Empty(Directory.EnumerateDirectories(Path.Combine(tempDir.FullName, "workspaces")));
+        Assert.Empty(Directory.EnumerateDirectories(workspacesRoot));
     }
 
     [Fact]
@@ -166,7 +168,7 @@ public class ArchiveWorkspaceFactoryTests
     {
         var tempDir = Directory.CreateTempSubdirectory();
         await using var stream = new MemoryStream([0x1F, 0x8B, 0x08, 0x00, 0xFF]);
-        var workspacesRoot = Path.Combine(tempDir.FullName, "workspaces");
+        var workspacesRoot = tempDir.CreateSubdirectory("workspaces").FullName;
         var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions { TempRoot = workspacesRoot });
 
         await Assert.ThrowsAnyAsync<IOException>(() => factory.CreateAsync(stream, CancellationToken.None));
@@ -180,7 +182,7 @@ public class ArchiveWorkspaceFactoryTests
         var tempDir = Directory.CreateTempSubdirectory();
         var archive = TestArchiveBuilder.CreateZipBytes(("module/main.tf", "resource {}"));
         await using var stream = new MemoryStream(archive[..^4]);
-        var workspacesRoot = Path.Combine(tempDir.FullName, "workspaces");
+        var workspacesRoot = tempDir.CreateSubdirectory("workspaces").FullName;
         var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions { TempRoot = workspacesRoot });
 
         await Assert.ThrowsAnyAsync<InvalidDataException>(() => factory.CreateAsync(stream, CancellationToken.None));
@@ -193,7 +195,7 @@ public class ArchiveWorkspaceFactoryTests
     {
         var tempDir = Directory.CreateTempSubdirectory();
         await using var stream = new MemoryStream(TestArchiveBuilder.CreateZipBytes(("module/main.tf", "resource {}")));
-        var workspacesRoot = Path.Combine(tempDir.FullName, "workspaces");
+        var workspacesRoot = tempDir.CreateSubdirectory("workspaces").FullName;
         var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions { TempRoot = workspacesRoot });
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();

--- a/TerraformRegistry.Tests/UnitTests/ProviderRegistryServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ProviderRegistryServiceTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Models;
 using TerraformRegistry.Services;
+using TerraformRegistry.Startup;
 
 namespace TerraformRegistry.Tests.UnitTests;
 
@@ -414,16 +415,88 @@ public class ProviderRegistryServiceTests
         repository.Verify(x => x.SetPlatformPackagePathAsync(platformId, "stored-package", 3), Times.Once);
     }
 
+    [Fact]
+    public async Task UploadPlatformPackageAsyncRejectsOversizedNonSeekableUploadBody()
+    {
+        var repository = new Mock<IProviderRepository>();
+        var storage = new Mock<IProviderArtifactStorage>(MockBehavior.Strict);
+        var validator = new Mock<IProviderPackageValidator>(MockBehavior.Strict);
+        var tempDir = Directory.CreateTempSubdirectory();
+        using var package = new NonSeekableReadStream([1, 2, 3, 4, 5]);
+        var service = CreateService(repository, storage, validator, new ProviderUploadOptions
+        {
+            MaxPackageBytes = 4,
+            TempRoot = tempDir.FullName
+        });
+        SetUpUploadPrerequisites(repository);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UploadPlatformPackageAsync("acme", "example", "1.0.0", "linux", "amd64", package, CancellationToken.None));
+
+        Assert.Contains("exceeds", exception.Message, StringComparison.OrdinalIgnoreCase);
+        validator.VerifyNoOtherCalls();
+        storage.VerifyNoOtherCalls();
+        Assert.Empty(Directory.EnumerateFiles(tempDir.FullName));
+    }
+
     private static ProviderRegistryService CreateService(
         Mock<IProviderRepository>? repository = null,
         Mock<IProviderArtifactStorage>? storage = null,
-        Mock<IProviderPackageValidator>? validator = null)
+        Mock<IProviderPackageValidator>? validator = null,
+        ProviderUploadOptions? uploadOptions = null)
     {
         return new ProviderRegistryService(
             repository?.Object ?? Mock.Of<IProviderRepository>(),
             storage?.Object ?? Mock.Of<IProviderArtifactStorage>(),
             validator?.Object ?? Mock.Of<IProviderPackageValidator>(),
-            NullLogger<ProviderRegistryService>.Instance);
+            NullLogger<ProviderRegistryService>.Instance,
+            uploadOptions);
+    }
+
+    private static void SetUpUploadPrerequisites(Mock<IProviderRepository> repository)
+    {
+        var providerId = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        repository.Setup(x => x.GetProviderAsync("acme", "example"))
+            .ReturnsAsync(new TerraformProvider
+            {
+                Id = providerId,
+                Namespace = "acme",
+                Type = "example",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            });
+        repository.Setup(x => x.GetProviderVersionAsync("acme", "example", "1.0.0"))
+            .ReturnsAsync(new ProviderVersion
+            {
+                Id = versionId,
+                ProviderId = providerId,
+                Version = "1.0.0",
+                Protocols = ["5.0"],
+                KeyId = "ABCDEF",
+                ShasumsStoragePath = "shasums",
+                ShasumsSignatureStoragePath = "sig",
+                PublishedAt = DateTime.UtcNow
+            });
+        repository.Setup(x => x.GetProviderPlatformAsync("acme", "example", "1.0.0", "linux", "amd64"))
+            .ReturnsAsync(new ProviderPlatform
+            {
+                Id = Guid.NewGuid(),
+                ProviderVersionId = versionId,
+                Os = "linux",
+                Arch = "amd64",
+                Filename = "terraform-provider-example_1.0.0_linux_amd64.zip",
+                Shasum = new string('a', 64)
+            });
+        repository.Setup(x => x.GetGpgKeyAsync("acme", "ABCDEF"))
+            .ReturnsAsync(new ProviderGpgKey
+            {
+                Id = Guid.NewGuid(),
+                Namespace = "acme",
+                KeyId = "ABCDEF",
+                AsciiArmor = "public-key",
+                CreatedAt = DateTime.UtcNow
+            });
     }
 
     private sealed class NonSeekableReadStream : Stream

--- a/scripts/remediation/gates/bounded-ingestion-security.sh
+++ b/scripts/remediation/gates/bounded-ingestion-security.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Acceptance evidence for bounded archive/provider/webhook ingestion and the
+# identity controls that authorize it. Keep the filter explicit: each selected
+# fixture maps to a gate requirement in the remediation delivery plan.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+ASPNETCORE_ENVIRONMENT=Test dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj \
+  --configuration Release \
+  --filter 'FullyQualifiedName~ArchiveWorkspaceFactoryTests|FullyQualifiedName~ModulePublishCoordinatorTests|FullyQualifiedName~ProviderRegistryServiceTests|FullyQualifiedName~VcsWebhookHandlersTests|FullyQualifiedName~VcsSourceTests|FullyQualifiedName~UserAdmissionOptionsTests|FullyQualifiedName~ApiKeyServiceSecurityTests|FullyQualifiedName~ApiKeyExpirationTests|FullyQualifiedName~RbacTests|FullyQualifiedName~NamespaceAuthorizationServiceTests|FullyQualifiedName~ArtifactDownloadTokenServiceTests|FullyQualifiedName~UploadModuleTests|FullyQualifiedName~TerraformAuthorizationCodeStoreTests|FullyQualifiedName~SqliteTerraformAuthorizationCodeStoreTests|FullyQualifiedName~RateLimitOptionsTests|FullyQualifiedName~ProviderMirrorEndpointTests'
+
+printf 'Bounded ingestion and identity security gate passed.\n'

--- a/scripts/remediation/gates/test-bounded-ingestion-security.sh
+++ b/scripts/remediation/gates/test-bounded-ingestion-security.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+GATE="$ROOT/scripts/remediation/gates/bounded-ingestion-security.sh"
+
+test -x "$GATE"
+grep -Fq 'ArchiveWorkspaceFactoryTests' "$GATE"
+grep -Fq 'ProviderRegistryServiceTests' "$GATE"
+grep -Fq 'VcsWebhookHandlersTests' "$GATE"
+grep -Fq 'ApiKeyServiceSecurityTests' "$GATE"
+grep -Fq 'ArtifactDownloadTokenServiceTests' "$GATE"
+grep -Fq 'RateLimitOptionsTests' "$GATE"
+grep -Fq 'ProviderMirrorEndpointTests' "$GATE"
+grep -Eq '^  bounded-ingestion-security-gate:' "$ROOT/.github/workflows/ci.yaml"
+grep -Fq 'bounded-ingestion-security.sh' "$ROOT/.github/workflows/ci.yaml"


### PR DESCRIPTION
Adds the executable acceptance gate for bounded archive/provider/webhook ingestion, identity policy, download tokens, and ingress overload handling.

Verification:
- `bash scripts/remediation/gates/bounded-ingestion-security.sh` (102 tests before the final focused oversized-provider addition)
- `ProviderRegistryServiceTests` (11 passed, including oversized non-seekable upload)
- `dotnet build terraform-registry.sln --configuration Release --no-restore`
- `bash scripts/remediation/gates/test-bounded-ingestion-security.sh`

The gate is wired as a required PR job for this acceptance branch.