### PR TITLE
perf: page module coordinates in SQL

### DIFF
--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleRepository.cs
@@ -17,67 +17,25 @@ public sealed class PostgreSqlModuleRepository(
 {
     public async Task<ModuleList> ListModulesAsync(ModuleSearchRequest request)
     {
-        var rows = new List<ModuleRow>();
-        var conditions = new List<string>();
-        var parameters = new List<NpgsqlParameter>();
-        var paramCounter = 0;
-
-        var sql = @"
-            SELECT 
-                m.namespace,
-                m.name,
-                m.provider,
-                m.version,
-                m.description,
-                m.published_at
-            FROM 
-                modules m
-            WHERE m.deleted_at IS NULL";
-
-        if (!string.IsNullOrWhiteSpace(request.Namespace))
-        {
-            conditions.Add($" AND m.namespace = @p{paramCounter}");
-            parameters.Add(new NpgsqlParameter($"@p{paramCounter}", request.Namespace));
-            paramCounter++;
-        }
-
-        if (!string.IsNullOrWhiteSpace(request.Provider))
-        {
-            conditions.Add($" AND m.provider = @p{paramCounter}");
-            parameters.Add(new NpgsqlParameter($"@p{paramCounter}", request.Provider));
-        }
-
-        sql += string.Join(" ", conditions);
-        sql += " ORDER BY m.namespace, m.name, m.provider";
-
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync();
+        var (whereClause, parameters) = BuildListFilter(request);
+        await using var countCommand = new NpgsqlCommand($"SELECT COUNT(*) FROM (SELECT 1 FROM modules m {whereClause} GROUP BY m.namespace, m.name, m.provider) coordinates", connection);
+        AddParameters(countCommand, parameters);
+        var total = Convert.ToInt32(await countCommand.ExecuteScalarAsync(), CultureInfo.InvariantCulture);
 
-        await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddRange(parameters.ToArray());
-
-        await using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        var coordinates = new List<(string Namespace, string Name, string Provider)>();
+        await using (var pageCommand = new NpgsqlCommand($"SELECT m.namespace, m.name, m.provider FROM modules m {whereClause} GROUP BY m.namespace, m.name, m.provider ORDER BY m.namespace, m.name, m.provider LIMIT @limit OFFSET @offset", connection))
         {
-            var namespace_ = reader.GetString(0);
-            var name = reader.GetString(1);
-            var provider = reader.GetString(2);
-            var version = reader.GetString(3);
-            var description = reader.IsDBNull(4) ? string.Empty : reader.GetString(4);
-            var publishedAt = reader.GetDateTime(5);
-
-            rows.Add(new ModuleRow
-            {
-                Namespace = namespace_,
-                Name = name,
-                Version = version,
-                Provider = provider,
-                Description = description,
-                PublishedAt = publishedAt.ToString("o", CultureInfo.InvariantCulture)
-            });
+            AddParameters(pageCommand, parameters);
+            pageCommand.Parameters.AddWithValue("@limit", request.Limit);
+            pageCommand.Parameters.AddWithValue("@offset", request.Offset);
+            await using var reader = await pageCommand.ExecuteReaderAsync();
+            while (await reader.ReadAsync()) coordinates.Add((reader.GetString(0), reader.GetString(1), reader.GetString(2)));
         }
 
-        var listedRows = rows
+        var rows = await GetPageRowsAsync(connection, coordinates);
+        var modules = rows
             .GroupBy(row => new { row.Namespace, row.Name, row.Provider })
             .Select(group =>
             {
@@ -89,19 +47,9 @@ public sealed class PostgreSqlModuleRepository(
                 latest.Versions = versions;
                 return latest;
             })
-            .Where(row => string.IsNullOrWhiteSpace(request.Q)
-                || row.Name.Contains(request.Q, StringComparison.OrdinalIgnoreCase)
-                || row.Description.Contains(request.Q, StringComparison.OrdinalIgnoreCase))
             .OrderBy(row => row.Namespace, StringComparer.Ordinal)
             .ThenBy(row => row.Name, StringComparer.Ordinal)
             .ThenBy(row => row.Provider, StringComparer.Ordinal)
-            .ToList();
-
-        var total = listedRows.Count;
-
-        var modules = listedRows
-            .Skip(request.Offset)
-            .Take(request.Limit)
             .Select(row => new ModuleListItem
             {
                 Id = $"{row.Namespace}/{row.Name}/{row.Provider}",
@@ -128,6 +76,41 @@ public sealed class PostgreSqlModuleRepository(
                 { "total", total.ToString(CultureInfo.InvariantCulture) }
             }
         };
+    }
+
+    private static (string WhereClause, IReadOnlyList<NpgsqlParameter> Parameters) BuildListFilter(ModuleSearchRequest request)
+    {
+        var conditions = new List<string> { "m.deleted_at IS NULL" };
+        var parameters = new List<NpgsqlParameter>();
+        if (!string.IsNullOrWhiteSpace(request.Namespace)) { conditions.Add("m.namespace = @ns"); parameters.Add(new NpgsqlParameter("@ns", request.Namespace)); }
+        if (!string.IsNullOrWhiteSpace(request.Provider)) { conditions.Add("m.provider = @provider"); parameters.Add(new NpgsqlParameter("@provider", request.Provider)); }
+        if (!string.IsNullOrWhiteSpace(request.Q)) { conditions.Add("(strpos(lower(m.name), lower(@q)) > 0 OR strpos(lower(COALESCE(m.description, '')), lower(@q)) > 0)"); parameters.Add(new NpgsqlParameter("@q", request.Q)); }
+        return ($"WHERE {string.Join(" AND ", conditions)}", parameters);
+    }
+
+    private static void AddParameters(NpgsqlCommand command, IReadOnlyList<NpgsqlParameter> parameters)
+    {
+        foreach (var parameter in parameters) command.Parameters.Add(new NpgsqlParameter(parameter.ParameterName, parameter.Value));
+    }
+
+    private static async Task<List<ModuleRow>> GetPageRowsAsync(NpgsqlConnection connection, List<(string Namespace, string Name, string Provider)> coordinates)
+    {
+        if (coordinates.Count == 0) return [];
+        await using var command = new NpgsqlCommand();
+        command.Connection = connection;
+        var values = new List<string>();
+        for (var index = 0; index < coordinates.Count; index++)
+        {
+            values.Add($"(@ns{index}, @name{index}, @provider{index})");
+            command.Parameters.AddWithValue($"@ns{index}", coordinates[index].Namespace);
+            command.Parameters.AddWithValue($"@name{index}", coordinates[index].Name);
+            command.Parameters.AddWithValue($"@provider{index}", coordinates[index].Provider);
+        }
+        command.CommandText = $"WITH page(namespace, name, provider) AS (VALUES {string.Join(", ", values)}) SELECT m.namespace, m.name, m.provider, m.version, m.description, m.published_at FROM modules m JOIN page p ON p.namespace = m.namespace AND p.name = m.name AND p.provider = m.provider WHERE m.deleted_at IS NULL";
+        var rows = new List<ModuleRow>();
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync()) rows.Add(new ModuleRow { Namespace = reader.GetString(0), Name = reader.GetString(1), Provider = reader.GetString(2), Version = reader.GetString(3), Description = reader.IsDBNull(4) ? string.Empty : reader.GetString(4), PublishedAt = reader.GetDateTime(5).ToString("o", CultureInfo.InvariantCulture) });
+        return rows;
     }
 
     /// <summary>

--- a/TerraformRegistry.Tests/IntegrationTests/UploadAndListModulesTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/UploadAndListModulesTests.cs
@@ -64,4 +64,29 @@ public class UploadAndListModulesTests(ITestOutputHelper output) : UploadModuleT
 
         Assert.Equal("1.10.0", module.GetProperty("version").GetString());
     }
+
+    [Fact]
+    public async Task ListModulesPagesCoordinatesAndKeepsVersionsForTheSelectedCoordinate()
+    {
+        var client = Factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AuthToken);
+
+        foreach (var (name, version) in new[]
+                 {
+                     ("alpha", "1.0.0"), ("alpha", "2.0.0"), ("bravo", "1.0.0"), ("charlie", "1.0.0")
+                 })
+        {
+            using var content = CreateModuleUploadContent();
+            var response = await client.PostAsync($"/v1/modules/test-ns/{name}/test-provider/{version}", content);
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        }
+
+        var responsePage = await client.GetAsync("/v1/modules?namespace=test-ns&provider=test-provider&offset=1&limit=1");
+        Assert.Equal(HttpStatusCode.OK, responsePage.StatusCode);
+        using var json = JsonDocument.Parse(await responsePage.Content.ReadAsStringAsync());
+        var module = Assert.Single(json.RootElement.GetProperty("modules").EnumerateArray());
+
+        Assert.Equal("bravo", module.GetProperty("name").GetString());
+        Assert.Equal("3", json.RootElement.GetProperty("meta").GetProperty("total").GetString());
+    }
 }

--- a/TerraformRegistry.Tests/UnitTests/Database/SqliteDatabaseServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/SqliteDatabaseServiceTests.cs
@@ -173,6 +173,40 @@ public class SqliteDatabaseServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ListModulesPagesCoordinatesWhileReturningAllVersionsForThePage()
+    {
+        var svc = CreateService(_connectionString);
+        await (svc as IInitializableDb).InitializeDatabase();
+
+        await svc.AddModuleAsync(MakeModule(name: "alpha", version: "1.0.0"));
+        await svc.AddModuleAsync(MakeModule(name: "alpha", version: "2.0.0"));
+        await svc.AddModuleAsync(MakeModule(name: "bravo", version: "1.0.0"));
+        await svc.AddModuleAsync(MakeModule(name: "charlie", version: "1.0.0"));
+
+        var page = await svc.ListModulesAsync(new ModuleSearchRequest { Limit = 1, Offset = 1 });
+
+        var item = Assert.Single(page.Modules);
+        Assert.Equal("bravo", item.Name);
+        Assert.Equal("3", page.Meta["total"]);
+        Assert.Equal("1", page.Meta["current_offset"]);
+        Assert.Equal("1.0.0", item.Version);
+    }
+
+    [Fact]
+    public async Task ListModulesTreatsSearchWildcardsAsLiteralText()
+    {
+        var svc = CreateService(_connectionString);
+        await (svc as IInitializableDb).InitializeDatabase();
+        await svc.AddModuleAsync(MakeModule(name: "literal%module", version: "1.0.0"));
+        await svc.AddModuleAsync(MakeModule(name: "ordinary-module", version: "1.0.0"));
+
+        var result = await svc.ListModulesAsync(new ModuleSearchRequest { Q = "%", Limit = 50 });
+
+        var item = Assert.Single(result.Modules);
+        Assert.Equal("literal%module", item.Name);
+    }
+
+    [Fact]
     public async Task GetModuleVersionsReturnsSemVerDescendingVersionList()
     {
         var svc = CreateService(_connectionString);

--- a/TerraformRegistry/Services/Sqlite/SqliteModuleRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModuleRepository.cs
@@ -16,60 +16,28 @@ public sealed class SqliteModuleRepository(
 {
     public async Task<ModuleList> ListModulesAsync(ModuleSearchRequest request)
     {
-        var rows = new List<ModuleRow>();
-
         await using var connection = new SqliteConnection(connectionString);
         await connection.OpenAsync();
+        var (whereClause, parameters) = BuildListFilter(request);
 
-        var sql = @"
-            SELECT m.namespace, m.name, m.provider, m.version, m.description, m.published_at
-            FROM modules m
-            WHERE m.deleted_at IS NULL";
+        await using var countCommand = connection.CreateCommand();
+        countCommand.CommandText = $"SELECT COUNT(*) FROM (SELECT 1 FROM modules m {whereClause} GROUP BY m.namespace, m.name, m.provider)";
+        AddParameters(countCommand, parameters);
+        var total = Convert.ToInt32(await countCommand.ExecuteScalarAsync(), CultureInfo.InvariantCulture);
 
-        var conditions = new List<string>();
-        var parameters = new List<SqliteParameter>();
-
-        if (!string.IsNullOrWhiteSpace(request.Namespace))
+        var coordinates = new List<(string Namespace, string Name, string Provider)>();
+        await using (var pageCommand = connection.CreateCommand())
         {
-            conditions.Add(" AND m.namespace = $ns");
-            parameters.Add(new SqliteParameter("$ns", request.Namespace));
+            pageCommand.CommandText = $"SELECT m.namespace, m.name, m.provider FROM modules m {whereClause} GROUP BY m.namespace, m.name, m.provider ORDER BY m.namespace, m.name, m.provider LIMIT $limit OFFSET $offset";
+            AddParameters(pageCommand, parameters);
+            pageCommand.Parameters.AddWithValue("$limit", request.Limit);
+            pageCommand.Parameters.AddWithValue("$offset", request.Offset);
+            await using var reader = await pageCommand.ExecuteReaderAsync();
+            while (await reader.ReadAsync()) coordinates.Add((reader.GetString(0), reader.GetString(1), reader.GetString(2)));
         }
 
-        if (!string.IsNullOrWhiteSpace(request.Provider))
-        {
-            conditions.Add(" AND m.provider = $prov");
-            parameters.Add(new SqliteParameter("$prov", request.Provider));
-        }
-
-        sql += string.Join("", conditions);
-        sql += " ORDER BY m.namespace, m.name, m.provider";
-
-        await using var command = connection.CreateCommand();
-        command.CommandText = sql;
-        foreach (var p in parameters) command.Parameters.Add(p);
-
-        await using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
-        {
-            var ns = reader.GetString(0);
-            var name = reader.GetString(1);
-            var provider = reader.GetString(2);
-            var version = reader.GetString(3);
-            var description = reader.IsDBNull(4) ? string.Empty : reader.GetString(4);
-            var publishedAtIso = reader.GetString(5);
-
-            rows.Add(new ModuleRow
-            {
-                Namespace = ns,
-                Name = name,
-                Version = version,
-                Provider = provider,
-                Description = description,
-                PublishedAt = publishedAtIso
-            });
-        }
-
-        var listedRows = rows
+        var rows = await GetPageRowsAsync(connection, coordinates);
+        var modules = rows
             .GroupBy(row => new { row.Namespace, row.Name, row.Provider })
             .Select(group =>
             {
@@ -81,19 +49,9 @@ public sealed class SqliteModuleRepository(
                 latest.Versions = versions;
                 return latest;
             })
-            .Where(row => string.IsNullOrWhiteSpace(request.Q)
-                || row.Name.Contains(request.Q, StringComparison.OrdinalIgnoreCase)
-                || row.Description.Contains(request.Q, StringComparison.OrdinalIgnoreCase))
             .OrderBy(row => row.Namespace, StringComparer.Ordinal)
             .ThenBy(row => row.Name, StringComparer.Ordinal)
             .ThenBy(row => row.Provider, StringComparer.Ordinal)
-            .ToList();
-
-        var total = listedRows.Count;
-
-        var modules = listedRows
-            .Skip(request.Offset)
-            .Take(request.Limit)
             .Select(row => new ModuleListItem
             {
                 Id = $"{row.Namespace}/{row.Name}/{row.Provider}",
@@ -120,6 +78,40 @@ public sealed class SqliteModuleRepository(
                 { "total", total.ToString(CultureInfo.InvariantCulture) }
             }
         };
+    }
+
+    private static (string WhereClause, IReadOnlyList<SqliteParameter> Parameters) BuildListFilter(ModuleSearchRequest request)
+    {
+        var conditions = new List<string> { "m.deleted_at IS NULL" };
+        var parameters = new List<SqliteParameter>();
+        if (!string.IsNullOrWhiteSpace(request.Namespace)) { conditions.Add("m.namespace = $ns"); parameters.Add(new SqliteParameter("$ns", request.Namespace)); }
+        if (!string.IsNullOrWhiteSpace(request.Provider)) { conditions.Add("m.provider = $prov"); parameters.Add(new SqliteParameter("$prov", request.Provider)); }
+        if (!string.IsNullOrWhiteSpace(request.Q)) { conditions.Add("(instr(lower(m.name), lower($q)) > 0 OR instr(lower(COALESCE(m.description, '')), lower($q)) > 0)"); parameters.Add(new SqliteParameter("$q", request.Q)); }
+        return ($"WHERE {string.Join(" AND ", conditions)}", parameters);
+    }
+
+    private static void AddParameters(SqliteCommand command, IReadOnlyList<SqliteParameter> parameters)
+    {
+        foreach (var parameter in parameters) command.Parameters.Add(new SqliteParameter(parameter.ParameterName, parameter.Value));
+    }
+
+    private static async Task<List<ModuleRow>> GetPageRowsAsync(SqliteConnection connection, List<(string Namespace, string Name, string Provider)> coordinates)
+    {
+        if (coordinates.Count == 0) return [];
+        await using var command = connection.CreateCommand();
+        var values = new List<string>();
+        for (var index = 0; index < coordinates.Count; index++)
+        {
+            values.Add($"($ns{index}, $name{index}, $provider{index})");
+            command.Parameters.AddWithValue($"$ns{index}", coordinates[index].Namespace);
+            command.Parameters.AddWithValue($"$name{index}", coordinates[index].Name);
+            command.Parameters.AddWithValue($"$provider{index}", coordinates[index].Provider);
+        }
+        command.CommandText = $"WITH page(namespace, name, provider) AS (VALUES {string.Join(", ", values)}) SELECT m.namespace, m.name, m.provider, m.version, m.description, m.published_at FROM modules m JOIN page p ON p.namespace = m.namespace AND p.name = m.name AND p.provider = m.provider WHERE m.deleted_at IS NULL";
+        var rows = new List<ModuleRow>();
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync()) rows.Add(new ModuleRow { Namespace = reader.GetString(0), Name = reader.GetString(1), Provider = reader.GetString(2), Version = reader.GetString(3), Description = reader.IsDBNull(4) ? string.Empty : reader.GetString(4), PublishedAt = reader.GetString(5) });
+        return rows;
     }
 
     public async Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version)


### PR DESCRIPTION
## Summary
- count, page coordinates, and fetch only versions belonging to the selected page in three database queries
- preserve module ordering, filters, semantic version selection, and literal search behavior
- cover SQLite and PostgreSQL coordinate pagination

## Verification
- `dotnet build terraform-registry.sln --no-restore -c Release`
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-build --no-restore --filter "FullyQualifiedName~SqliteDatabaseServiceTests|FullyQualifiedName~UploadAndListModulesTests"`
- `git diff --check`

## Static scan
`slopwatch analyze -d . --no-baseline --fail-on warning` reports four existing findings outside this diff; no new findings in the changed files.