### PR TITLE
fix: address mirror review findings

### DIFF
--- a/TerraformRegistry.Tests/UnitTests/ProviderMirrorServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ProviderMirrorServiceTests.cs
@@ -68,7 +68,7 @@ public sealed class ProviderMirrorServiceTests
         var http = new RecordingHttpMessageHandler();
         var repo = new Mock<IProviderMirrorRepository>();
         repo.SetupSequence(x => x.GetProviderIndexAsync("registry.terraform.io", "hashicorp", "missing"))
-            .ReturnsAsync((MirrorProviderIndex?)null)
+            .ReturnsAsync(default(MirrorProviderIndex))
             .ReturnsAsync(new MirrorProviderIndex
             {
                 Hostname = "registry.terraform.io",

--- a/TerraformRegistry/Services/Mirror/MirrorConfigurationValidator.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorConfigurationValidator.cs
@@ -70,13 +70,10 @@ public static class MirrorConfigurationValidator
 
     private static bool TryGetMapping(IReadOnlyDictionary<string, string> mappings, string hostname, out string upstream)
     {
-        foreach (var mapping in mappings)
+        foreach (var mapping in mappings.Where(mapping => string.Equals(mapping.Key, hostname, StringComparison.OrdinalIgnoreCase)))
         {
-            if (string.Equals(mapping.Key, hostname, StringComparison.OrdinalIgnoreCase))
-            {
-                upstream = mapping.Value;
-                return true;
-            }
+            upstream = mapping.Value;
+            return true;
         }
 
         upstream = string.Empty;

--- a/TerraformRegistry/Services/Mirror/MirrorLeaseHeartbeat.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorLeaseHeartbeat.cs
@@ -64,7 +64,17 @@ public sealed class MirrorLeaseHeartbeat : IAsyncDisposable
                 {
                     return;
                 }
-                catch
+                catch (TimeoutException)
+                {
+                    Interlocked.Exchange(ref _ownershipLost, 1);
+                    return;
+                }
+                catch (System.Data.Common.DbException)
+                {
+                    Interlocked.Exchange(ref _ownershipLost, 1);
+                    return;
+                }
+                catch (IOException)
                 {
                     Interlocked.Exchange(ref _ownershipLost, 1);
                     return;


### PR DESCRIPTION
Addresses the CodeQL review findings on integration PR #91.

- removes the unnecessary null conversion in the test setup
- makes hostname mapping filtering explicit
- narrows heartbeat failure handling to expected persistence/transient failures while preserving fail-closed lease ownership behavior

Verification:
- `dotnet build terraform-registry.sln --no-restore -c Release`
- focused mirror service and heartbeat tests: 25 passed