### PR TITLE
feat: enforce mirror runtime limits

### DIFF
--- a/TerraformRegistry.Migrations/Scripts/PostgreSQL/022_mirror_cache_budget.sql
+++ b/TerraformRegistry.Migrations/Scripts/PostgreSQL/022_mirror_cache_budget.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mirror_provider_packages ADD COLUMN IF NOT EXISTS cache_size_bytes BIGINT NULL;
+ALTER TABLE mirror_module_packages ADD COLUMN IF NOT EXISTS cache_size_bytes BIGINT NULL;

--- a/TerraformRegistry.Migrations/Scripts/SQLite/020_mirror_cache_budget.sql
+++ b/TerraformRegistry.Migrations/Scripts/SQLite/020_mirror_cache_budget.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mirror_provider_packages ADD COLUMN cache_size_bytes INTEGER NULL;
+ALTER TABLE mirror_module_packages ADD COLUMN cache_size_bytes INTEGER NULL;

--- a/TerraformRegistry.Models/MirrorCacheModels.cs
+++ b/TerraformRegistry.Models/MirrorCacheModels.cs
@@ -28,6 +28,8 @@ public sealed record MirrorProviderPackage
     public string? Filename { get; init; }
     public string? PackageStoragePath { get; init; }
     public long? SizeBytes { get; init; }
+    /// <summary>Total bytes consumed by this package and its mirror sidecar artifacts.</summary>
+    public long? CacheSizeBytes { get; init; }
     public string ProtocolsJson { get; init; } = "[]";
     public string HashesJson { get; init; } = "[]";
     public string? Shasum { get; init; }
@@ -68,6 +70,8 @@ public sealed record MirrorModulePackage
     public string? Source { get; init; }
     public string? PackageStoragePath { get; init; }
     public long? SizeBytes { get; init; }
+    /// <summary>Total bytes consumed by this mirrored module package.</summary>
+    public long? CacheSizeBytes { get; init; }
     public string? MetadataJson { get; init; }
     public string State { get; init; } = "pending";
     public string? LastError { get; init; }

--- a/TerraformRegistry.Models/MirrorNetworkProtocolModels.cs
+++ b/TerraformRegistry.Models/MirrorNetworkProtocolModels.cs
@@ -27,4 +27,5 @@ public sealed record ProviderMirrorPackageDownload(
     Stream Content,
     string Filename,
     string ContentType,
-    long? ContentLength);
+    long? ContentLength,
+    IDisposable? CacheLease = null);

--- a/TerraformRegistry.Models/MirrorOptions.cs
+++ b/TerraformRegistry.Models/MirrorOptions.cs
@@ -15,6 +15,11 @@ public sealed class MirrorProviderRuntimeOptions
     public bool Enabled { get; set; } = true;
     public bool RequireAuthentication { get; set; } = true;
     public List<string> AllowedHostnames { get; set; } = ["registry.terraform.io"];
+    /// <summary>
+    /// Maps each advertised provider mirror hostname to the HTTPS registry used to retrieve it.
+    /// A multi-host configuration must provide one explicit entry for every allowed hostname.
+    /// </summary>
+    public Dictionary<string, string> UpstreamRegistryUrls { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     public List<string> AllowedArtifactHosts { get; set; } = [];
     public List<string> Allowlist { get; set; } = [];
     public List<string> Denylist { get; set; } = [];

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleMirrorRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleMirrorRepository.cs
@@ -74,7 +74,7 @@ public sealed class PostgreSqlModuleMirrorRepository(string connectionString) : 
         var parameters = new List<NpgsqlParameter>();
         var sql = @"
             SELECT id, hostname, namespace, name, provider, version, download_url, source, package_storage_path,
-                   size_bytes, metadata_json::text, state, last_error, http_status_code, last_sync_at, created_at, updated_at
+                   size_bytes, cache_size_bytes, metadata_json::text, state, last_error, http_status_code, last_sync_at, created_at, updated_at
             FROM mirror_module_packages
             WHERE TRUE";
 
@@ -118,7 +118,7 @@ public sealed class PostgreSqlModuleMirrorRepository(string connectionString) : 
     {
         const string sql = @"
             SELECT id, hostname, namespace, name, provider, version, download_url, source, package_storage_path,
-                   size_bytes, metadata_json::text, state, last_error, http_status_code, last_sync_at, created_at, updated_at
+                   size_bytes, cache_size_bytes, metadata_json::text, state, last_error, http_status_code, last_sync_at, created_at, updated_at
             FROM mirror_module_packages
             WHERE hostname = @hostname AND namespace = @namespace AND name = @name
               AND provider = @provider AND version = @version";
@@ -141,15 +141,16 @@ public sealed class PostgreSqlModuleMirrorRepository(string connectionString) : 
         const string sql = @"
             INSERT INTO mirror_module_packages (
                 id, hostname, namespace, name, provider, version, download_url, source, package_storage_path,
-                size_bytes, metadata_json, state, last_error, http_status_code, last_sync_at, created_at, updated_at)
+                size_bytes, cache_size_bytes, metadata_json, state, last_error, http_status_code, last_sync_at, created_at, updated_at)
             VALUES (
                 @id, @hostname, @namespace, @name, @provider, @version, @downloadUrl, @source, @packageStoragePath,
-                @sizeBytes, @metadataJson, @state, @lastError, @httpStatusCode, @lastSyncAt, @createdAt, @updatedAt)
+                @sizeBytes, @cacheSizeBytes, @metadataJson, @state, @lastError, @httpStatusCode, @lastSyncAt, @createdAt, @updatedAt)
             ON CONFLICT(hostname, namespace, name, provider, version) DO UPDATE SET
                 download_url = EXCLUDED.download_url,
                 source = EXCLUDED.source,
                 package_storage_path = EXCLUDED.package_storage_path,
                 size_bytes = EXCLUDED.size_bytes,
+                cache_size_bytes = EXCLUDED.cache_size_bytes,
                 metadata_json = EXCLUDED.metadata_json,
                 state = EXCLUDED.state,
                 last_error = EXCLUDED.last_error,
@@ -210,6 +211,7 @@ public sealed class PostgreSqlModuleMirrorRepository(string connectionString) : 
         command.Parameters.AddWithValue("@source", DbValue(package.Source));
         command.Parameters.AddWithValue("@packageStoragePath", DbValue(package.PackageStoragePath));
         command.Parameters.AddWithValue("@sizeBytes", DbValue(package.SizeBytes));
+        command.Parameters.AddWithValue("@cacheSizeBytes", DbValue(package.CacheSizeBytes));
         AddJsonb(command, "metadataJson", package.MetadataJson);
         command.Parameters.AddWithValue("@state", package.State);
         command.Parameters.AddWithValue("@lastError", DbValue(package.LastError));
@@ -252,13 +254,14 @@ public sealed class PostgreSqlModuleMirrorRepository(string connectionString) : 
             Source = ReadString(reader, 7),
             PackageStoragePath = ReadString(reader, 8),
             SizeBytes = reader.IsDBNull(9) ? null : reader.GetInt64(9),
-            MetadataJson = ReadString(reader, 10),
-            State = reader.GetString(11),
-            LastError = ReadString(reader, 12),
-            HttpStatusCode = reader.IsDBNull(13) ? null : reader.GetInt32(13),
-            LastSyncAt = ReadDateTime(reader, 14),
-            CreatedAt = reader.GetDateTime(15),
-            UpdatedAt = reader.GetDateTime(16)
+            CacheSizeBytes = reader.IsDBNull(10) ? null : reader.GetInt64(10),
+            MetadataJson = ReadString(reader, 11),
+            State = reader.GetString(12),
+            LastError = ReadString(reader, 13),
+            HttpStatusCode = reader.IsDBNull(14) ? null : reader.GetInt32(14),
+            LastSyncAt = ReadDateTime(reader, 15),
+            CreatedAt = reader.GetDateTime(16),
+            UpdatedAt = reader.GetDateTime(17)
         };
     }
 

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlProviderMirrorRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlProviderMirrorRepository.cs
@@ -71,7 +71,7 @@ public sealed class PostgreSqlProviderMirrorRepository(string connectionString) 
         var parameters = new List<NpgsqlParameter>();
         var sql = @"
             SELECT id, hostname, namespace, type, version, os, arch, download_url, filename, package_storage_path,
-                   size_bytes, protocols_json::text, hashes_json::text, shasum, signing_keys_json::text, state,
+                   size_bytes, cache_size_bytes, protocols_json::text, hashes_json::text, shasum, signing_keys_json::text, state,
                    last_error, http_status_code, last_sync_at, created_at, updated_at
             FROM mirror_provider_packages
             WHERE TRUE";
@@ -117,7 +117,7 @@ public sealed class PostgreSqlProviderMirrorRepository(string connectionString) 
     {
         const string sql = @"
             SELECT id, hostname, namespace, type, version, os, arch, download_url, filename, package_storage_path,
-                   size_bytes, protocols_json::text, hashes_json::text, shasum, signing_keys_json::text, state,
+                   size_bytes, cache_size_bytes, protocols_json::text, hashes_json::text, shasum, signing_keys_json::text, state,
                    last_error, http_status_code, last_sync_at, created_at, updated_at
             FROM mirror_provider_packages
             WHERE hostname = @hostname AND namespace = @namespace AND type = @type
@@ -142,17 +142,18 @@ public sealed class PostgreSqlProviderMirrorRepository(string connectionString) 
         const string sql = @"
             INSERT INTO mirror_provider_packages (
                 id, hostname, namespace, type, version, os, arch, download_url, filename, package_storage_path,
-                size_bytes, protocols_json, hashes_json, shasum, signing_keys_json, state, last_error,
+                size_bytes, cache_size_bytes, protocols_json, hashes_json, shasum, signing_keys_json, state, last_error,
                 http_status_code, last_sync_at, created_at, updated_at)
             VALUES (
                 @id, @hostname, @namespace, @type, @version, @os, @arch, @downloadUrl, @filename, @packageStoragePath,
-                @sizeBytes, @protocolsJson, @hashesJson, @shasum, @signingKeysJson, @state, @lastError,
+                @sizeBytes, @cacheSizeBytes, @protocolsJson, @hashesJson, @shasum, @signingKeysJson, @state, @lastError,
                 @httpStatusCode, @lastSyncAt, @createdAt, @updatedAt)
             ON CONFLICT(hostname, namespace, type, version, os, arch) DO UPDATE SET
                 download_url = EXCLUDED.download_url,
                 filename = EXCLUDED.filename,
                 package_storage_path = EXCLUDED.package_storage_path,
                 size_bytes = EXCLUDED.size_bytes,
+                cache_size_bytes = EXCLUDED.cache_size_bytes,
                 protocols_json = EXCLUDED.protocols_json,
                 hashes_json = EXCLUDED.hashes_json,
                 shasum = EXCLUDED.shasum,
@@ -227,6 +228,7 @@ public sealed class PostgreSqlProviderMirrorRepository(string connectionString) 
         command.Parameters.AddWithValue("@filename", DbValue(package.Filename));
         command.Parameters.AddWithValue("@packageStoragePath", DbValue(package.PackageStoragePath));
         command.Parameters.AddWithValue("@sizeBytes", DbValue(package.SizeBytes));
+        command.Parameters.AddWithValue("@cacheSizeBytes", DbValue(package.CacheSizeBytes));
         AddJsonb(command, "protocolsJson", package.ProtocolsJson);
         AddJsonb(command, "hashesJson", package.HashesJson);
         command.Parameters.AddWithValue("@shasum", DbValue(package.Shasum));
@@ -272,16 +274,17 @@ public sealed class PostgreSqlProviderMirrorRepository(string connectionString) 
             Filename = ReadString(reader, 8),
             PackageStoragePath = ReadString(reader, 9),
             SizeBytes = reader.IsDBNull(10) ? null : reader.GetInt64(10),
-            ProtocolsJson = reader.GetString(11),
-            HashesJson = reader.GetString(12),
-            Shasum = ReadString(reader, 13),
-            SigningKeysJson = ReadString(reader, 14),
-            State = reader.GetString(15),
-            LastError = ReadString(reader, 16),
-            HttpStatusCode = reader.IsDBNull(17) ? null : reader.GetInt32(17),
-            LastSyncAt = ReadDateTime(reader, 18),
-            CreatedAt = reader.GetDateTime(19),
-            UpdatedAt = reader.GetDateTime(20)
+            CacheSizeBytes = reader.IsDBNull(11) ? null : reader.GetInt64(11),
+            ProtocolsJson = reader.GetString(12),
+            HashesJson = reader.GetString(13),
+            Shasum = ReadString(reader, 14),
+            SigningKeysJson = ReadString(reader, 15),
+            State = reader.GetString(16),
+            LastError = ReadString(reader, 17),
+            HttpStatusCode = reader.IsDBNull(18) ? null : reader.GetInt32(18),
+            LastSyncAt = ReadDateTime(reader, 19),
+            CreatedAt = reader.GetDateTime(20),
+            UpdatedAt = reader.GetDateTime(21)
         };
     }
 

--- a/TerraformRegistry.Tests/UnitTests/Database/MirrorRepositoryTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/MirrorRepositoryTests.cs
@@ -145,6 +145,7 @@ internal static class ProviderRepositoryContract
             Filename = "terraform-provider-aws_5.0.0_linux_amd64.zip",
             PackageStoragePath = "mirror/providers/hashicorp/aws/5.0.0/linux_amd64.zip",
             SizeBytes = 123456789,
+            CacheSizeBytes = 123456999,
             ProtocolsJson = """["5.0"]""",
             HashesJson = """["h1:test","zh:test"]""",
             Shasum = new string('a', 64),
@@ -167,6 +168,7 @@ internal static class ProviderRepositoryContract
         MirrorJsonAssert.Equal(package.HashesJson, loadedPackage!.HashesJson);
         MirrorJsonAssert.Equal(package.ProtocolsJson, loadedPackage.ProtocolsJson);
         Assert.Equal(package.SizeBytes, loadedPackage.SizeBytes);
+        Assert.Equal(package.CacheSizeBytes, loadedPackage.CacheSizeBytes);
         Assert.Equal(package.PackageStoragePath, loadedPackage.PackageStoragePath);
 
         var listed = await repository.ListProviderPackagesAsync("aws", "ready", 10, 0);
@@ -261,6 +263,7 @@ internal static class ModuleRepositoryContract
             Source = "github.com/terraform-aws-modules/terraform-aws-vpc",
             PackageStoragePath = "mirror/modules/terraform-aws-modules/vpc/aws/1.0.0.tgz",
             SizeBytes = 4567,
+            CacheSizeBytes = 4567,
             MetadataJson = """{"root":{"readme":"README.md"}}""",
             State = "ready",
             LastSyncAt = DateTime.UtcNow
@@ -278,6 +281,7 @@ internal static class ModuleRepositoryContract
         Assert.NotNull(loadedPackage);
         MirrorJsonAssert.Equal(package.MetadataJson, loadedPackage!.MetadataJson);
         Assert.Equal(package.SizeBytes, loadedPackage.SizeBytes);
+        Assert.Equal(package.CacheSizeBytes, loadedPackage.CacheSizeBytes);
         Assert.Equal(package.PackageStoragePath, loadedPackage.PackageStoragePath);
 
         var listed = await repository.ListModulePackagesAsync("vpc", "ready", 10, 0);

--- a/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
@@ -1,0 +1,54 @@
+using Moq;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+using TerraformRegistry.Services.Mirror;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class MirrorCacheBudgetServiceTests
+{
+    [Fact]
+    public async Task EnsuresCapacityByEvictingReadyProviderPackagesOldestFirst()
+    {
+        var providerRepository = new Mock<IProviderMirrorRepository>();
+        providerRepository.Setup(x => x.ListProviderPackagesAsync(null, "ready", 1000, 0))
+            .ReturnsAsync(
+            [
+                ProviderPackage("old", 6, DateTime.UtcNow.AddMinutes(-2)),
+                ProviderPackage("new", 4, DateTime.UtcNow.AddMinutes(-1))
+            ]);
+        providerRepository.Setup(x => x.ListProviderPackagesAsync(null, "ready", 1000, 2))
+            .ReturnsAsync([]);
+        var moduleRepository = new Mock<IModuleMirrorRepository>();
+        moduleRepository.Setup(x => x.ListModulePackagesAsync(null, "ready", 1000, 0)).ReturnsAsync([]);
+        var storage = new Mock<IProviderArtifactStorage>();
+        storage.Setup(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        var modules = new Mock<IModuleService>();
+        var service = new MirrorCacheBudgetService(providerRepository.Object, moduleRepository.Object, storage.Object, modules.Object);
+
+        var result = await service.EnsureCapacityAsync(5, 10, CancellationToken.None);
+
+        Assert.True(result);
+        storage.Verify(x => x.DeleteAsync("old", It.IsAny<CancellationToken>()), Times.Once);
+        storage.Verify(x => x.DeleteAsync("new", It.IsAny<CancellationToken>()), Times.Never);
+        providerRepository.Verify(x => x.UpsertProviderPackageAsync(It.Is<MirrorProviderPackage>(p =>
+            p.PackageStoragePath == null && p.CacheSizeBytes == 0 && p.State == "evicted")), Times.Once);
+    }
+
+    private static MirrorProviderPackage ProviderPackage(string path, long size, DateTime updatedAt) => new()
+    {
+        Hostname = "registry.example.com",
+        Namespace = "hashicorp",
+        Type = "aws",
+        Version = "1.0.0",
+        Os = "linux",
+        Arch = "amd64",
+        DownloadUrl = "https://registry.example.com/package",
+        PackageStoragePath = path,
+        SizeBytes = size,
+        CacheSizeBytes = size,
+        State = "ready",
+        LastSyncAt = updatedAt,
+        UpdatedAt = updatedAt
+    };
+}

--- a/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
@@ -35,6 +35,32 @@ public sealed class MirrorCacheBudgetServiceTests
             p.PackageStoragePath == null && p.CacheSizeBytes == 0 && p.State == "evicted")), Times.Once);
     }
 
+    [Fact]
+    public async Task EnsuresCapacitySkipsAnActiveProviderPackage()
+    {
+        var active = ProviderPackage("active", 6, DateTime.UtcNow.AddMinutes(-2));
+        var idle = ProviderPackage("idle", 6, DateTime.UtcNow.AddMinutes(-1));
+        idle = idle with { Version = "2.0.0" };
+        var providerRepository = new Mock<IProviderMirrorRepository>();
+        providerRepository.Setup(x => x.ListProviderPackagesAsync(null, "ready", 1000, 0))
+            .ReturnsAsync([active, idle]);
+        providerRepository.Setup(x => x.ListProviderPackagesAsync(null, "ready", 1000, 2)).ReturnsAsync([]);
+        var moduleRepository = new Mock<IModuleMirrorRepository>();
+        moduleRepository.Setup(x => x.ListModulePackagesAsync(null, "ready", 1000, 0)).ReturnsAsync([]);
+        var storage = new Mock<IProviderArtifactStorage>();
+        storage.Setup(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        var modules = new Mock<IModuleService>();
+        var usage = new MirrorCacheUsage();
+        using var lease = usage.Acquire("provider:registry.example.com:hashicorp:aws:1.0.0:linux:amd64");
+        var service = new MirrorCacheBudgetService(providerRepository.Object, moduleRepository.Object, storage.Object, modules.Object, usage);
+
+        var result = await service.EnsureCapacityAsync(5, 12, CancellationToken.None);
+
+        Assert.True(result);
+        storage.Verify(x => x.DeleteAsync("active", It.IsAny<CancellationToken>()), Times.Never);
+        storage.Verify(x => x.DeleteAsync("idle", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     private static MirrorProviderPackage ProviderPackage(string path, long size, DateTime updatedAt) => new()
     {
         Hostname = "registry.example.com",

--- a/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
@@ -24,7 +24,7 @@ public sealed class MirrorCacheBudgetServiceTests
         var storage = new Mock<IProviderArtifactStorage>();
         storage.Setup(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
         var modules = new Mock<IModuleService>();
-        var service = new MirrorCacheBudgetService(providerRepository.Object, moduleRepository.Object, storage.Object, modules.Object);
+        var service = new MirrorCacheBudgetService(providerRepository.Object, moduleRepository.Object, storage.Object, modules.Object, new MirrorCacheUsage());
 
         var result = await service.EnsureCapacityAsync(5, 10, CancellationToken.None);
 

--- a/TerraformRegistry.Tests/UnitTests/MirrorConfigServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorConfigServiceTests.cs
@@ -197,4 +197,17 @@ public class MirrorConfigServiceTests
 
         Assert.Contains("explicit upstream mapping", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void MirrorConfigurationRejectsAnEmptyProviderHostnameAllowlist()
+    {
+        var options = new MirrorOptions
+        {
+            Providers = new MirrorProviderRuntimeOptions { AllowedHostnames = [] }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => MirrorConfigurationValidator.Validate(options));
+
+        Assert.Contains("at least one", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/TerraformRegistry.Tests/UnitTests/MirrorConfigServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorConfigServiceTests.cs
@@ -70,6 +70,9 @@ public class MirrorConfigServiceTests
                                 "enabled": true,
                                 "requireAuthentication": false,
                                 "allowedHostnames": ["registry.terraform.io"],
+                                "upstreamRegistryUrls": {
+                                  "registry.terraform.io": "https://registry.terraform.io"
+                                },
                                 "allowlist": ["hashicorp/aws"],
                                 "denylist": ["blocked/provider"],
                                 "platforms": ["linux_amd64"],
@@ -154,5 +157,44 @@ public class MirrorConfigServiceTests
         Assert.DoesNotContain("mirror.read", Permissions.DefaultUserPermissions);
         Assert.DoesNotContain("mirror.manage", Permissions.DefaultUserPermissions);
         Assert.DoesNotContain("mirror.configure", Permissions.DefaultUserPermissions);
+    }
+
+    [Fact]
+    public void MirrorConfigurationMapsEveryAllowedProviderHostToItsOwnHttpsUpstream()
+    {
+        var options = new MirrorOptions
+        {
+            Providers = new MirrorProviderRuntimeOptions
+            {
+                AllowedHostnames = ["registry.terraform.io", "registry.example.com"],
+                UpstreamRegistryUrls = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["registry.terraform.io"] = "https://registry.terraform.io",
+                    ["registry.example.com"] = "https://mirror-upstream.example.net"
+                }
+            }
+        };
+
+        MirrorConfigurationValidator.Validate(options);
+
+        Assert.Equal(
+            "https://mirror-upstream.example.net/",
+            MirrorConfigurationValidator.GetProviderUpstreamUri(options, "registry.example.com").ToString());
+    }
+
+    [Fact]
+    public void MirrorConfigurationRejectsAnAllowedProviderHostWithoutAnExplicitMapping()
+    {
+        var options = new MirrorOptions
+        {
+            Providers = new MirrorProviderRuntimeOptions
+            {
+                AllowedHostnames = ["first.example.com", "second.example.com"]
+            }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => MirrorConfigurationValidator.Validate(options));
+
+        Assert.Contains("explicit upstream mapping", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/TerraformRegistry.Tests/UnitTests/MirrorDownloadAdmissionTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorDownloadAdmissionTests.cs
@@ -1,0 +1,52 @@
+using TerraformRegistry.Models;
+using TerraformRegistry.Services.Mirror;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class MirrorDownloadAdmissionTests
+{
+    [Fact]
+    public void AdmissionEnforcesGlobalAndPerCoordinateLimitsAndReleasesCapacity()
+    {
+        var admission = new MirrorDownloadAdmission();
+        var limits = new MirrorLimitRuntimeOptions
+        {
+            MaxConcurrentDownloads = 2,
+            MaxConcurrentDownloadsPerCoordinate = 1
+        };
+
+        using var first = admission.TryAcquire(limits, "provider:aws");
+        using var second = admission.TryAcquire(limits, "provider:azurerm");
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Null(admission.TryAcquire(limits, "provider:aws"));
+        Assert.Null(admission.TryAcquire(limits, "provider:random"));
+
+        second!.Dispose();
+
+        using var replacement = admission.TryAcquire(limits, "provider:random");
+        Assert.NotNull(replacement);
+    }
+
+    [Fact]
+    public void AdmissionAppliesReducedRuntimeLimitsImmediately()
+    {
+        var admission = new MirrorDownloadAdmission();
+        var relaxed = new MirrorLimitRuntimeOptions
+        {
+            MaxConcurrentDownloads = 2,
+            MaxConcurrentDownloadsPerCoordinate = 2
+        };
+        var strict = new MirrorLimitRuntimeOptions
+        {
+            MaxConcurrentDownloads = 1,
+            MaxConcurrentDownloadsPerCoordinate = 1
+        };
+
+        using var first = admission.TryAcquire(relaxed, "provider:aws");
+        Assert.NotNull(first);
+
+        Assert.Null(admission.TryAcquire(strict, "provider:azurerm"));
+    }
+}

--- a/TerraformRegistry.Tests/UnitTests/ModuleMirrorServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleMirrorServiceTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using TerraformRegistry.API.Interfaces;
@@ -191,6 +192,40 @@ public sealed class ModuleMirrorServiceTests
             request.Metadata.Source.Origin == "registry.example.com" &&
             request.Metadata.Source.SourceUrl == "/archives/vpc-1.2.3.zip" &&
             request.Metadata.Source.ResolvedPackageUrl == "https://registry.example.com/archives/vpc-1.2.3.zip"), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CachedMirrorDownloadRegistersItsActiveCacheCoordinate()
+    {
+        var tokens = new ArtifactDownloadTokenService(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ArtifactDownloadTokens:SigningKey"] = "test-signing-key-that-is-long-enough-to-be-safe-0123456789"
+            })
+            .Build());
+        var token = tokens.Create("module", "cache/vpc.zip", TimeSpan.FromMinutes(5));
+        var usage = new MirrorCacheUsage();
+        var moduleService = new Mock<IModuleService>();
+        moduleService.Setup(x => x.GetModuleAsync("hashicorp", "vpc", "aws", "1.2.3"))
+            .ReturnsAsync(CreateModule("cached", "mirror"));
+        var repository = new Mock<IModuleMirrorRepository>();
+        repository.Setup(x => x.GetModulePackageAsync("registry.example.com", "hashicorp", "vpc", "aws", "1.2.3"))
+            .ReturnsAsync(new MirrorModulePackage
+            {
+                Hostname = "registry.example.com",
+                Namespace = "hashicorp",
+                Name = "vpc",
+                Provider = "aws",
+                Version = "1.2.3",
+                DownloadUrl = "https://registry.example.com/archive",
+                State = "ready"
+            });
+        var service = CreateService(new RecordingHttpMessageHandler(), repository, moduleService, cacheUsage: usage, downloadTokens: tokens);
+
+        var result = await service.GetModuleDownloadPathAsync("hashicorp", "vpc", "aws", "1.2.3", $"/module/download?token={token}");
+
+        Assert.Equal($"/module/download?token={token}", result);
+        Assert.NotNull(usage.TryAcquireModuleTokenPath("cache/vpc.zip"));
     }
 
     [Fact]
@@ -585,7 +620,9 @@ public sealed class ModuleMirrorServiceTests
         IMirrorPolicyService? policyService = null,
         Mock<IMirrorLeaseService>? lease = null,
         MirrorOptions? options = null,
-        IHttpClientFactory? httpClientFactory = null)
+        IHttpClientFactory? httpClientFactory = null,
+        MirrorCacheUsage? cacheUsage = null,
+        ArtifactDownloadTokenService? downloadTokens = null)
     {
         options ??= new MirrorOptions
         {
@@ -643,7 +680,9 @@ public sealed class ModuleMirrorServiceTests
             clientFactory,
             new MirrorHttpClient(clientFactory, policyService ?? policy!.Object, NullLogger<MirrorHttpClient>.Instance),
             publish?.Object ?? Mock.Of<IModulePublishCoordinator>(),
-            NullLogger<ModuleMirrorService>.Instance);
+            NullLogger<ModuleMirrorService>.Instance,
+            cacheUsage: cacheUsage,
+            downloadTokens: downloadTokens);
     }
 
     private static MirrorPolicyService CreateRealPolicy(IReadOnlyDictionary<string, IPAddress[]> addressesByHost)

--- a/TerraformRegistry.Tests/UnitTests/ProviderMirrorServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ProviderMirrorServiceTests.cs
@@ -39,6 +39,56 @@ public sealed class ProviderMirrorServiceTests
     }
 
     [Fact]
+    public async Task ProviderIndexUsesTheUpstreamMappedToTheRequestedHostname()
+    {
+        var http = new RecordingHttpMessageHandler();
+        http.RespondJson("https://secondary-upstream.example.net/v1/providers/hashicorp/aws/versions", UpstreamVersionsJson());
+        var configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            ["Mirror:Providers:AllowedHostnames:1"] = "registry.secondary.example",
+            ["Mirror:Providers:UpstreamRegistryUrls:registry.terraform.io"] = "https://registry.example.com",
+            ["Mirror:Providers:UpstreamRegistryUrls:registry.secondary.example"] = "https://secondary-upstream.example.net"
+        });
+        var service = CreateService(http, configuration: configuration);
+
+        var index = await service.GetProviderIndexAsync(
+            "registry.secondary.example",
+            "hashicorp",
+            "aws",
+            CancellationToken.None);
+
+        Assert.NotNull(index);
+        Assert.Contains(http.Requests, uri => uri.Host == "secondary-upstream.example.net");
+        Assert.DoesNotContain(http.Requests, uri => uri.Host == "registry.example.com");
+    }
+
+    [Fact]
+    public async Task ProviderIndexCachesAnUpstreamNotFoundForTheConfiguredNegativeTtl()
+    {
+        var http = new RecordingHttpMessageHandler();
+        var repo = new Mock<IProviderMirrorRepository>();
+        repo.SetupSequence(x => x.GetProviderIndexAsync("registry.terraform.io", "hashicorp", "missing"))
+            .ReturnsAsync((MirrorProviderIndex?)null)
+            .ReturnsAsync(new MirrorProviderIndex
+            {
+                Hostname = "registry.terraform.io",
+                Namespace = "hashicorp",
+                Type = "missing",
+                VersionsJson = "{}",
+                State = "not_found",
+                LastSyncAt = DateTime.UtcNow
+            });
+        var service = CreateService(http, repo: repo);
+
+        Assert.Null(await service.GetProviderIndexAsync("registry.terraform.io", "hashicorp", "missing", CancellationToken.None));
+        Assert.Null(await service.GetProviderIndexAsync("registry.terraform.io", "hashicorp", "missing", CancellationToken.None));
+
+        Assert.Single(http.Requests);
+        repo.Verify(x => x.UpsertProviderIndexAsync(It.Is<MirrorProviderIndex>(index =>
+            index.State == "not_found" && index.LastSyncAt != null)), Times.Once);
+    }
+
+    [Fact]
     public async Task ProviderVersionDownloadsCachesAndReturnsSignedArchiveWithTerraformHash()
     {
         var packageBytes = new byte[] { 1, 2, 3 };
@@ -878,6 +928,7 @@ public sealed class ProviderMirrorServiceTests
             ["Mirror:UpstreamRegistryBaseUrl"] = "https://registry.example.com",
             ["Mirror:Providers:Enabled"] = "true",
             ["Mirror:Providers:AllowedHostnames:0"] = "registry.terraform.io",
+            ["Mirror:Providers:UpstreamRegistryUrls:registry.terraform.io"] = "https://registry.example.com",
             ["Mirror:PackageUrlSigningKey"] = "provider-mirror-service-signing-key",
             ["Oidc:JwtSecretKey"] = "provider-mirror-service-jwt-secret-key"
         };

--- a/TerraformRegistry/Handlers/MirrorHandlers.cs
+++ b/TerraformRegistry/Handlers/MirrorHandlers.cs
@@ -80,6 +80,11 @@ public static class MirrorHandlers
             return Results.Problem("Provider mirror package was not found.", statusCode: StatusCodes.Status404NotFound);
         }
 
+        if (download.CacheLease is not null)
+        {
+            context.Response.RegisterForDispose(download.CacheLease);
+        }
+
         return Results.File(
             download.Content,
             download.ContentType,

--- a/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
@@ -8,7 +8,8 @@ public sealed class MirrorCacheBudgetService(
     IProviderMirrorRepository providerRepository,
     IModuleMirrorRepository moduleRepository,
     IProviderArtifactStorage providerStorage,
-    IModuleService moduleService)
+    IModuleService moduleService,
+    MirrorCacheUsage cacheUsage)
 {
     private const int PageSize = 1000;
 
@@ -54,6 +55,10 @@ public sealed class MirrorCacheBudgetService(
     {
         if (candidate.Provider is { } provider)
         {
+            if (cacheUsage.IsInUse(ProviderKey(provider)))
+            {
+                return false;
+            }
             if (string.IsNullOrWhiteSpace(provider.PackageStoragePath) ||
                 !await providerStorage.DeleteAsync(provider.PackageStoragePath, cancellationToken))
             {
@@ -73,6 +78,10 @@ public sealed class MirrorCacheBudgetService(
         }
 
         var module = candidate.Module!;
+        if (cacheUsage.IsInUse(ModuleKey(module)))
+        {
+            return false;
+        }
         if (!await moduleService.PurgeModuleVersionAsync(module.Namespace, module.Name, module.Provider, module.Version))
         {
             return false;
@@ -116,6 +125,10 @@ public sealed class MirrorCacheBudgetService(
 
     private static long CacheBytes(MirrorProviderPackage package) => package.CacheSizeBytes ?? package.SizeBytes ?? 0;
     private static long CacheBytes(MirrorModulePackage package) => package.CacheSizeBytes ?? package.SizeBytes ?? 0;
+    internal static string ProviderKey(MirrorProviderPackage package) =>
+        $"provider:{package.Hostname}:{package.Namespace}:{package.Type}:{package.Version}:{package.Os}:{package.Arch}";
+    internal static string ModuleKey(MirrorModulePackage package) =>
+        $"module:{package.Hostname}:{package.Namespace}:{package.Name}:{package.Provider}:{package.Version}";
 
     private sealed class EvictionCandidate(MirrorProviderPackage? provider, MirrorModulePackage? module)
     {

--- a/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
@@ -1,0 +1,130 @@
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Services.Mirror;
+
+/// <summary>Maintains the configured mirror cache budget with deterministic oldest-first eviction.</summary>
+public sealed class MirrorCacheBudgetService(
+    IProviderMirrorRepository providerRepository,
+    IModuleMirrorRepository moduleRepository,
+    IProviderArtifactStorage providerStorage,
+    IModuleService moduleService)
+{
+    private const int PageSize = 1000;
+
+    public async Task<bool> EnsureCapacityAsync(long additionalBytes, long maximumBytes, CancellationToken cancellationToken)
+    {
+        if (additionalBytes < 0 || maximumBytes <= 0 || additionalBytes > maximumBytes)
+        {
+            return false;
+        }
+
+        var providers = await ListProviderPackagesAsync(cancellationToken);
+        var modules = await ListModulePackagesAsync(cancellationToken);
+        var totalBytes = providers.Sum(CacheBytes) + modules.Sum(CacheBytes);
+        if (totalBytes + additionalBytes <= maximumBytes)
+        {
+            return true;
+        }
+
+        var candidates = providers.Select(package => new EvictionCandidate(package, null))
+            .Concat(modules.Select(package => new EvictionCandidate(null, package)))
+            .OrderBy(candidate => candidate.UpdatedAt)
+            .ThenBy(candidate => candidate.Key, StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var candidate in candidates)
+        {
+            if (!await EvictAsync(candidate, cancellationToken))
+            {
+                continue;
+            }
+
+            totalBytes -= candidate.Bytes;
+            if (totalBytes + additionalBytes <= maximumBytes)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<bool> EvictAsync(EvictionCandidate candidate, CancellationToken cancellationToken)
+    {
+        if (candidate.Provider is { } provider)
+        {
+            if (string.IsNullOrWhiteSpace(provider.PackageStoragePath) ||
+                !await providerStorage.DeleteAsync(provider.PackageStoragePath, cancellationToken))
+            {
+                return false;
+            }
+
+            await providerRepository.UpsertProviderPackageAsync(provider with
+            {
+                PackageStoragePath = null,
+                SizeBytes = null,
+                CacheSizeBytes = 0,
+                State = "evicted",
+                LastError = "Evicted to enforce the mirror cache budget.",
+                LastSyncAt = DateTime.UtcNow
+            });
+            return true;
+        }
+
+        var module = candidate.Module!;
+        if (!await moduleService.PurgeModuleVersionAsync(module.Namespace, module.Name, module.Provider, module.Version))
+        {
+            return false;
+        }
+
+        await moduleRepository.UpsertModulePackageAsync(module with
+        {
+            PackageStoragePath = null,
+            SizeBytes = null,
+            CacheSizeBytes = 0,
+            State = "evicted",
+            LastError = "Evicted to enforce the mirror cache budget.",
+            LastSyncAt = DateTime.UtcNow
+        });
+        return true;
+    }
+
+    private async Task<List<MirrorProviderPackage>> ListProviderPackagesAsync(CancellationToken cancellationToken)
+    {
+        var packages = new List<MirrorProviderPackage>();
+        for (var offset = 0; ; offset += PageSize)
+        {
+            var page = await providerRepository.ListProviderPackagesAsync(null, "ready", PageSize, offset);
+            packages.AddRange(page);
+            if (page.Count < PageSize) return packages;
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+
+    private async Task<List<MirrorModulePackage>> ListModulePackagesAsync(CancellationToken cancellationToken)
+    {
+        var packages = new List<MirrorModulePackage>();
+        for (var offset = 0; ; offset += PageSize)
+        {
+            var page = await moduleRepository.ListModulePackagesAsync(null, "ready", PageSize, offset);
+            packages.AddRange(page);
+            if (page.Count < PageSize) return packages;
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+
+    private static long CacheBytes(MirrorProviderPackage package) => package.CacheSizeBytes ?? package.SizeBytes ?? 0;
+    private static long CacheBytes(MirrorModulePackage package) => package.CacheSizeBytes ?? package.SizeBytes ?? 0;
+
+    private sealed class EvictionCandidate(MirrorProviderPackage? provider, MirrorModulePackage? module)
+    {
+        public MirrorProviderPackage? Provider { get; } = provider;
+        public MirrorModulePackage? Module { get; } = module;
+        public long Bytes => Provider is not null ? CacheBytes(Provider) : CacheBytes(Module!);
+        public DateTime UpdatedAt => Provider?.UpdatedAt ?? Module!.UpdatedAt;
+        public string Key => Provider is not null
+            ? $"provider:{Provider.Hostname}:{Provider.Namespace}:{Provider.Type}:{Provider.Version}:{Provider.Os}:{Provider.Arch}"
+            : $"module:{Module!.Hostname}:{Module.Namespace}:{Module.Name}:{Module.Provider}:{Module.Version}";
+    }
+}

--- a/TerraformRegistry/Services/Mirror/MirrorCacheUsage.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorCacheUsage.cs
@@ -1,0 +1,44 @@
+using System.Collections.Concurrent;
+
+namespace TerraformRegistry.Services.Mirror;
+
+public sealed class MirrorCacheUsage
+{
+    private readonly ConcurrentDictionary<string, int> _active = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, string> _moduleCoordinatesByTokenPath = new(StringComparer.Ordinal);
+
+    public IDisposable Acquire(string key)
+    {
+        _active.AddOrUpdate(key, 1, static (_, count) => checked(count + 1));
+        return new Lease(this, key);
+    }
+
+    public bool IsInUse(string key) => _active.ContainsKey(key);
+
+    public void RegisterModuleTokenPath(string tokenPath, string coordinate) =>
+        _moduleCoordinatesByTokenPath[tokenPath] = coordinate;
+
+    public IDisposable? TryAcquireModuleTokenPath(string tokenPath) =>
+        _moduleCoordinatesByTokenPath.TryGetValue(tokenPath, out var coordinate) ? Acquire(coordinate) : null;
+
+    private void Release(string key)
+    {
+        while (_active.TryGetValue(key, out var count))
+        {
+            if (count == 1)
+            {
+                if (_active.TryRemove(new KeyValuePair<string, int>(key, count))) return;
+            }
+            else if (_active.TryUpdate(key, count - 1, count))
+            {
+                return;
+            }
+        }
+    }
+
+    private sealed class Lease(MirrorCacheUsage owner, string key) : IDisposable
+    {
+        private MirrorCacheUsage? _owner = owner;
+        public void Dispose() => Interlocked.Exchange(ref _owner, null)?.Release(key);
+    }
+}

--- a/TerraformRegistry/Services/Mirror/MirrorConfigService.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorConfigService.cs
@@ -18,13 +18,16 @@ public sealed class MirrorConfigService(IConfiguration configuration, IRuntimeSe
         var stored = await runtimeSettings.GetAsync(SettingsKey, cancellationToken);
         if (stored == null)
         {
+            MirrorConfigurationValidator.Validate(startup);
             return new MirrorConfigResponse { Effective = startup };
         }
 
         var runtime = JsonSerializer.Deserialize<MirrorConfigUpdateRequest>(stored.ValueJson, JsonOptions) ?? new();
+        var effective = Merge(startup, runtime);
+        MirrorConfigurationValidator.Validate(effective);
         return new MirrorConfigResponse
         {
-            Effective = Merge(startup, runtime),
+            Effective = effective,
             HasRuntimeOverride = true,
             UpdatedAt = stored.UpdatedAt,
             UpdatedBy = stored.UpdatedBy
@@ -36,6 +39,9 @@ public sealed class MirrorConfigService(IConfiguration configuration, IRuntimeSe
         string? updatedBy,
         CancellationToken cancellationToken)
     {
+        var startup = new MirrorOptions();
+        configuration.GetSection("Mirror").Bind(startup);
+        MirrorConfigurationValidator.Validate(Merge(startup, request));
         var json = JsonSerializer.Serialize(request, JsonOptions);
         await runtimeSettings.SetAsync(SettingsKey, json, updatedBy, cancellationToken);
         return await GetConfigAsync(cancellationToken);

--- a/TerraformRegistry/Services/Mirror/MirrorConfigurationValidator.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorConfigurationValidator.cs
@@ -14,6 +14,10 @@ public static class MirrorConfigurationValidator
             .Where(static host => !string.IsNullOrWhiteSpace(host))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
+        if (hosts.Length == 0)
+        {
+            throw new InvalidOperationException("Mirror provider configuration must allow at least one hostname.");
+        }
         if (options.Providers.UpstreamRegistryUrls.Count == 0)
         {
             var upstreamHost = new Uri(options.UpstreamRegistryBaseUrl, UriKind.Absolute).DnsSafeHost;

--- a/TerraformRegistry/Services/Mirror/MirrorConfigurationValidator.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorConfigurationValidator.cs
@@ -1,0 +1,94 @@
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Services.Mirror;
+
+public static class MirrorConfigurationValidator
+{
+    public static void Validate(MirrorOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        ValidateHttpsUri(options.UpstreamRegistryBaseUrl, "Mirror:UpstreamRegistryBaseUrl");
+
+        var hosts = options.Providers.AllowedHostnames
+            .Where(static host => !string.IsNullOrWhiteSpace(host))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (options.Providers.UpstreamRegistryUrls.Count == 0)
+        {
+            var upstreamHost = new Uri(options.UpstreamRegistryBaseUrl, UriKind.Absolute).DnsSafeHost;
+            if (!hosts.Contains(upstreamHost, StringComparer.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    "Each allowed provider hostname requires an explicit upstream mapping when it does not exactly match the legacy upstream host.");
+            }
+        }
+        else
+        {
+            foreach (var host in hosts)
+            {
+                if (!TryGetMapping(options.Providers.UpstreamRegistryUrls, host, out var upstream))
+                {
+                    throw new InvalidOperationException($"Provider hostname '{host}' requires an explicit upstream mapping.");
+                }
+
+                ValidateHttpsUri(upstream, $"Mirror:Providers:UpstreamRegistryUrls:{host}");
+            }
+
+            if (options.Providers.UpstreamRegistryUrls.Keys.Any(key => !hosts.Contains(key, StringComparer.OrdinalIgnoreCase)))
+            {
+                throw new InvalidOperationException("Provider upstream mappings must correspond to an allowed provider hostname.");
+            }
+        }
+
+        if (options.Limits.MaxConcurrentDownloads <= 0 ||
+            options.Limits.MaxConcurrentDownloadsPerCoordinate <= 0 ||
+            options.Limits.MaxConcurrentDownloadsPerCoordinate > options.Limits.MaxConcurrentDownloads ||
+            options.Limits.MaxTotalCachedBytes <= 0 ||
+            options.Limits.NegativeCacheTtlSeconds <= 0 ||
+            options.Providers.DownloadTimeoutSeconds <= 0 ||
+            options.Modules.DownloadTimeoutSeconds <= 0)
+        {
+            throw new InvalidOperationException("Mirror runtime limits must be positive and per-coordinate concurrency cannot exceed global concurrency.");
+        }
+    }
+
+    public static Uri GetProviderUpstreamUri(MirrorOptions options, string hostname)
+    {
+        Validate(options);
+        if (TryGetMapping(options.Providers.UpstreamRegistryUrls, hostname, out var upstream))
+        {
+            return ToBaseUri(upstream);
+        }
+
+        return ToBaseUri(options.UpstreamRegistryBaseUrl);
+    }
+
+    private static bool TryGetMapping(IReadOnlyDictionary<string, string> mappings, string hostname, out string upstream)
+    {
+        foreach (var mapping in mappings)
+        {
+            if (string.Equals(mapping.Key, hostname, StringComparison.OrdinalIgnoreCase))
+            {
+                upstream = mapping.Value;
+                return true;
+            }
+        }
+
+        upstream = string.Empty;
+        return false;
+    }
+
+    private static void ValidateHttpsUri(string value, string settingName)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
+            !string.IsNullOrEmpty(uri.UserInfo) ||
+            string.IsNullOrWhiteSpace(uri.DnsSafeHost))
+        {
+            throw new InvalidOperationException($"{settingName} must be an absolute HTTPS URI without userinfo.");
+        }
+    }
+
+    private static Uri ToBaseUri(string value) => new(value.TrimEnd('/') + "/", UriKind.Absolute);
+}

--- a/TerraformRegistry/Services/Mirror/MirrorDownloadAdmission.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorDownloadAdmission.cs
@@ -1,0 +1,67 @@
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Services.Mirror;
+
+/// <summary>
+/// Process-wide admission accounting for upstream mirror downloads. Limits are evaluated at
+/// acquisition time so an operator reduction takes effect before any additional fetch starts.
+/// </summary>
+public sealed class MirrorDownloadAdmission
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, int> _activeByCoordinate = new(StringComparer.Ordinal);
+    private int _activeDownloads;
+
+    public MirrorDownloadAdmissionLease? TryAcquire(MirrorLimitRuntimeOptions limits, string coordinate)
+    {
+        ArgumentNullException.ThrowIfNull(limits);
+        ArgumentException.ThrowIfNullOrWhiteSpace(coordinate);
+
+        lock (_gate)
+        {
+            if (_activeDownloads >= limits.MaxConcurrentDownloads ||
+                _activeByCoordinate.GetValueOrDefault(coordinate) >= limits.MaxConcurrentDownloadsPerCoordinate)
+            {
+                return null;
+            }
+
+            _activeDownloads++;
+            _activeByCoordinate[coordinate] = _activeByCoordinate.GetValueOrDefault(coordinate) + 1;
+            return new MirrorDownloadAdmissionLease(this, coordinate);
+        }
+    }
+
+    private void Release(string coordinate)
+    {
+        lock (_gate)
+        {
+            _activeDownloads--;
+            var coordinateActive = _activeByCoordinate[coordinate] - 1;
+            if (coordinateActive == 0)
+            {
+                _activeByCoordinate.Remove(coordinate);
+            }
+            else
+            {
+                _activeByCoordinate[coordinate] = coordinateActive;
+            }
+        }
+    }
+
+    public sealed class MirrorDownloadAdmissionLease : IDisposable
+    {
+        private MirrorDownloadAdmission? _owner;
+        private readonly string _coordinate;
+
+        internal MirrorDownloadAdmissionLease(MirrorDownloadAdmission owner, string coordinate)
+        {
+            _owner = owner;
+            _coordinate = coordinate;
+        }
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _owner, null)?.Release(_coordinate);
+        }
+    }
+}

--- a/TerraformRegistry/Services/Mirror/MirrorHttpClient.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorHttpClient.cs
@@ -13,10 +13,18 @@ public sealed class MirrorHttpClient(
     private const string ClientName = "TerraformRegistryMirror";
     private const int BufferSize = 81920;
 
+    public Task<MirrorFetchResult> FetchModuleArchiveAsync(
+        string archiveUrl,
+        long maxBytes,
+        int maxRedirects,
+        CancellationToken cancellationToken = default) =>
+        FetchModuleArchiveAsync(archiveUrl, maxBytes, maxRedirects, 120, cancellationToken);
+
     public async Task<MirrorFetchResult> FetchModuleArchiveAsync(
         string archiveUrl,
         long maxBytes,
         int maxRedirects,
+        int timeoutSeconds,
         CancellationToken cancellationToken = default)
     {
         if (maxBytes <= 0)
@@ -24,8 +32,13 @@ public sealed class MirrorHttpClient(
 
         if (maxRedirects < 0)
             throw new ArgumentOutOfRangeException(nameof(maxRedirects), "Maximum redirects must not be negative.");
+        if (timeoutSeconds <= 0)
+            throw new ArgumentOutOfRangeException(nameof(timeoutSeconds), "Timeout must be positive.");
 
-        var currentEndpoint = await policyService.ValidateModuleArchiveUrlAsync(archiveUrl, cancellationToken);
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+        var requestToken = timeout.Token;
+        var currentEndpoint = await policyService.ValidateModuleArchiveUrlAsync(archiveUrl, requestToken);
         var httpClient = httpClientFactory.CreateClient(ClientName);
 
         for (var redirectCount = 0; ; redirectCount++)
@@ -35,7 +48,7 @@ public sealed class MirrorHttpClient(
             using var response = await httpClient.SendAsync(
                 request,
                 HttpCompletionOption.ResponseHeadersRead,
-                cancellationToken);
+                requestToken);
 
             if (IsRedirect(response.StatusCode))
             {
@@ -49,13 +62,13 @@ public sealed class MirrorHttpClient(
                     ? response.Headers.Location
                     : new Uri(currentEndpoint.Uri, response.Headers.Location);
 
-                currentEndpoint = await policyService.ValidateModuleArchiveUrlAsync(redirectUri.ToString(), cancellationToken);
+                currentEndpoint = await policyService.ValidateModuleArchiveUrlAsync(redirectUri.ToString(), requestToken);
                 continue;
             }
 
             response.EnsureSuccessStatusCode();
 
-            var content = await ReadContentAsync(response, currentEndpoint.Uri, maxBytes, cancellationToken);
+            var content = await ReadContentAsync(response, currentEndpoint.Uri, maxBytes, requestToken);
             return new MirrorFetchResult
             {
                 Content = content,

--- a/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
@@ -18,11 +18,13 @@ public sealed class ModuleMirrorService(
     IHttpClientFactory httpClientFactory,
     MirrorHttpClient mirrorHttpClient,
     IModulePublishCoordinator publishCoordinator,
-    ILogger<ModuleMirrorService> logger) : IModuleMirrorService
+    ILogger<ModuleMirrorService> logger,
+    MirrorDownloadAdmission? downloadAdmission = null) : IModuleMirrorService
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private static readonly TimeSpan LeaseReleaseTimeout = TimeSpan.FromSeconds(5);
     private const string MirrorDiscoveryHttpClientName = "TerraformRegistryMirrorDiscovery";
+    private readonly MirrorDownloadAdmission _downloadAdmission = downloadAdmission ?? new MirrorDownloadAdmission();
 
     public async Task<ModuleVersions> GetModuleVersionsAsync(
         string moduleNamespace,
@@ -73,7 +75,8 @@ public sealed class ModuleMirrorService(
         var uri = BuildUpstreamUri(
             config.UpstreamRegistryBaseUrl,
             $"/v1/modules/{moduleNamespace}/{name}/{provider}/{version}");
-        using var response = await client.GetAsync(uri, cancellationToken);
+        using var timeout = CreateTimeout(config.Modules.DownloadTimeoutSeconds, cancellationToken);
+        using var response = await client.GetAsync(uri, timeout.Token);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
             return null;
@@ -138,6 +141,13 @@ public sealed class ModuleMirrorService(
         }
 
         var leaseKey = $"module-package:{hostname}:{moduleNamespace}:{name}:{provider}:{version}";
+        using var admission = _downloadAdmission.TryAcquire(config.Limits, leaseKey);
+        if (admission is null)
+        {
+            RegistryLog.Warning(logger, "Module mirror admission limit reached for {LeaseKey}", leaseKey);
+            return null;
+        }
+
         var lease = await leaseService.TryAcquireAsync(leaseKey, "module-package", TimeSpan.FromMinutes(5), cancellationToken);
         if (lease is null)
         {
@@ -177,6 +187,14 @@ public sealed class ModuleMirrorService(
     {
         var cached = await repository.GetModuleVersionsAsync(hostname, moduleNamespace, name, provider);
         if (cached is not null &&
+            string.Equals(cached.State, "not_found", StringComparison.OrdinalIgnoreCase) &&
+            cached.LastSyncAt is { } negativeSync &&
+            negativeSync.AddSeconds(config.Limits.NegativeCacheTtlSeconds) > DateTime.UtcNow)
+        {
+            return null;
+        }
+
+        if (cached is not null &&
             string.Equals(cached.State, "ready", StringComparison.OrdinalIgnoreCase) &&
             cached.LastSyncAt is { } lastSync &&
             lastSync.AddMinutes(Math.Max(1, config.Modules.MetadataTtlMinutes)) > DateTime.UtcNow)
@@ -186,9 +204,20 @@ public sealed class ModuleMirrorService(
 
         var client = httpClientFactory.CreateClient();
         var uri = BuildUpstreamUri(config.UpstreamRegistryBaseUrl, $"/v1/modules/{moduleNamespace}/{name}/{provider}/versions");
-        using var response = await client.GetAsync(uri, cancellationToken);
+        using var timeout = CreateTimeout(config.Modules.DownloadTimeoutSeconds, cancellationToken);
+        using var response = await client.GetAsync(uri, timeout.Token);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
+            await repository.UpsertModuleVersionsAsync(new MirrorModuleVersions
+            {
+                Hostname = hostname,
+                Namespace = moduleNamespace,
+                Name = name,
+                Provider = provider,
+                VersionsJson = "{}",
+                State = "not_found",
+                LastSyncAt = DateTime.UtcNow
+            });
             return null;
         }
 
@@ -300,7 +329,10 @@ public sealed class ModuleMirrorService(
             var upstreamDownloadUri = BuildUpstreamUri(
                 config.UpstreamRegistryBaseUrl,
                 $"/v1/modules/{moduleNamespace}/{name}/{provider}/{version}/download");
-            source = await GetUpstreamArchiveSourceAsync(upstreamDownloadUri, cancellationToken);
+            source = await GetUpstreamArchiveSourceAsync(
+                upstreamDownloadUri,
+                config.Modules.DownloadTimeoutSeconds,
+                cancellationToken);
 
             var replaceExistingMirror = false;
             var currentModule = await moduleService.GetModuleAsync(moduleNamespace, name, provider, version);
@@ -336,6 +368,7 @@ public sealed class ModuleMirrorService(
                 source.ArchiveUrl.ToString(),
                 config.Modules.MaxPackageBytes,
                 config.Modules.MaxRedirects,
+                config.Modules.DownloadTimeoutSeconds,
                 cancellationToken)).Content;
 
             var sizeBytes = archive.CanSeek ? archive.Length : (long?)null;
@@ -412,10 +445,12 @@ public sealed class ModuleMirrorService(
 
     private async Task<ModuleArchiveSource> GetUpstreamArchiveSourceAsync(
         Uri upstreamDownloadUri,
+        int timeoutSeconds,
         CancellationToken cancellationToken)
     {
         var client = httpClientFactory.CreateClient(MirrorDiscoveryHttpClientName);
-        using var response = await client.GetAsync(upstreamDownloadUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        using var timeout = CreateTimeout(timeoutSeconds, cancellationToken);
+        using var response = await client.GetAsync(upstreamDownloadUri, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
             throw new InvalidOperationException("Upstream module package was not found.");
@@ -611,6 +646,13 @@ public sealed class ModuleMirrorService(
 
     private static string GetUpstreamHostname(MirrorOptions config) =>
         new Uri(config.UpstreamRegistryBaseUrl.TrimEnd('/') + "/").DnsSafeHost;
+
+    private static CancellationTokenSource CreateTimeout(int timeoutSeconds, CancellationToken cancellationToken)
+    {
+        var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+        return timeout;
+    }
 
     private static string AppendPreservedHints(string localPath, ModuleArchiveSource source)
     {

--- a/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
@@ -19,7 +19,8 @@ public sealed class ModuleMirrorService(
     MirrorHttpClient mirrorHttpClient,
     IModulePublishCoordinator publishCoordinator,
     ILogger<ModuleMirrorService> logger,
-    MirrorDownloadAdmission? downloadAdmission = null) : IModuleMirrorService
+    MirrorDownloadAdmission? downloadAdmission = null,
+    MirrorCacheBudgetService? cacheBudget = null) : IModuleMirrorService
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private static readonly TimeSpan LeaseReleaseTimeout = TimeSpan.FromSeconds(5);
@@ -372,6 +373,11 @@ public sealed class ModuleMirrorService(
                 cancellationToken)).Content;
 
             var sizeBytes = archive.CanSeek ? archive.Length : (long?)null;
+            if (cacheBudget is not null && sizeBytes is { } cacheBytes &&
+                !await cacheBudget.EnsureCapacityAsync(cacheBytes, config.Limits.MaxTotalCachedBytes, cancellationToken))
+            {
+                throw new InvalidOperationException("Mirror cache budget cannot accommodate the module package.");
+            }
             var metadata = CreateMetadata(hostname, source);
             var published = await publishCoordinator.PublishAsync(new ModulePublishRequest
             {

--- a/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.WebUtilities;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.API.Logging;
 using TerraformRegistry.Models;
+using TerraformRegistry.Services;
 using TerraformRegistry.Services.Publishing;
 
 namespace TerraformRegistry.Services.Mirror;
@@ -20,12 +21,15 @@ public sealed class ModuleMirrorService(
     IModulePublishCoordinator publishCoordinator,
     ILogger<ModuleMirrorService> logger,
     MirrorDownloadAdmission? downloadAdmission = null,
-    MirrorCacheBudgetService? cacheBudget = null) : IModuleMirrorService
+    MirrorCacheBudgetService? cacheBudget = null,
+    MirrorCacheUsage? cacheUsage = null,
+    ArtifactDownloadTokenService? downloadTokens = null) : IModuleMirrorService
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private static readonly TimeSpan LeaseReleaseTimeout = TimeSpan.FromSeconds(5);
     private const string MirrorDiscoveryHttpClientName = "TerraformRegistryMirrorDiscovery";
     private readonly MirrorDownloadAdmission _downloadAdmission = downloadAdmission ?? new MirrorDownloadAdmission();
+    private readonly MirrorCacheUsage _cacheUsage = cacheUsage ?? new MirrorCacheUsage();
 
     public async Task<ModuleVersions> GetModuleVersionsAsync(
         string moduleNamespace,
@@ -432,6 +436,7 @@ public sealed class ModuleMirrorService(
                 LastSyncAt = DateTime.UtcNow
             });
 
+            RegisterModuleTokenPath(localPath, hostname, moduleNamespace, name, provider, version);
             return AppendPreservedHints(localPath, source);
         }
         catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or JsonException or IOException)
@@ -659,6 +664,16 @@ public sealed class ModuleMirrorService(
         var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeout.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
         return timeout;
+    }
+
+    private void RegisterModuleTokenPath(string localPath, string hostname, string moduleNamespace, string name, string provider, string version)
+    {
+        if (downloadTokens is null || !Uri.TryCreate(new Uri("http://localhost"), localPath, out var uri)) return;
+        var token = QueryHelpers.ParseQuery(uri.Query).TryGetValue("token", out var values) ? values.FirstOrDefault() : null;
+        if (token is not null && downloadTokens.TryValidate(token, "module", out var tokenPath))
+        {
+            _cacheUsage.RegisterModuleTokenPath(tokenPath, $"module:{hostname}:{moduleNamespace}:{name}:{provider}:{version}");
+        }
     }
 
     private static string AppendPreservedHints(string localPath, ModuleArchiveSource source)

--- a/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
@@ -420,6 +420,7 @@ public sealed class ModuleMirrorService(
                 Source = source.OriginalSource,
                 PackageStoragePath = localPath,
                 SizeBytes = sizeBytes,
+                CacheSizeBytes = sizeBytes,
                 MetadataJson = JsonSerializer.Serialize(packageMetadata, JsonOptions),
                 State = "ready",
                 LastSyncAt = DateTime.UtcNow

--- a/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
@@ -266,9 +266,13 @@ public sealed class ModuleMirrorService(
         var localPath = await moduleService.GetModuleDownloadPathAsync(moduleNamespace, name, provider, version);
         if (!string.IsNullOrWhiteSpace(localPath))
         {
-            return await IsLocalMirrorArtifactAsync(hostname, moduleNamespace, name, provider, version, cancellationToken)
-                ? AppendPackageMetadataHints(localPath, DeserializePackageMetadata(cached.MetadataJson))
-                : localPath;
+            if (await IsLocalMirrorArtifactAsync(hostname, moduleNamespace, name, provider, version, cancellationToken))
+            {
+                RegisterModuleTokenPath(localPath, hostname, moduleNamespace, name, provider, version);
+                return AppendPackageMetadataHints(localPath, DeserializePackageMetadata(cached.MetadataJson));
+            }
+
+            return localPath;
         }
 
         await repository.MarkModulePackageFailedAsync(
@@ -291,11 +295,15 @@ public sealed class ModuleMirrorService(
         CancellationToken cancellationToken)
     {
         var cached = await repository.GetModulePackageAsync(hostname, moduleNamespace, name, provider, version);
-        return cached is not null &&
-               string.Equals(cached.State, "ready", StringComparison.OrdinalIgnoreCase) &&
-               await IsLocalMirrorArtifactAsync(hostname, moduleNamespace, name, provider, version, cancellationToken)
-            ? AppendPackageMetadataHints(localDownloadPath, DeserializePackageMetadata(cached.MetadataJson))
-            : localDownloadPath;
+        if (cached is not null &&
+            string.Equals(cached.State, "ready", StringComparison.OrdinalIgnoreCase) &&
+            await IsLocalMirrorArtifactAsync(hostname, moduleNamespace, name, provider, version, cancellationToken))
+        {
+            RegisterModuleTokenPath(localDownloadPath, hostname, moduleNamespace, name, provider, version);
+            return AppendPackageMetadataHints(localDownloadPath, DeserializePackageMetadata(cached.MetadataJson));
+        }
+
+        return localDownloadPath;
     }
 
     private async Task<bool> IsLocalMirrorArtifactAsync(

--- a/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
@@ -420,6 +420,7 @@ public sealed class ProviderMirrorService(
                 Filename = metadata.Filename,
                 PackageStoragePath = packageSave.StoragePath,
                 SizeBytes = packageSave.SizeBytes,
+                CacheSizeBytes = checked(packageSave.SizeBytes + shasumsSave.SizeBytes + signatureSave.SizeBytes),
                 ProtocolsJson = JsonSerializer.Serialize(metadata.Protocols, JsonOptions),
                 HashesJson = JsonSerializer.Serialize(hashes, JsonOptions),
                 Shasum = packageSha,

--- a/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
@@ -18,7 +18,8 @@ public sealed class ProviderMirrorService(
     IMirrorLeaseService leaseService,
     IHttpClientFactory httpClientFactory,
     MirrorPackageUrlSigner signer,
-    ILogger<ProviderMirrorService> logger) : IProviderMirrorService
+    ILogger<ProviderMirrorService> logger,
+    MirrorDownloadAdmission? downloadAdmission = null) : IProviderMirrorService
 {
     private const string MirrorHttpClientName = "TerraformRegistryMirror";
     private const int BufferSize = 81920;
@@ -26,6 +27,7 @@ public sealed class ProviderMirrorService(
     private const int SignedPackageUrlLifetimeMinutes = 10;
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private static readonly object EmptyVersion = new();
+    private readonly MirrorDownloadAdmission _downloadAdmission = downloadAdmission ?? new MirrorDownloadAdmission();
 
     public async Task<ProviderMirrorIndexResponse?> GetProviderIndexAsync(
         string hostname,
@@ -182,6 +184,14 @@ public sealed class ProviderMirrorService(
     {
         var cached = await repository.GetProviderIndexAsync(hostname, providerNamespace, type);
         if (cached is not null &&
+            string.Equals(cached.State, "not_found", StringComparison.OrdinalIgnoreCase) &&
+            cached.LastSyncAt is { } negativeSync &&
+            negativeSync.AddSeconds(config.Limits.NegativeCacheTtlSeconds) > DateTime.UtcNow)
+        {
+            return null;
+        }
+
+        if (cached is not null &&
             string.Equals(cached.State, "ready", StringComparison.OrdinalIgnoreCase) &&
             cached.LastSyncAt is { } lastSync &&
             lastSync.AddMinutes(Math.Max(1, config.Providers.MetadataTtlMinutes)) > DateTime.UtcNow)
@@ -190,10 +200,20 @@ public sealed class ProviderMirrorService(
         }
 
         var client = httpClientFactory.CreateClient();
-        var uri = BuildUpstreamUri(config.UpstreamRegistryBaseUrl, $"/v1/providers/{providerNamespace}/{type}/versions");
-        using var response = await client.GetAsync(uri, cancellationToken);
+        var uri = BuildUpstreamUri(MirrorConfigurationValidator.GetProviderUpstreamUri(config, hostname).ToString(), $"/v1/providers/{providerNamespace}/{type}/versions");
+        using var timeout = CreateTimeout(config.Providers.DownloadTimeoutSeconds, cancellationToken);
+        using var response = await client.GetAsync(uri, timeout.Token);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
+            await repository.UpsertProviderIndexAsync(new MirrorProviderIndex
+            {
+                Hostname = hostname,
+                Namespace = providerNamespace,
+                Type = type,
+                VersionsJson = "{}",
+                State = "not_found",
+                LastSyncAt = DateTime.UtcNow
+            });
             return null;
         }
 
@@ -235,6 +255,13 @@ public sealed class ProviderMirrorService(
         }
 
         var leaseKey = $"provider-package:{hostname}:{providerNamespace}:{type}:{version.Version}:{platform.Os}:{platform.Arch}";
+        using var admission = _downloadAdmission.TryAcquire(config.Limits, leaseKey);
+        if (admission is null)
+        {
+            RegistryLog.Warning(logger, "Provider mirror admission limit reached for {LeaseKey}", leaseKey);
+            return null;
+        }
+
         var lease = await leaseService.TryAcquireAsync(leaseKey, "provider-package", TimeSpan.FromMinutes(5), cancellationToken);
         if (lease is null)
         {
@@ -321,9 +348,10 @@ public sealed class ProviderMirrorService(
         try
         {
             var metadataUri = BuildUpstreamUri(
-                config.UpstreamRegistryBaseUrl,
+                MirrorConfigurationValidator.GetProviderUpstreamUri(config, hostname).ToString(),
                 $"/v1/providers/{providerNamespace}/{type}/{version.Version}/download/{platform.Os}/{platform.Arch}");
-            var metadata = await client.GetFromJsonAsync<ProviderPackageResponse>(metadataUri, JsonOptions, cancellationToken);
+            using var metadataTimeout = CreateTimeout(config.Providers.DownloadTimeoutSeconds, cancellationToken);
+            var metadata = await client.GetFromJsonAsync<ProviderPackageResponse>(metadataUri, JsonOptions, metadataTimeout.Token);
             if (metadata is null)
             {
                 return null;
@@ -336,6 +364,7 @@ public sealed class ProviderMirrorService(
                 config.Providers.MaxPackageBytes,
                 config.Providers.MaxRedirects,
                 computeSha256: true,
+                config.Providers.DownloadTimeoutSeconds,
                 cancellationToken);
             var packageSha = packageArtifact.Sha256Hex ??
                              throw new InvalidOperationException("Provider package SHA-256 could not be computed.");
@@ -349,6 +378,7 @@ public sealed class ProviderMirrorService(
                 config.Providers.MaxChecksumBytes,
                 config.Providers.MaxRedirects,
                 computeSha256: false,
+                config.Providers.DownloadTimeoutSeconds,
                 cancellationToken);
             shasumsArtifact.Content.Position = 0;
             using var shasumsReader = new StreamReader(shasumsArtifact.Content, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
@@ -364,6 +394,7 @@ public sealed class ProviderMirrorService(
                 config.Providers.MaxChecksumBytes,
                 config.Providers.MaxRedirects,
                 computeSha256: false,
+                config.Providers.DownloadTimeoutSeconds,
                 cancellationToken);
             var packagePath = PackageStoragePath(hostname, providerNamespace, type, version.Version, platform.Os, platform.Arch, metadata.Filename);
             var shasumsPath = ShasumsStoragePath(hostname, providerNamespace, type, version.Version);
@@ -466,6 +497,7 @@ public sealed class ProviderMirrorService(
         long maxBytes,
         int maxRedirects,
         bool computeSha256,
+        int timeoutSeconds,
         CancellationToken cancellationToken)
     {
         if (maxBytes <= 0)
@@ -477,8 +509,14 @@ public sealed class ProviderMirrorService(
         {
             throw new ArgumentOutOfRangeException(nameof(maxRedirects), "Maximum redirects must not be negative.");
         }
+        if (timeoutSeconds <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeoutSeconds), "Timeout must be positive.");
+        }
 
-        var currentEndpoint = await policyService.ValidateProviderArtifactUrlAsync(url, cancellationToken);
+        using var timeout = CreateTimeout(timeoutSeconds, cancellationToken);
+        var requestToken = timeout.Token;
+        var currentEndpoint = await policyService.ValidateProviderArtifactUrlAsync(url, requestToken);
         var mirrorClient = httpClientFactory.CreateClient(MirrorHttpClientName);
 
         for (var redirectCount = 0; ; redirectCount++)
@@ -488,7 +526,7 @@ public sealed class ProviderMirrorService(
             using var response = await mirrorClient.SendAsync(
                 request,
                 HttpCompletionOption.ResponseHeadersRead,
-                cancellationToken);
+                requestToken);
 
             if (IsRedirect(response.StatusCode))
             {
@@ -505,12 +543,12 @@ public sealed class ProviderMirrorService(
                 var redirectUri = response.Headers.Location.IsAbsoluteUri
                     ? response.Headers.Location
                     : new Uri(currentEndpoint.Uri, response.Headers.Location);
-                currentEndpoint = await policyService.ValidateProviderArtifactUrlAsync(redirectUri.ToString(), cancellationToken);
+                currentEndpoint = await policyService.ValidateProviderArtifactUrlAsync(redirectUri.ToString(), requestToken);
                 continue;
             }
 
             response.EnsureSuccessStatusCode();
-            return await ReadArtifactToTempFileAsync(response, currentEndpoint.Uri, maxBytes, computeSha256, cancellationToken);
+            return await ReadArtifactToTempFileAsync(response, currentEndpoint.Uri, maxBytes, computeSha256, requestToken);
         }
     }
 
@@ -591,6 +629,13 @@ public sealed class ProviderMirrorService(
             or HttpStatusCode.RedirectMethod
             or HttpStatusCode.TemporaryRedirect
             or HttpStatusCode.PermanentRedirect;
+
+    private static CancellationTokenSource CreateTimeout(int timeoutSeconds, CancellationToken cancellationToken)
+    {
+        var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+        return timeout;
+    }
 
     private static ProviderMirrorIndexResponse ToNetworkMirrorIndex(UpstreamProviderVersions versions)
     {

--- a/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
@@ -19,7 +19,8 @@ public sealed class ProviderMirrorService(
     IHttpClientFactory httpClientFactory,
     MirrorPackageUrlSigner signer,
     ILogger<ProviderMirrorService> logger,
-    MirrorDownloadAdmission? downloadAdmission = null) : IProviderMirrorService
+    MirrorDownloadAdmission? downloadAdmission = null,
+    MirrorCacheBudgetService? cacheBudget = null) : IProviderMirrorService
 {
     private const string MirrorHttpClientName = "TerraformRegistryMirror";
     private const int BufferSize = 81920;
@@ -399,6 +400,12 @@ public sealed class ProviderMirrorService(
             var packagePath = PackageStoragePath(hostname, providerNamespace, type, version.Version, platform.Os, platform.Arch, metadata.Filename);
             var shasumsPath = ShasumsStoragePath(hostname, providerNamespace, type, version.Version);
             var signaturePath = $"{shasumsPath}.sig";
+            var cacheBytes = checked(packageArtifact.Length + shasumsArtifact.Length + signatureArtifact.Length);
+            if (cacheBudget is not null &&
+                !await cacheBudget.EnsureCapacityAsync(cacheBytes, config.Limits.MaxTotalCachedBytes, cancellationToken))
+            {
+                throw new InvalidOperationException("Mirror cache budget cannot accommodate the provider package.");
+            }
 
             packageArtifact.Content.Position = 0;
             var packageSave = await storage.SaveAsync(packagePath, packageArtifact.Content, cancellationToken);
@@ -420,7 +427,7 @@ public sealed class ProviderMirrorService(
                 Filename = metadata.Filename,
                 PackageStoragePath = packageSave.StoragePath,
                 SizeBytes = packageSave.SizeBytes,
-                CacheSizeBytes = checked(packageSave.SizeBytes + shasumsSave.SizeBytes + signatureSave.SizeBytes),
+                CacheSizeBytes = cacheBytes,
                 ProtocolsJson = JsonSerializer.Serialize(metadata.Protocols, JsonOptions),
                 HashesJson = JsonSerializer.Serialize(hashes, JsonOptions),
                 Shasum = packageSha,

--- a/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
@@ -20,7 +20,8 @@ public sealed class ProviderMirrorService(
     MirrorPackageUrlSigner signer,
     ILogger<ProviderMirrorService> logger,
     MirrorDownloadAdmission? downloadAdmission = null,
-    MirrorCacheBudgetService? cacheBudget = null) : IProviderMirrorService
+    MirrorCacheBudgetService? cacheBudget = null,
+    MirrorCacheUsage? cacheUsage = null) : IProviderMirrorService
 {
     private const string MirrorHttpClientName = "TerraformRegistryMirror";
     private const int BufferSize = 81920;
@@ -29,6 +30,7 @@ public sealed class ProviderMirrorService(
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private static readonly object EmptyVersion = new();
     private readonly MirrorDownloadAdmission _downloadAdmission = downloadAdmission ?? new MirrorDownloadAdmission();
+    private readonly MirrorCacheUsage _cacheUsage = cacheUsage ?? new MirrorCacheUsage();
 
     public async Task<ProviderMirrorIndexResponse?> GetProviderIndexAsync(
         string hostname,
@@ -169,11 +171,14 @@ public sealed class ProviderMirrorService(
             return null;
         }
 
+        var cacheLease = _cacheUsage.Acquire(MirrorCacheBudgetService.ProviderKey(package));
+
         return new ProviderMirrorPackageDownload(
             content,
             package.Filename ?? filename,
             "application/zip",
-            package.SizeBytes);
+            package.SizeBytes,
+            cacheLease);
     }
 
     private async Task<UpstreamProviderVersions?> GetProviderVersionsAsync(

--- a/TerraformRegistry/Services/Sqlite/SqliteModuleMirrorRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModuleMirrorRepository.cs
@@ -79,7 +79,7 @@ public sealed class SqliteModuleMirrorRepository(string connectionString) : IMod
 
         var sql = @"
             SELECT id, hostname, namespace, name, provider, version, download_url, source, package_storage_path,
-                   size_bytes, metadata_json, state, last_error, http_status_code, last_sync_at, created_at, updated_at
+                   size_bytes, cache_size_bytes, metadata_json, state, last_error, http_status_code, last_sync_at, created_at, updated_at
             FROM mirror_module_packages
             WHERE 1 = 1";
         var parameters = new List<SqliteParameter>();
@@ -130,7 +130,7 @@ public sealed class SqliteModuleMirrorRepository(string connectionString) : IMod
         await using var command = connection.CreateCommand();
         command.CommandText = @"
             SELECT id, hostname, namespace, name, provider, version, download_url, source, package_storage_path,
-                   size_bytes, metadata_json, state, last_error, http_status_code, last_sync_at, created_at, updated_at
+                   size_bytes, cache_size_bytes, metadata_json, state, last_error, http_status_code, last_sync_at, created_at, updated_at
             FROM mirror_module_packages
             WHERE hostname = $hostname AND namespace = $namespace AND name = $name
               AND provider = $provider AND version = $version";
@@ -155,15 +155,16 @@ public sealed class SqliteModuleMirrorRepository(string connectionString) : IMod
         command.CommandText = @"
             INSERT INTO mirror_module_packages (
                 id, hostname, namespace, name, provider, version, download_url, source, package_storage_path,
-                size_bytes, metadata_json, state, last_error, http_status_code, last_sync_at, created_at, updated_at)
+                size_bytes, cache_size_bytes, metadata_json, state, last_error, http_status_code, last_sync_at, created_at, updated_at)
             VALUES (
                 $id, $hostname, $namespace, $name, $provider, $version, $downloadUrl, $source, $packageStoragePath,
-                $sizeBytes, $metadataJson, $state, $lastError, $httpStatusCode, $lastSyncAt, $createdAt, $updatedAt)
+                $sizeBytes, $cacheSizeBytes, $metadataJson, $state, $lastError, $httpStatusCode, $lastSyncAt, $createdAt, $updatedAt)
             ON CONFLICT(hostname, namespace, name, provider, version) DO UPDATE SET
                 download_url = excluded.download_url,
                 source = excluded.source,
                 package_storage_path = excluded.package_storage_path,
                 size_bytes = excluded.size_bytes,
+                cache_size_bytes = excluded.cache_size_bytes,
                 metadata_json = excluded.metadata_json,
                 state = excluded.state,
                 last_error = excluded.last_error,
@@ -220,6 +221,7 @@ public sealed class SqliteModuleMirrorRepository(string connectionString) : IMod
         command.Parameters.AddWithValue("$source", DbValue(package.Source));
         command.Parameters.AddWithValue("$packageStoragePath", DbValue(package.PackageStoragePath));
         command.Parameters.AddWithValue("$sizeBytes", DbValue(package.SizeBytes));
+        command.Parameters.AddWithValue("$cacheSizeBytes", DbValue(package.CacheSizeBytes));
         command.Parameters.AddWithValue("$metadataJson", DbValue(package.MetadataJson));
         command.Parameters.AddWithValue("$state", package.State);
         command.Parameters.AddWithValue("$lastError", DbValue(package.LastError));
@@ -262,13 +264,14 @@ public sealed class SqliteModuleMirrorRepository(string connectionString) : IMod
             Source = ReadString(reader, 7),
             PackageStoragePath = ReadString(reader, 8),
             SizeBytes = reader.IsDBNull(9) ? null : reader.GetInt64(9),
-            MetadataJson = ReadString(reader, 10),
-            State = reader.GetString(11),
-            LastError = ReadString(reader, 12),
-            HttpStatusCode = reader.IsDBNull(13) ? null : reader.GetInt32(13),
-            LastSyncAt = ReadDateTime(reader, 14),
-            CreatedAt = ReadRequiredDateTime(reader, 15),
-            UpdatedAt = ReadRequiredDateTime(reader, 16)
+            CacheSizeBytes = reader.IsDBNull(10) ? null : reader.GetInt64(10),
+            MetadataJson = ReadString(reader, 11),
+            State = reader.GetString(12),
+            LastError = ReadString(reader, 13),
+            HttpStatusCode = reader.IsDBNull(14) ? null : reader.GetInt32(14),
+            LastSyncAt = ReadDateTime(reader, 15),
+            CreatedAt = ReadRequiredDateTime(reader, 16),
+            UpdatedAt = ReadRequiredDateTime(reader, 17)
         };
     }
 

--- a/TerraformRegistry/Services/Sqlite/SqliteProviderMirrorRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteProviderMirrorRepository.cs
@@ -76,7 +76,7 @@ public sealed class SqliteProviderMirrorRepository(string connectionString) : IP
 
         var sql = @"
             SELECT id, hostname, namespace, type, version, os, arch, download_url, filename, package_storage_path,
-                   size_bytes, protocols_json, hashes_json, shasum, signing_keys_json, state, last_error,
+                   size_bytes, cache_size_bytes, protocols_json, hashes_json, shasum, signing_keys_json, state, last_error,
                    http_status_code, last_sync_at, created_at, updated_at
             FROM mirror_provider_packages
             WHERE 1 = 1";
@@ -129,7 +129,7 @@ public sealed class SqliteProviderMirrorRepository(string connectionString) : IP
         await using var command = connection.CreateCommand();
         command.CommandText = @"
             SELECT id, hostname, namespace, type, version, os, arch, download_url, filename, package_storage_path,
-                   size_bytes, protocols_json, hashes_json, shasum, signing_keys_json, state, last_error,
+                   size_bytes, cache_size_bytes, protocols_json, hashes_json, shasum, signing_keys_json, state, last_error,
                    http_status_code, last_sync_at, created_at, updated_at
             FROM mirror_provider_packages
             WHERE hostname = $hostname AND namespace = $namespace AND type = $type
@@ -156,17 +156,18 @@ public sealed class SqliteProviderMirrorRepository(string connectionString) : IP
         command.CommandText = @"
             INSERT INTO mirror_provider_packages (
                 id, hostname, namespace, type, version, os, arch, download_url, filename, package_storage_path,
-                size_bytes, protocols_json, hashes_json, shasum, signing_keys_json, state, last_error,
+                size_bytes, cache_size_bytes, protocols_json, hashes_json, shasum, signing_keys_json, state, last_error,
                 http_status_code, last_sync_at, created_at, updated_at)
             VALUES (
                 $id, $hostname, $namespace, $type, $version, $os, $arch, $downloadUrl, $filename, $packageStoragePath,
-                $sizeBytes, $protocolsJson, $hashesJson, $shasum, $signingKeysJson, $state, $lastError,
+                $sizeBytes, $cacheSizeBytes, $protocolsJson, $hashesJson, $shasum, $signingKeysJson, $state, $lastError,
                 $httpStatusCode, $lastSyncAt, $createdAt, $updatedAt)
             ON CONFLICT(hostname, namespace, type, version, os, arch) DO UPDATE SET
                 download_url = excluded.download_url,
                 filename = excluded.filename,
                 package_storage_path = excluded.package_storage_path,
                 size_bytes = excluded.size_bytes,
+                cache_size_bytes = excluded.cache_size_bytes,
                 protocols_json = excluded.protocols_json,
                 hashes_json = excluded.hashes_json,
                 shasum = excluded.shasum,
@@ -237,6 +238,7 @@ public sealed class SqliteProviderMirrorRepository(string connectionString) : IP
         command.Parameters.AddWithValue("$filename", DbValue(package.Filename));
         command.Parameters.AddWithValue("$packageStoragePath", DbValue(package.PackageStoragePath));
         command.Parameters.AddWithValue("$sizeBytes", DbValue(package.SizeBytes));
+        command.Parameters.AddWithValue("$cacheSizeBytes", DbValue(package.CacheSizeBytes));
         command.Parameters.AddWithValue("$protocolsJson", package.ProtocolsJson);
         command.Parameters.AddWithValue("$hashesJson", package.HashesJson);
         command.Parameters.AddWithValue("$shasum", DbValue(package.Shasum));
@@ -282,16 +284,17 @@ public sealed class SqliteProviderMirrorRepository(string connectionString) : IP
             Filename = ReadString(reader, 8),
             PackageStoragePath = ReadString(reader, 9),
             SizeBytes = reader.IsDBNull(10) ? null : reader.GetInt64(10),
-            ProtocolsJson = reader.GetString(11),
-            HashesJson = reader.GetString(12),
-            Shasum = ReadString(reader, 13),
-            SigningKeysJson = ReadString(reader, 14),
-            State = reader.GetString(15),
-            LastError = ReadString(reader, 16),
-            HttpStatusCode = reader.IsDBNull(17) ? null : reader.GetInt32(17),
-            LastSyncAt = ReadDateTime(reader, 18),
-            CreatedAt = ReadRequiredDateTime(reader, 19),
-            UpdatedAt = ReadRequiredDateTime(reader, 20)
+            CacheSizeBytes = reader.IsDBNull(11) ? null : reader.GetInt64(11),
+            ProtocolsJson = reader.GetString(12),
+            HashesJson = reader.GetString(13),
+            Shasum = ReadString(reader, 14),
+            SigningKeysJson = ReadString(reader, 15),
+            State = reader.GetString(16),
+            LastError = ReadString(reader, 17),
+            HttpStatusCode = reader.IsDBNull(18) ? null : reader.GetInt32(18),
+            LastSyncAt = ReadDateTime(reader, 19),
+            CreatedAt = ReadRequiredDateTime(reader, 20),
+            UpdatedAt = ReadRequiredDateTime(reader, 21)
         };
     }
 

--- a/TerraformRegistry/Startup/ModuleEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/ModuleEndpointMappingExtensions.cs
@@ -2,6 +2,7 @@ using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Handlers;
 using TerraformRegistry.Models;
 using TerraformRegistry.Services;
+using TerraformRegistry.Services.Mirror;
 using TerraformRegistry.Services.Publishing;
 using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.RateLimiting;
@@ -188,6 +189,13 @@ internal static class ModuleEndpointMappingExtensions
                 await context.Response.WriteAsync("Invalid or expired download link.");
                 return;
             }
+
+            var downloadTokens = context.RequestServices.GetRequiredService<ArtifactDownloadTokenService>();
+            var cacheUsage = context.RequestServices.GetRequiredService<MirrorCacheUsage>();
+            IDisposable? cacheLease = downloadTokens.TryValidate(token, "module", out var tokenPath)
+                ? cacheUsage.TryAcquireModuleTokenPath(tokenPath)
+                : null;
+            if (cacheLease is not null) context.Response.RegisterForDispose(cacheLease);
 
             if (!File.Exists(filePath))
             {

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -432,6 +432,7 @@ internal static class ServiceRegistrationExtensions
     {
         services.AddSingleton<IMirrorConfigService, MirrorConfigService>();
         services.AddSingleton<MirrorDownloadAdmission>();
+        services.AddSingleton<MirrorCacheBudgetService>();
         services.AddSingleton<IMirrorPolicyService, MirrorPolicyService>();
         services.AddSingleton<MirrorPinnedConnectionHelper>();
         services.AddSingleton<MirrorHttpClient>();

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -48,7 +48,21 @@ internal static class ServiceRegistrationExtensions
         configuration.GetSection(ProviderUploadOptions.SectionName).Bind(providerUploadOptions);
         providerUploadOptions.Validate();
         services.AddSingleton(providerUploadOptions);
-        services.Configure<MirrorOptions>(configuration.GetSection("Mirror"));
+        services.AddOptions<MirrorOptions>()
+            .Bind(configuration.GetSection("Mirror"))
+            .Validate(options =>
+            {
+                try
+                {
+                    MirrorConfigurationValidator.Validate(options);
+                    return true;
+                }
+                catch (InvalidOperationException)
+                {
+                    return false;
+                }
+            }, "Mirror configuration must map allowed provider hostnames to valid HTTPS upstreams and use valid runtime limits.")
+            .ValidateOnStart();
         services.AddSingleton<IWebhookHostResolver, DnsWebhookHostResolver>();
         services.AddSingleton<IWebhookStreamConnector, SocketWebhookStreamConnector>();
         services.AddSingleton<WebhookPinnedConnectionHelper>();
@@ -417,6 +431,7 @@ internal static class ServiceRegistrationExtensions
     private static IServiceCollection AddMirrorServices(this IServiceCollection services)
     {
         services.AddSingleton<IMirrorConfigService, MirrorConfigService>();
+        services.AddSingleton<MirrorDownloadAdmission>();
         services.AddSingleton<IMirrorPolicyService, MirrorPolicyService>();
         services.AddSingleton<MirrorPinnedConnectionHelper>();
         services.AddSingleton<MirrorHttpClient>();

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -432,6 +432,7 @@ internal static class ServiceRegistrationExtensions
     {
         services.AddSingleton<IMirrorConfigService, MirrorConfigService>();
         services.AddSingleton<MirrorDownloadAdmission>();
+        services.AddSingleton<MirrorCacheUsage>();
         services.AddSingleton<MirrorCacheBudgetService>();
         services.AddSingleton<IMirrorPolicyService, MirrorPolicyService>();
         services.AddSingleton<MirrorPinnedConnectionHelper>();


### PR DESCRIPTION
## Summary
- validate provider upstream mappings and runtime mirror limits
- enforce bounded mirror downloads, negative caching, timeout and cache budgets
- preserve active cache artifacts while downloads are served

## Verification
- `dotnet build terraform-registry.sln --no-restore`
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --filter FullyQualifiedName~Mirror` (106 passed)
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-build --filter FullyQualifiedName~UnitTests` (360 passed)
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-build --filter FullyQualifiedName~ProviderMirrorEndpointTests` (10 passed)

The repository-wide integration runner currently leaves an orphaned VSTest host without a result summary; this PR remains gated on GitHub checks.