### PR TITLE
perf: fetch provider archives on demand

### DIFF
--- a/TerraformRegistry.Tests/UnitTests/ProviderMirrorServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ProviderMirrorServiceTests.cs
@@ -89,7 +89,7 @@ public sealed class ProviderMirrorServiceTests
     }
 
     [Fact]
-    public async Task ProviderVersionDownloadsCachesAndReturnsSignedArchiveWithTerraformHash()
+    public async Task ProviderVersionCachesVerificationSidecarsWithoutDownloadingThePlatformArchive()
     {
         var packageBytes = new byte[] { 1, 2, 3 };
         var shasum = Convert.ToHexString(SHA256.HashData(packageBytes)).ToLowerInvariant();
@@ -112,16 +112,8 @@ public sealed class ProviderMirrorServiceTests
         http.RespondText("https://releases.example.com/SHA256SUMS", $"{shasum}  {filename}\n");
         http.RespondBytes("https://releases.example.com/SHA256SUMS.sig", [9, 8, 7], "application/octet-stream");
         var storage = new InMemoryProviderArtifactStorage();
-        var repo = new Mock<IProviderMirrorRepository>();
-        repo.Setup(x => x.GetProviderPackageAsync(
-                "registry.terraform.io",
-                "hashicorp",
-                "aws",
-                "5.0.0",
-                "linux",
-                "amd64"))
-            .ReturnsAsync((MirrorProviderPackage?)null);
-        var service = CreateService(http, repo, storage);
+        var repository = new InMemoryProviderMirrorRepository();
+        var service = CreateServiceWithRepository(http, repository, storage);
 
         var version = await service.GetProviderVersionAsync(
             "registry.terraform.io",
@@ -137,15 +129,21 @@ public sealed class ProviderMirrorServiceTests
         var hash = Assert.Single(archive.Value.Hashes);
         Assert.Equal($"zh:{shasum}", hash);
         Assert.DoesNotContain(shasum, archive.Value.Hashes);
-        Assert.Contains(storage.Paths, path => path.EndsWith(filename, StringComparison.Ordinal));
+        Assert.DoesNotContain(storage.Paths, path => path.EndsWith(filename, StringComparison.Ordinal));
         Assert.Contains(storage.Paths, path => path.EndsWith("terraform-provider-aws_5.0.0_SHA256SUMS", StringComparison.Ordinal));
         Assert.Contains(storage.Paths, path => path.EndsWith("terraform-provider-aws_5.0.0_SHA256SUMS.sig", StringComparison.Ordinal));
-        repo.Verify(x => x.UpsertProviderPackageAsync(It.Is<MirrorProviderPackage>(package =>
-            package.State == "ready" &&
-            package.PackageStoragePath != null &&
-            package.HashesJson == JsonSerializer.Serialize(new[] { $"zh:{shasum}" }) &&
-            package.SigningKeysJson != null &&
-            package.SigningKeysJson.Contains("\"signature_verification\":\"not_verified\"", StringComparison.Ordinal))), Times.Once);
+        var download = await service.OpenPackageAsync(
+            "registry.terraform.io",
+            "hashicorp",
+            "aws",
+            filename,
+            QueryFromUrl(archive.Value.Url),
+            CancellationToken.None);
+        Assert.NotNull(download);
+        await using var content = download!.Content;
+        using var downloaded = new MemoryStream();
+        await content.CopyToAsync(downloaded);
+        Assert.Equal(packageBytes, downloaded.ToArray());
     }
 
     [Fact]
@@ -273,7 +271,7 @@ public sealed class ProviderMirrorServiceTests
     }
 
     [Fact]
-    public async Task ProviderVersionReleasesLeaseWithUncancelledTokenWhenRequestIsCancelled()
+    public async Task ProviderVersionCancellationDoesNotAcquireAnArchiveLease()
     {
         var http = new RecordingHttpMessageHandler();
         var repo = new Mock<IProviderMirrorRepository>();
@@ -350,8 +348,8 @@ public sealed class ProviderMirrorServiceTests
             "5.0.0",
             cts.Token));
 
-        lease.Verify(x => x.ReleaseAsync(handle, It.IsAny<CancellationToken>()), Times.Once);
-        Assert.False(releaseToken.IsCancellationRequested);
+        lease.Verify(x => x.TryAcquireAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()), Times.Never);
+        lease.Verify(x => x.ReleaseAsync(handle, It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -452,6 +450,11 @@ public sealed class ProviderMirrorServiceTests
 
         Assert.NotNull(result);
         Assert.Contains(http.Requests, uri => uri.Host == "releases.example.com");
+        Assert.DoesNotContain(http.Requests, uri => uri.Host == "cdn.example.com");
+        var archive = Assert.Single(result!.Archives);
+        var download = await service.OpenPackageAsync("registry.terraform.io", "hashicorp", "aws", ExpectedFilename,
+            QueryFromUrl(archive.Value.Url), CancellationToken.None);
+        Assert.NotNull(download);
         Assert.Contains(http.Requests, uri => uri.Host == "cdn.example.com");
     }
 
@@ -484,8 +487,13 @@ public sealed class ProviderMirrorServiceTests
             "5.0.0",
             CancellationToken.None);
 
-        Assert.Null(result);
+        Assert.NotNull(result);
         Assert.Contains(http.Requests, uri => uri.Host == "releases.example.com");
+        Assert.DoesNotContain(http.Requests, uri => uri.Host == "private.example.com");
+        var archive = Assert.Single(result!.Archives);
+        var download = await service.OpenPackageAsync("registry.terraform.io", "hashicorp", "aws", ExpectedFilename,
+            QueryFromUrl(archive.Value.Url), CancellationToken.None);
+        Assert.Null(download);
         Assert.DoesNotContain(http.Requests, uri => uri.Host == "private.example.com");
     }
 
@@ -512,8 +520,11 @@ public sealed class ProviderMirrorServiceTests
             "5.0.0",
             CancellationToken.None);
 
-        Assert.Null(result);
-        repo.Verify(x => x.UpsertProviderPackageAsync(It.IsAny<MirrorProviderPackage>()), Times.Never);
+        Assert.NotNull(result);
+        var archive = Assert.Single(result!.Archives);
+        var download = await service.OpenPackageAsync("registry.terraform.io", "hashicorp", "aws", ExpectedFilename,
+            QueryFromUrl(archive.Value.Url), CancellationToken.None);
+        Assert.Null(download);
     }
 
     [Fact]
@@ -879,7 +890,8 @@ public sealed class ProviderMirrorServiceTests
 
     private static ProviderMirrorService CreateServiceWithRepository(
         RecordingHttpMessageHandler http,
-        IProviderMirrorRepository repository)
+        IProviderMirrorRepository repository,
+        InMemoryProviderArtifactStorage? storage = null)
     {
         var configuration = CreateConfiguration();
         var settings = new Mock<IRuntimeSettingsService>();
@@ -911,7 +923,7 @@ public sealed class ProviderMirrorServiceTests
 
         return new ProviderMirrorService(
             repository,
-            new InMemoryProviderArtifactStorage(),
+            storage ?? new InMemoryProviderArtifactStorage(),
             policy.Object,
             configService,
             lease.Object,

--- a/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
@@ -86,7 +86,7 @@ public sealed class ProviderMirrorService(
                 continue;
             }
 
-            var package = await GetOrFetchPackageAsync(
+            var package = await GetOrFetchPackageMetadataAsync(
                 hostname,
                 providerNamespace,
                 type,
@@ -154,7 +154,27 @@ public sealed class ProviderMirrorService(
             !string.Equals(package.Filename, claims.Filename, StringComparison.Ordinal) ||
             string.IsNullOrWhiteSpace(package.PackageStoragePath))
         {
-            return null;
+            var config = (await configService.GetConfigAsync(cancellationToken)).Effective;
+            if (!config.Enabled || !config.Providers.Enabled ||
+                !await policyService.IsProviderAllowedAsync(claims.Hostname, claims.Namespace, claims.Type, claims.Os, claims.Arch, cancellationToken))
+            {
+                return null;
+            }
+
+            package = await GetOrFetchPackageAsync(
+                claims.Hostname,
+                claims.Namespace,
+                claims.Type,
+                new UpstreamProviderVersion { Version = claims.Version },
+                new UpstreamProviderPlatform { Os = claims.Os, Arch = claims.Arch },
+                config,
+                cancellationToken);
+            if (package is null ||
+                !string.Equals(package.Filename, claims.Filename, StringComparison.Ordinal) ||
+                string.IsNullOrWhiteSpace(package.PackageStoragePath))
+            {
+                return null;
+            }
         }
 
         var content = await storage.OpenReadAsync(package.PackageStoragePath, cancellationToken);
@@ -290,6 +310,78 @@ public sealed class ProviderMirrorService(
         finally
         {
             await ReleaseLeaseAsync(lease);
+        }
+    }
+
+    private async Task<MirrorProviderPackage?> GetOrFetchPackageMetadataAsync(
+        string hostname, string providerNamespace, string type, UpstreamProviderVersion version,
+        UpstreamProviderPlatform platform, MirrorOptions config, CancellationToken cancellationToken)
+    {
+        var client = httpClientFactory.CreateClient();
+        try
+        {
+            var uri = BuildUpstreamUri(MirrorConfigurationValidator.GetProviderUpstreamUri(config, hostname).ToString(),
+                $"/v1/providers/{providerNamespace}/{type}/{version.Version}/download/{platform.Os}/{platform.Arch}");
+            using var timeout = CreateTimeout(config.Providers.DownloadTimeoutSeconds, cancellationToken);
+            var metadata = await client.GetFromJsonAsync<ProviderPackageResponse>(uri, JsonOptions, timeout.Token);
+            if (metadata is null) return null;
+            ValidateUpstreamPackageMetadata(type, version.Version, platform, metadata);
+            await policyService.ValidateProviderArtifactUrlAsync(metadata.DownloadUrl, cancellationToken);
+
+            await using var shasums = await DownloadArtifactToTempFileAsync(metadata.ShasumsUrl, config.Providers.MaxChecksumBytes,
+                config.Providers.MaxRedirects, false, config.Providers.DownloadTimeoutSeconds, cancellationToken);
+            shasums.Content.Position = 0;
+            using var reader = new StreamReader(shasums.Content, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+            var text = await reader.ReadToEndAsync(cancellationToken);
+            if (!string.Equals(FindShasumsEntry(text, metadata.Filename), metadata.Shasum, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("Provider package SHA-256 did not match upstream SHA256SUMS entry.");
+            await using var signature = await DownloadArtifactToTempFileAsync(metadata.ShasumsSignatureUrl, config.Providers.MaxChecksumBytes,
+                config.Providers.MaxRedirects, false, config.Providers.DownloadTimeoutSeconds, cancellationToken);
+            var sidecarPath = ShasumsStoragePath(hostname, providerNamespace, type, version.Version);
+            shasums.Content.Position = 0;
+            var shasumsSave = await storage.SaveAsync(sidecarPath, shasums.Content, cancellationToken);
+            signature.Content.Position = 0;
+            var signatureSave = await storage.SaveAsync($"{sidecarPath}.sig", signature.Content, cancellationToken);
+            var package = new MirrorProviderPackage
+            {
+                Hostname = hostname,
+                Namespace = providerNamespace,
+                Type = type,
+                Version = version.Version,
+                Os = platform.Os,
+                Arch = platform.Arch,
+                DownloadUrl = metadata.DownloadUrl,
+                Filename = metadata.Filename,
+                CacheSizeBytes = checked(shasums.Length + signature.Length),
+                ProtocolsJson = JsonSerializer.Serialize(metadata.Protocols, JsonOptions),
+                HashesJson = JsonSerializer.Serialize(new[] { $"zh:{metadata.Shasum}" }, JsonOptions),
+                Shasum = metadata.Shasum,
+                SigningKeysJson = JsonSerializer.Serialize(new
+                {
+                    signing_keys = metadata.SigningKeys,
+                    signature_verification = "not_verified",
+                    shasums_storage_path = shasumsSave.StoragePath,
+                    shasums_signature_storage_path = signatureSave.StoragePath
+                }, JsonOptions),
+                State = "pending",
+                LastSyncAt = DateTime.UtcNow
+            };
+            await repository.UpsertProviderPackageAsync(package);
+            return package;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or JsonException or IOException)
+        {
+            RegistryLog.Warning(logger, ex, "Provider mirror metadata fetch failed for {Hostname}/{Namespace}/{Type}/{Version}/{Os}/{Arch}", hostname, providerNamespace, type, version.Version, platform.Os, platform.Arch);
+            await repository.MarkProviderPackageFailedAsync(
+                hostname,
+                providerNamespace,
+                type,
+                version.Version,
+                platform.Os,
+                platform.Arch,
+                ex.Message,
+                ex is HttpRequestException httpEx ? (int?)httpEx.StatusCode : null);
+            return null;
         }
     }
 


### PR DESCRIPTION
## Summary
- advertise provider platforms after metadata and checksum-sidecar validation
- defer provider archive transfer and hash verification to the signed package request
- retain SSRF, redirect, size, and failure-state protections at their execution boundary

## Verification
- `dotnet build terraform-registry.sln --no-restore`
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --filter FullyQualifiedName~ProviderMirrorServiceTests` (22 passed)

The hygiene scan reports only the pre-existing ModuleExtraction empty catches and timing-test warning.