### PR TITLE
test: reuse webhook test client

### DIFF
--- a/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
@@ -150,7 +150,7 @@ public class ModulePublishCoordinatorTests
             Mock.Of<IModuleExtractionService>(),
             new WebhookDispatcher(
                 webhookService.Object,
-                new TestHttpClientFactory(new HttpClient(new StaticOkHandler())),
+                new TestHttpClientFactory(StaticOkClient),
                 new ConfigurationBuilder()
                     .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal))
                     .Build(),
@@ -194,7 +194,7 @@ public class ModulePublishCoordinatorTests
             .ReturnsAsync(Array.Empty<Webhook>());
         return new WebhookDispatcher(
             webhookService.Object,
-            new TestHttpClientFactory(new HttpClient(new StaticOkHandler())),
+            new TestHttpClientFactory(StaticOkClient),
             new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build(),
             new WebhookUrlValidator(
                 Options.Create(new WebhookSecurityOptions { AllowPrivateNetworks = true }),


### PR DESCRIPTION
Completes the remaining CodeQL disposal recommendation by reusing the shared static test HttpClient in every webhook dispatcher fixture.

Verification:
- `ModulePublishCoordinatorTests` (3 passed)
- release solution build passed
- Slopwatch: four known baseline findings only.