### PR TITLE
fix: harden temporary path handling

### DIFF
--- a/TerraformRegistry.Tests/UnitTests/ArchiveWorkspaceFactoryTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ArchiveWorkspaceFactoryTests.cs
@@ -10,7 +10,7 @@ public class ArchiveWorkspaceFactoryTests
     public async Task ArchiveWorkspaceFactoryExtractsGitHubTarballDespiteZipStorageName()
     {
         var tempDir = Directory.CreateTempSubdirectory();
-        var tarGzPath = Path.Combine(tempDir.FullName, "artifact.zip");
+        var tarGzPath = Path.Join(tempDir.FullName, "artifact.zip");
 
         await TestArchiveBuilder.CreateTarGzAsync(
             tarGzPath,
@@ -20,31 +20,31 @@ public class ArchiveWorkspaceFactoryTests
         await using var stream = File.OpenRead(tarGzPath);
         var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
         {
-            TempRoot = Path.Combine(tempDir.FullName, "workspaces")
+            TempRoot = Path.Join(tempDir.FullName, "workspaces")
         });
 
         await using var workspace = await factory.CreateAsync(stream, CancellationToken.None);
 
-        Assert.True(File.Exists(Path.Combine(workspace.RootPath, "README.md")));
-        Assert.True(File.Exists(Path.Combine(workspace.RootPath, "variables.tf")));
+        Assert.True(File.Exists(Path.Join(workspace.RootPath, "README.md")));
+        Assert.True(File.Exists(Path.Join(workspace.RootPath, "variables.tf")));
     }
 
     [Fact]
     public async Task ArchiveWorkspaceFactoryExtractsEmptyRegularFileFromTarGz()
     {
         var tempDir = Directory.CreateTempSubdirectory();
-        var tarGzPath = Path.Combine(tempDir.FullName, "module.tar.gz");
+        var tarGzPath = Path.Join(tempDir.FullName, "module.tar.gz");
         await TestArchiveBuilder.CreateTarGzAsync(tarGzPath, ("module/main.tf", string.Empty));
 
         await using var stream = File.OpenRead(tarGzPath);
         var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
         {
-            TempRoot = Path.Combine(tempDir.FullName, "workspaces")
+            TempRoot = Path.Join(tempDir.FullName, "workspaces")
         });
 
         await using var workspace = await factory.CreateAsync(stream, CancellationToken.None);
 
-        var file = Path.Combine(workspace.RootPath, "main.tf");
+        var file = Path.Join(workspace.RootPath, "main.tf");
         Assert.True(File.Exists(file));
         Assert.Equal(0, new FileInfo(file).Length);
     }
@@ -56,7 +56,7 @@ public class ArchiveWorkspaceFactoryTests
         await using var stream = new MemoryStream([1, 2, 3, 4, 5]);
         var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
         {
-            TempRoot = Path.Combine(tempDir.FullName, "workspaces"),
+            TempRoot = Path.Join(tempDir.FullName, "workspaces"),
             MaxArchiveBytes = 4
         });
 
@@ -64,7 +64,7 @@ public class ArchiveWorkspaceFactoryTests
             factory.CreateAsync(stream, CancellationToken.None));
 
         Assert.Contains("exceeds", ex.Message, StringComparison.OrdinalIgnoreCase);
-        var workspacesRoot = Path.Combine(tempDir.FullName, "workspaces");
+        var workspacesRoot = Path.Join(tempDir.FullName, "workspaces");
         Assert.True(!Directory.Exists(workspacesRoot) || !Directory.EnumerateDirectories(workspacesRoot).Any());
     }
 
@@ -94,15 +94,15 @@ public class ArchiveWorkspaceFactoryTests
         await using var stream = new MemoryStream(TestArchiveBuilder.CreateZipBytes(("../outside.tf", "resource {}")));
         var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
         {
-            TempRoot = Path.Combine(tempDir.FullName, "workspaces")
+            TempRoot = Path.Join(tempDir.FullName, "workspaces")
         });
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             factory.CreateAsync(stream, CancellationToken.None));
 
         Assert.Contains("escapes", exception.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.False(File.Exists(Path.Combine(tempDir.FullName, "outside.tf")));
-        var workspacesRoot = Path.Combine(tempDir.FullName, "workspaces");
+        Assert.False(File.Exists(Path.Join(tempDir.FullName, "outside.tf")));
+        var workspacesRoot = Path.Join(tempDir.FullName, "workspaces");
         Assert.True(!Directory.Exists(workspacesRoot) || !Directory.EnumerateDirectories(workspacesRoot).Any());
     }
 
@@ -115,7 +115,7 @@ public class ArchiveWorkspaceFactoryTests
             ("module/two.tf", "two")));
         var factory = new ArchiveWorkspaceFactory(new ModuleExtractionOptions
         {
-            TempRoot = Path.Combine(tempDir.FullName, "workspaces"),
+            TempRoot = Path.Join(tempDir.FullName, "workspaces"),
             MaxArchiveEntries = 1
         });
 

--- a/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
@@ -14,6 +14,8 @@ namespace TerraformRegistry.Tests.UnitTests;
 
 public class ModulePublishCoordinatorTests
 {
+    private static readonly HttpClient StaticOkClient = new(new StaticOkHandler());
+
     [Fact]
     public async Task PublishAsyncDoesNotCreateSideEffectsWhenArchiveValidationFails()
     {
@@ -74,7 +76,7 @@ public class ModulePublishCoordinatorTests
 
         var webhookDispatcher = new WebhookDispatcher(
             webhookService.Object,
-            new TestHttpClientFactory(new HttpClient(new StaticOkHandler())),
+            new TestHttpClientFactory(StaticOkClient),
             new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal) { ["BaseUrl"] = "https://registry.example.com" })
                 .Build(),

--- a/TerraformRegistry.Tests/UnitTests/NamespaceAuthorizationServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/NamespaceAuthorizationServiceTests.cs
@@ -23,7 +23,7 @@ public sealed class NamespaceAuthorizationServiceTests
     [Fact]
     public async Task SqliteMaintainerAssignmentSurvivesAStoreRestart()
     {
-        var database = Path.Combine(Path.GetTempPath(), $"namespace-maintainer-{Guid.NewGuid():N}.db");
+        var database = Path.Join(Path.GetTempPath(), $"namespace-maintainer-{Guid.NewGuid():N}.db");
         try
         {
             using (var connection = new SqliteConnection($"Data Source={database}"))

--- a/TerraformRegistry.Tests/UnitTests/SqliteTerraformAuthorizationCodeStoreTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/SqliteTerraformAuthorizationCodeStoreTests.cs
@@ -9,7 +9,7 @@ public sealed class SqliteTerraformAuthorizationCodeStoreTests
     [Fact]
     public void CodeCreatedByOneStoreInstanceIsConsumedOnceByAnother()
     {
-        var database = Path.Combine(Path.GetTempPath(), $"terraform-auth-code-{Guid.NewGuid():N}.db");
+        var database = Path.Join(Path.GetTempPath(), $"terraform-auth-code-{Guid.NewGuid():N}.db");
         try
         {
             CreateSchema(database);
@@ -36,7 +36,7 @@ public sealed class SqliteTerraformAuthorizationCodeStoreTests
     [Fact]
     public void IncorrectClientOrRedirectDoesNotConsumeTheCode()
     {
-        var database = Path.Combine(Path.GetTempPath(), $"terraform-auth-code-{Guid.NewGuid():N}.db");
+        var database = Path.Join(Path.GetTempPath(), $"terraform-auth-code-{Guid.NewGuid():N}.db");
         try
         {
             CreateSchema(database);
@@ -57,7 +57,7 @@ public sealed class SqliteTerraformAuthorizationCodeStoreTests
     [Fact]
     public void ExpiredCodeCannotBeConsumed()
     {
-        var database = Path.Combine(Path.GetTempPath(), $"terraform-auth-code-{Guid.NewGuid():N}.db");
+        var database = Path.Join(Path.GetTempPath(), $"terraform-auth-code-{Guid.NewGuid():N}.db");
         try
         {
             CreateSchema(database);

--- a/TerraformRegistry/Services/LocalModuleService.cs
+++ b/TerraformRegistry/Services/LocalModuleService.cs
@@ -258,7 +258,7 @@ public class LocalModuleService : ModuleService
         filePath = string.Empty;
         if (!_tokens.TryValidate(token, "module", out var path)) return false;
         if (Path.IsPathRooted(path)) return false;
-        var candidate = Path.GetFullPath(Path.Combine(_moduleStorageRoot, path));
+        var candidate = Path.GetFullPath(Path.Join(_moduleStorageRoot, path));
         if (!IsInsideStorageRoot(candidate)) return false;
         filePath = candidate;
         return true;

--- a/TerraformRegistry/Services/ModuleExtraction/ArchiveIngestionValidator.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ArchiveIngestionValidator.cs
@@ -10,7 +10,7 @@ public sealed class ArchiveIngestionValidator(
     {
         options.Validate();
         Directory.CreateDirectory(options.TempRoot);
-        var path = Path.Combine(options.TempRoot, $".{Guid.NewGuid():N}.upload");
+        var path = Path.Join(options.TempRoot, $".{Guid.NewGuid():N}.upload");
 
         try
         {
@@ -41,6 +41,10 @@ public sealed class ArchiveIngestionValidator(
                              BufferSize, FileOptions.Asynchronous | FileOptions.SequentialScan))
             await using (var workspace = await workspaceFactory.CreateAsync(validationInput, cancellationToken))
             {
+                if (!Directory.Exists(workspace.RootPath))
+                {
+                    throw new InvalidOperationException("Archive validation workspace was not created.");
+                }
             }
 
             return new ValidatedArchive(path);

--- a/TerraformRegistry/Services/ModuleExtraction/ArchiveWorkspaceFactory.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ArchiveWorkspaceFactory.cs
@@ -21,8 +21,8 @@ public sealed class ArchiveWorkspaceFactory : IArchiveWorkspaceFactory
 
     public async Task<ArchiveWorkspace> CreateAsync(Stream archiveStream, CancellationToken cancellationToken)
     {
-        var workRoot = Path.Combine(_options.TempRoot, Guid.NewGuid().ToString("N"));
-        var spoolPath = Path.Combine(_options.TempRoot, $".{Guid.NewGuid():N}.archive");
+        var workRoot = Path.Join(_options.TempRoot, Guid.NewGuid().ToString("N"));
+        var spoolPath = Path.Join(_options.TempRoot, $".{Guid.NewGuid():N}.archive");
         Directory.CreateDirectory(workRoot);
 
         try
@@ -209,7 +209,7 @@ public sealed class ArchiveWorkspaceFactory : IArchiveWorkspaceFactory
         }
 
         var root = Path.GetFullPath(workRoot);
-        var destination = Path.GetFullPath(Path.Combine(root, entryName));
+        var destination = Path.GetFullPath(Path.Join(root, entryName));
         if (!destination.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.Ordinal))
         {
             throw new InvalidOperationException("Archive entry path escapes the extraction root.");

--- a/TerraformRegistry/Services/ProviderRegistryService.cs
+++ b/TerraformRegistry/Services/ProviderRegistryService.cs
@@ -355,7 +355,7 @@ public sealed class ProviderRegistryService : IProviderRegistryService
     private async Task<FileStream> CopyToReplayableFileAsync(Stream source, CancellationToken cancellationToken)
     {
         Directory.CreateDirectory(_uploadOptions.TempRoot);
-        var path = Path.Combine(_uploadOptions.TempRoot, $".{Guid.NewGuid():N}.provider-upload");
+        var path = Path.Join(_uploadOptions.TempRoot, $".{Guid.NewGuid():N}.provider-upload");
         try
         {
             var output = new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 1024 * 1024,


### PR DESCRIPTION
Addresses the CodeQL recommendations on the bounded-ingestion integration PR. Uses `Path.Join` for controlled path segments, verifies archive validation workspace creation, and removes the test-local HttpClient allocation.

Verification:
- 30 focused tests passed
- release solution build passed
- Slopwatch: four known baseline findings only.