### PR TITLE
fix: coordinate mirror fetch ownership

### DIFF
--- a/TerraformRegistry.Tests/UnitTests/MirrorLeaseHeartbeatTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorLeaseHeartbeatTests.cs
@@ -1,0 +1,31 @@
+using Moq;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+using TerraformRegistry.Services.Mirror;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class MirrorLeaseHeartbeatTests
+{
+    [Fact]
+    public async Task MarksOwnershipLostWhenHeartbeatIsRejected()
+    {
+        var leaseService = new Mock<IMirrorLeaseService>();
+        leaseService.Setup(x => x.HeartbeatAsync(It.IsAny<MirrorLeaseHandle>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        var handle = new MirrorLeaseHandle
+        {
+            Id = Guid.NewGuid(),
+            LeaseKey = "provider:hashicorp/aws",
+            OperationType = "provider-package",
+            OwnerInstanceId = "worker-a",
+            ExpiresAt = DateTime.UtcNow.AddMinutes(5)
+        };
+
+        await using var heartbeat = new MirrorLeaseHeartbeat(leaseService.Object, handle, TimeSpan.Zero);
+
+        await heartbeat.WaitForFirstHeartbeatAsync();
+
+        Assert.True(heartbeat.IsOwnershipLost);
+    }
+}

--- a/TerraformRegistry/Services/Mirror/MirrorLeaseHeartbeat.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorLeaseHeartbeat.cs
@@ -82,6 +82,8 @@ public sealed class MirrorLeaseHeartbeat : IAsyncDisposable
         }
         catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
         {
+            // Disposal deliberately cancels the renewal delay after the fetch completes.
+            return;
         }
         finally
         {

--- a/TerraformRegistry/Services/Mirror/MirrorLeaseHeartbeat.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorLeaseHeartbeat.cs
@@ -1,0 +1,91 @@
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Services.Mirror;
+
+/// <summary>Renews a mirror lease and records ownership loss so callers can fail closed before publishing.</summary>
+public sealed class MirrorLeaseHeartbeat : IAsyncDisposable
+{
+    private readonly IMirrorLeaseService _leaseService;
+    private readonly MirrorLeaseHandle _lease;
+    private readonly TimeSpan _interval;
+    private readonly CancellationTokenSource _stopping = new();
+    private readonly TaskCompletionSource _firstHeartbeat = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly Task _runner;
+    private int _ownershipLost;
+
+    public MirrorLeaseHeartbeat(IMirrorLeaseService leaseService, MirrorLeaseHandle lease, TimeSpan interval)
+    {
+        _leaseService = leaseService;
+        _lease = lease;
+        _interval = interval;
+        _runner = RunAsync();
+    }
+
+    public bool IsOwnershipLost => Volatile.Read(ref _ownershipLost) != 0;
+
+    public Task WaitForFirstHeartbeatAsync() => _firstHeartbeat.Task;
+
+    public void ThrowIfOwnershipLost()
+    {
+        if (IsOwnershipLost)
+        {
+            throw new InvalidOperationException($"Mirror lease ownership was lost for '{_lease.LeaseKey}'.");
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _stopping.CancelAsync();
+        await _runner;
+        _stopping.Dispose();
+    }
+
+    private async Task RunAsync()
+    {
+        try
+        {
+            while (!_stopping.IsCancellationRequested)
+            {
+                if (_interval > TimeSpan.Zero)
+                {
+                    await Task.Delay(_interval, _stopping.Token);
+                }
+
+                try
+                {
+                    if (!await _leaseService.HeartbeatAsync(_lease, _stopping.Token))
+                    {
+                        Interlocked.Exchange(ref _ownershipLost, 1);
+                        return;
+                    }
+                }
+                catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch
+                {
+                    Interlocked.Exchange(ref _ownershipLost, 1);
+                    return;
+                }
+                finally
+                {
+                    _firstHeartbeat.TrySetResult();
+                }
+
+                if (_interval <= TimeSpan.Zero)
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, _stopping.Token);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            _firstHeartbeat.TrySetResult();
+        }
+    }
+}

--- a/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
@@ -146,27 +146,30 @@ public sealed class ModuleMirrorService(
         }
 
         var leaseKey = $"module-package:{hostname}:{moduleNamespace}:{name}:{provider}:{version}";
-        using var admission = _downloadAdmission.TryAcquire(config.Limits, leaseKey);
-        if (admission is null)
-        {
-            RegistryLog.Warning(logger, "Module mirror admission limit reached for {LeaseKey}", leaseKey);
-            return null;
-        }
-
         var lease = await leaseService.TryAcquireAsync(leaseKey, "module-package", TimeSpan.FromMinutes(5), cancellationToken);
         if (lease is null)
         {
-            return await GetReadyPackageLocalPathAsync(hostname, moduleNamespace, name, provider, version, cancellationToken);
+            return await WaitForReadyPackageLocalPathAsync(hostname, moduleNamespace, name, provider, version,
+                config.Modules.DownloadTimeoutSeconds, cancellationToken);
         }
 
         try
         {
+            using var admission = _downloadAdmission.TryAcquire(config.Limits, leaseKey);
+            if (admission is null)
+            {
+                RegistryLog.Warning(logger, "Module mirror admission limit reached for {LeaseKey}", leaseKey);
+                return await WaitForReadyPackageLocalPathAsync(hostname, moduleNamespace, name, provider, version,
+                    config.Modules.DownloadTimeoutSeconds, cancellationToken);
+            }
+
             cachedLocalPath = await GetReadyPackageLocalPathAsync(hostname, moduleNamespace, name, provider, version, cancellationToken);
             if (!string.IsNullOrWhiteSpace(cachedLocalPath))
             {
                 return cachedLocalPath;
             }
 
+            await using var heartbeat = new MirrorLeaseHeartbeat(leaseService, lease, TimeSpan.FromMinutes(1));
             return await FetchCacheAndCreateLocalDownloadPathAsync(
                 hostname,
                 moduleNamespace,
@@ -174,6 +177,7 @@ public sealed class ModuleMirrorService(
                 provider,
                 version,
                 config,
+                heartbeat,
                 cancellationToken);
         }
         finally
@@ -285,6 +289,21 @@ public sealed class ModuleMirrorService(
         return null;
     }
 
+    private async Task<string?> WaitForReadyPackageLocalPathAsync(
+        string hostname, string moduleNamespace, string name, string provider, string version,
+        int timeoutSeconds, CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        do
+        {
+            var localPath = await GetReadyPackageLocalPathAsync(hostname, moduleNamespace, name, provider, version, cancellationToken);
+            if (!string.IsNullOrWhiteSpace(localPath)) return localPath;
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+        } while (DateTime.UtcNow < deadline);
+
+        return await GetReadyPackageLocalPathAsync(hostname, moduleNamespace, name, provider, version, cancellationToken);
+    }
+
     private async Task<string> ApplyCachedPackageHintsAsync(
         string hostname,
         string moduleNamespace,
@@ -334,6 +353,7 @@ public sealed class ModuleMirrorService(
         string provider,
         string version,
         MirrorOptions config,
+        MirrorLeaseHeartbeat heartbeat,
         CancellationToken cancellationToken)
     {
         ModuleArchiveSource? source = null;
@@ -364,6 +384,7 @@ public sealed class ModuleMirrorService(
                 replaceExistingMirror = true;
             }
 
+            heartbeat.ThrowIfOwnershipLost();
             await repository.UpsertModulePackageAsync(new MirrorModulePackage
             {
                 Hostname = hostname,
@@ -390,6 +411,7 @@ public sealed class ModuleMirrorService(
             {
                 throw new InvalidOperationException("Mirror cache budget cannot accommodate the module package.");
             }
+            heartbeat.ThrowIfOwnershipLost();
             var metadata = CreateMetadata(hostname, source);
             var published = await publishCoordinator.PublishAsync(new ModulePublishRequest
             {
@@ -427,6 +449,7 @@ public sealed class ModuleMirrorService(
                 PreservedSuffix = source.PreservedSuffix,
                 ArchiveFormat = source.ArchiveFormat
             };
+            heartbeat.ThrowIfOwnershipLost();
             await repository.UpsertModulePackageAsync(new MirrorModulePackage
             {
                 Hostname = hostname,

--- a/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
@@ -261,28 +261,31 @@ public sealed class ProviderMirrorService(
         }
 
         var leaseKey = $"provider-package:{hostname}:{providerNamespace}:{type}:{version.Version}:{platform.Os}:{platform.Arch}";
-        using var admission = _downloadAdmission.TryAcquire(config.Limits, leaseKey);
-        if (admission is null)
-        {
-            RegistryLog.Warning(logger, "Provider mirror admission limit reached for {LeaseKey}", leaseKey);
-            return null;
-        }
-
         var lease = await leaseService.TryAcquireAsync(leaseKey, "provider-package", TimeSpan.FromMinutes(5), cancellationToken);
         if (lease is null)
         {
-            return await GetReadyPackageAsync(hostname, providerNamespace, type, version.Version, platform.Os, platform.Arch, cancellationToken);
+            return await WaitForReadyPackageAsync(hostname, providerNamespace, type, version.Version, platform.Os, platform.Arch,
+                config.Providers.DownloadTimeoutSeconds, cancellationToken);
         }
 
         try
         {
+            using var admission = _downloadAdmission.TryAcquire(config.Limits, leaseKey);
+            if (admission is null)
+            {
+                RegistryLog.Warning(logger, "Provider mirror admission limit reached for {LeaseKey}", leaseKey);
+                return await WaitForReadyPackageAsync(hostname, providerNamespace, type, version.Version, platform.Os, platform.Arch,
+                    config.Providers.DownloadTimeoutSeconds, cancellationToken);
+            }
+
             cached = await GetReadyPackageAsync(hostname, providerNamespace, type, version.Version, platform.Os, platform.Arch, cancellationToken);
             if (cached is not null)
             {
                 return cached;
             }
 
-            return await FetchAndCachePackageAsync(hostname, providerNamespace, type, version, platform, config, cancellationToken);
+            await using var heartbeat = new MirrorLeaseHeartbeat(leaseService, lease, TimeSpan.FromMinutes(1));
+            return await FetchAndCachePackageAsync(hostname, providerNamespace, type, version, platform, config, heartbeat, cancellationToken);
         }
         finally
         {
@@ -341,6 +344,21 @@ public sealed class ProviderMirrorService(
         return null;
     }
 
+    private async Task<MirrorProviderPackage?> WaitForReadyPackageAsync(
+        string hostname, string providerNamespace, string type, string version, string os, string arch,
+        int timeoutSeconds, CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        do
+        {
+            var cached = await GetReadyPackageAsync(hostname, providerNamespace, type, version, os, arch, cancellationToken);
+            if (cached is not null) return cached;
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+        } while (DateTime.UtcNow < deadline);
+
+        return await GetReadyPackageAsync(hostname, providerNamespace, type, version, os, arch, cancellationToken);
+    }
+
     private async Task<MirrorProviderPackage?> FetchAndCachePackageAsync(
         string hostname,
         string providerNamespace,
@@ -348,6 +366,7 @@ public sealed class ProviderMirrorService(
         UpstreamProviderVersion version,
         UpstreamProviderPlatform platform,
         MirrorOptions config,
+        MirrorLeaseHeartbeat heartbeat,
         CancellationToken cancellationToken)
     {
         var client = httpClientFactory.CreateClient();
@@ -412,6 +431,8 @@ public sealed class ProviderMirrorService(
                 throw new InvalidOperationException("Mirror cache budget cannot accommodate the provider package.");
             }
 
+            heartbeat.ThrowIfOwnershipLost();
+
             packageArtifact.Content.Position = 0;
             var packageSave = await storage.SaveAsync(packagePath, packageArtifact.Content, cancellationToken);
             shasumsArtifact.Content.Position = 0;
@@ -447,6 +468,7 @@ public sealed class ProviderMirrorService(
                 LastSyncAt = DateTime.UtcNow
             };
 
+            heartbeat.ThrowIfOwnershipLost();
             await repository.UpsertProviderPackageAsync(package);
             return package;
         }


### PR DESCRIPTION
## Summary
- resolve the distributed mirror lease before local admission
- wait for the lease owner to publish instead of returning transient cache misses
- renew long-running ownership and fail closed when ownership is lost

## Verification
- `dotnet build terraform-registry.sln --no-restore`
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --filter FullyQualifiedName~UnitTests` (361 passed)
- focused lease, provider, and module mirror tests (46 passed)

The 100-concurrent-miss acceptance scenario remains in the mirror containment gate package, where it can exercise the complete endpoint path.