### PR TITLE
refactor: establish publication commit contract

### DIFF
--- a/TerraformRegistry.API/Interfaces/IDatabaseService.cs
+++ b/TerraformRegistry.API/Interfaces/IDatabaseService.cs
@@ -8,7 +8,8 @@ public interface IDatabaseService :
     IModuleExtractionRepository,
     IUserRepository,
     IApiKeyRepository,
-    IModuleDownloadRecorder
+    IModuleDownloadRecorder,
+    IModulePublicationRepository
 {
     /// <summary>
     ///     Checks that the database connection is healthy.

--- a/TerraformRegistry.API/Interfaces/IModulePublicationRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IModulePublicationRepository.cs
@@ -1,0 +1,10 @@
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.API.Interfaces;
+
+public interface IModulePublicationRepository
+{
+    Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job);
+    Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id);
+    Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id);
+}

--- a/TerraformRegistry.API/Interfaces/IModulePublicationRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IModulePublicationRepository.cs
@@ -9,6 +9,7 @@ public interface IModulePublicationRepository
         ModulePublicationAttempt attempt,
         ModuleStorage newModule,
         ModuleStorage? expectedModule);
+    Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason);
     Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id);
     Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id);
 }

--- a/TerraformRegistry.API/Interfaces/IModulePublicationRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IModulePublicationRepository.cs
@@ -5,6 +5,10 @@ namespace TerraformRegistry.API.Interfaces;
 public interface IModulePublicationRepository
 {
     Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job);
+    Task<bool> TryCommitStagedPublicationAsync(
+        ModulePublicationAttempt attempt,
+        ModuleStorage newModule,
+        ModuleStorage? expectedModule);
     Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id);
     Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id);
 }

--- a/TerraformRegistry.Migrations/Scripts/PostgreSQL/023_publication_attempts.sql
+++ b/TerraformRegistry.Migrations/Scripts/PostgreSQL/023_publication_attempts.sql
@@ -1,0 +1,38 @@
+CREATE TABLE module_publication_attempts (
+    id UUID PRIMARY KEY,
+    namespace VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    provider VARCHAR(255) NOT NULL,
+    version VARCHAR(255) NOT NULL,
+    state VARCHAR(32) NOT NULL,
+    staging_key TEXT NOT NULL,
+    expected_revision TEXT,
+    committed_revision TEXT,
+    error TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    completed_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX idx_module_publication_attempts_coordinate
+    ON module_publication_attempts(namespace, name, provider, version, created_at DESC);
+
+CREATE TABLE module_extraction_jobs (
+    id UUID PRIMARY KEY,
+    publication_attempt_id UUID NOT NULL UNIQUE REFERENCES module_publication_attempts(id) ON DELETE CASCADE,
+    namespace VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    provider VARCHAR(255) NOT NULL,
+    version VARCHAR(255) NOT NULL,
+    state VARCHAR(32) NOT NULL,
+    owner_id VARCHAR(255),
+    lease_expires_at TIMESTAMP WITH TIME ZONE,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    completed_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX idx_module_extraction_jobs_claim
+    ON module_extraction_jobs(state, lease_expires_at, created_at);

--- a/TerraformRegistry.Migrations/Scripts/SQLite/021_publication_attempts.sql
+++ b/TerraformRegistry.Migrations/Scripts/SQLite/021_publication_attempts.sql
@@ -1,0 +1,38 @@
+CREATE TABLE module_publication_attempts (
+    id TEXT PRIMARY KEY,
+    namespace TEXT NOT NULL,
+    name TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    version TEXT NOT NULL,
+    state TEXT NOT NULL,
+    staging_key TEXT NOT NULL,
+    expected_revision TEXT,
+    committed_revision TEXT,
+    error TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    completed_at TEXT
+);
+
+CREATE INDEX idx_module_publication_attempts_coordinate
+    ON module_publication_attempts(namespace, name, provider, version, created_at DESC);
+
+CREATE TABLE module_extraction_jobs (
+    id TEXT PRIMARY KEY,
+    publication_attempt_id TEXT NOT NULL UNIQUE REFERENCES module_publication_attempts(id) ON DELETE CASCADE,
+    namespace TEXT NOT NULL,
+    name TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    version TEXT NOT NULL,
+    state TEXT NOT NULL,
+    owner_id TEXT,
+    lease_expires_at TEXT,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    completed_at TEXT
+);
+
+CREATE INDEX idx_module_extraction_jobs_claim
+    ON module_extraction_jobs(state, lease_expires_at, created_at);

--- a/TerraformRegistry.Models/ModuleExtractionJob.cs
+++ b/TerraformRegistry.Models/ModuleExtractionJob.cs
@@ -1,0 +1,16 @@
+namespace TerraformRegistry.Models;
+
+public static class ModuleExtractionJobState { public const string Pending = "pending"; }
+
+public sealed record ModuleExtractionJob
+{
+    public required Guid Id { get; init; }
+    public required Guid PublicationAttemptId { get; init; }
+    public required string Namespace { get; init; }
+    public required string Name { get; init; }
+    public required string Provider { get; init; }
+    public required string Version { get; init; }
+    public required string State { get; init; }
+    public required DateTime CreatedAt { get; init; }
+    public required DateTime UpdatedAt { get; init; }
+}

--- a/TerraformRegistry.Models/ModulePublicationAttempt.cs
+++ b/TerraformRegistry.Models/ModulePublicationAttempt.cs
@@ -1,0 +1,25 @@
+namespace TerraformRegistry.Models;
+
+public static class ModulePublicationAttemptState
+{
+    public const string Staged = "staged";
+    public const string Committed = "committed";
+    public const string Failed = "failed";
+}
+
+public sealed record ModulePublicationAttempt
+{
+    public required Guid Id { get; init; }
+    public required string Namespace { get; init; }
+    public required string Name { get; init; }
+    public required string Provider { get; init; }
+    public required string Version { get; init; }
+    public required string State { get; init; }
+    public required string StagingKey { get; init; }
+    public string? ExpectedRevision { get; init; }
+    public string? CommittedRevision { get; init; }
+    public string? Error { get; init; }
+    public required DateTime CreatedAt { get; init; }
+    public required DateTime UpdatedAt { get; init; }
+    public DateTime? CompletedAt { get; init; }
+}

--- a/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
@@ -38,6 +38,11 @@ public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRep
         _modules.ListModulesAsync(request);
 
     public Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job) => _publications.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+    public Task<bool> TryCommitStagedPublicationAsync(
+        ModulePublicationAttempt attempt,
+        ModuleStorage newModule,
+        ModuleStorage? expectedModule) =>
+        _publications.TryCommitStagedPublicationAsync(attempt, newModule, expectedModule);
     public Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) => _publications.GetPublicationAttemptAsync(id);
     public Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) => _publications.GetExtractionJobAsync(id);
 

--- a/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
@@ -43,6 +43,8 @@ public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRep
         ModuleStorage newModule,
         ModuleStorage? expectedModule) =>
         _publications.TryCommitStagedPublicationAsync(attempt, newModule, expectedModule);
+    public Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason) =>
+        _publications.TryFailStagedPublicationAsync(attemptId, failureReason);
     public Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) => _publications.GetPublicationAttemptAsync(id);
     public Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) => _publications.GetExtractionJobAsync(id);
 

--- a/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
@@ -10,7 +10,7 @@ namespace TerraformRegistry.PostgreSQL;
 /// <summary>
 ///     PostgreSQL compatibility facade for registry database storage.
 /// </summary>
-public class PostgreSqlDatabaseService : IDatabaseService, IInitializableDb
+public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRepository, IInitializableDb
 {
     private readonly string _connectionString;
     private readonly DbUpMigrator _dbUpMigrator;
@@ -18,6 +18,7 @@ public class PostgreSqlDatabaseService : IDatabaseService, IInitializableDb
     private readonly PostgreSqlModuleDownloadRecorder _downloads;
     private readonly PostgreSqlModuleExtractionRepository _moduleExtractions;
     private readonly PostgreSqlModuleRepository _modules;
+    private readonly PostgreSqlModulePublicationRepository _publications;
     private readonly PostgreSqlUserRepository _users;
 
     public PostgreSqlDatabaseService(string connectionString, string baseUrl, ILogger<PostgreSqlDatabaseService> logger,
@@ -26,6 +27,7 @@ public class PostgreSqlDatabaseService : IDatabaseService, IInitializableDb
         _connectionString = connectionString;
         _dbUpMigrator = dbUpMigrator;
         _modules = new PostgreSqlModuleRepository(connectionString, baseUrl, logger);
+        _publications = new PostgreSqlModulePublicationRepository(connectionString);
         _moduleExtractions = new PostgreSqlModuleExtractionRepository(connectionString);
         _users = new PostgreSqlUserRepository(connectionString);
         _apiKeys = new PostgreSqlApiKeyRepository(connectionString);
@@ -34,6 +36,10 @@ public class PostgreSqlDatabaseService : IDatabaseService, IInitializableDb
 
     public Task<ModuleList> ListModulesAsync(ModuleSearchRequest request) =>
         _modules.ListModulesAsync(request);
+
+    public Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job) => _publications.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+    public Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) => _publications.GetPublicationAttemptAsync(id);
+    public Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) => _publications.GetExtractionJobAsync(id);
 
     public Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version) =>
         _modules.GetModuleAsync(moduleNamespace, name, provider, version);

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
@@ -1,0 +1,21 @@
+using Npgsql;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.PostgreSQL.Repositories;
+
+public sealed class PostgreSqlModulePublicationRepository(string connectionString) : IModulePublicationRepository
+{
+    public async Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var transaction = await connection.BeginTransactionAsync();
+        await using var command = new NpgsqlCommand(@"INSERT INTO module_publication_attempts (id, namespace, name, provider, version, state, staging_key, created_at, updated_at) VALUES (@id,@ns,@name,@provider,@version,@state,@key,@created,@updated); INSERT INTO module_extraction_jobs (id, publication_attempt_id, namespace, name, provider, version, state, created_at, updated_at) VALUES (@jobId,@attemptId,@jobNs,@jobName,@jobProvider,@jobVersion,@jobState,@jobCreated,@jobUpdated);", connection, transaction);
+        command.Parameters.AddWithValue("@id", attempt.Id); command.Parameters.AddWithValue("@ns", attempt.Namespace); command.Parameters.AddWithValue("@name", attempt.Name); command.Parameters.AddWithValue("@provider", attempt.Provider); command.Parameters.AddWithValue("@version", attempt.Version); command.Parameters.AddWithValue("@state", attempt.State); command.Parameters.AddWithValue("@key", attempt.StagingKey); command.Parameters.AddWithValue("@created", attempt.CreatedAt); command.Parameters.AddWithValue("@updated", attempt.UpdatedAt);
+        command.Parameters.AddWithValue("@jobId", job.Id); command.Parameters.AddWithValue("@attemptId", job.PublicationAttemptId); command.Parameters.AddWithValue("@jobNs", job.Namespace); command.Parameters.AddWithValue("@jobName", job.Name); command.Parameters.AddWithValue("@jobProvider", job.Provider); command.Parameters.AddWithValue("@jobVersion", job.Version); command.Parameters.AddWithValue("@jobState", job.State); command.Parameters.AddWithValue("@jobCreated", job.CreatedAt); command.Parameters.AddWithValue("@jobUpdated", job.UpdatedAt);
+        await command.ExecuteNonQueryAsync(); await transaction.CommitAsync();
+    }
+    public async Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) { await using var c=new NpgsqlConnection(connectionString); await c.OpenAsync(); await using var q=new NpgsqlCommand("SELECT id,namespace,name,provider,version,state,staging_key,created_at,updated_at FROM module_publication_attempts WHERE id=@id",c); q.Parameters.AddWithValue("@id",id); await using var r=await q.ExecuteReaderAsync(); return await r.ReadAsync()?new ModulePublicationAttempt{Id=r.GetGuid(0),Namespace=r.GetString(1),Name=r.GetString(2),Provider=r.GetString(3),Version=r.GetString(4),State=r.GetString(5),StagingKey=r.GetString(6),CreatedAt=r.GetDateTime(7),UpdatedAt=r.GetDateTime(8)}:null; }
+    public async Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) { await using var c=new NpgsqlConnection(connectionString); await c.OpenAsync(); await using var q=new NpgsqlCommand("SELECT id,publication_attempt_id,namespace,name,provider,version,state,created_at,updated_at FROM module_extraction_jobs WHERE id=@id",c); q.Parameters.AddWithValue("@id",id); await using var r=await q.ExecuteReaderAsync(); return await r.ReadAsync()?new ModuleExtractionJob{Id=r.GetGuid(0),PublicationAttemptId=r.GetGuid(1),Namespace=r.GetString(2),Name=r.GetString(3),Provider=r.GetString(4),Version=r.GetString(5),State=r.GetString(6),CreatedAt=r.GetDateTime(7),UpdatedAt=r.GetDateTime(8)}:null; }
+}

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
@@ -6,16 +6,129 @@ namespace TerraformRegistry.PostgreSQL.Repositories;
 
 public sealed class PostgreSqlModulePublicationRepository(string connectionString) : IModulePublicationRepository
 {
-    public async Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job)
+    public async Task CreatePublicationAttemptWithExtractionJobAsync(
+        ModulePublicationAttempt attempt,
+        ModuleExtractionJob job)
     {
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync();
         await using var transaction = await connection.BeginTransactionAsync();
-        await using var command = new NpgsqlCommand(@"INSERT INTO module_publication_attempts (id, namespace, name, provider, version, state, staging_key, created_at, updated_at) VALUES (@id,@ns,@name,@provider,@version,@state,@key,@created,@updated); INSERT INTO module_extraction_jobs (id, publication_attempt_id, namespace, name, provider, version, state, created_at, updated_at) VALUES (@jobId,@attemptId,@jobNs,@jobName,@jobProvider,@jobVersion,@jobState,@jobCreated,@jobUpdated);", connection, transaction);
-        command.Parameters.AddWithValue("@id", attempt.Id); command.Parameters.AddWithValue("@ns", attempt.Namespace); command.Parameters.AddWithValue("@name", attempt.Name); command.Parameters.AddWithValue("@provider", attempt.Provider); command.Parameters.AddWithValue("@version", attempt.Version); command.Parameters.AddWithValue("@state", attempt.State); command.Parameters.AddWithValue("@key", attempt.StagingKey); command.Parameters.AddWithValue("@created", attempt.CreatedAt); command.Parameters.AddWithValue("@updated", attempt.UpdatedAt);
-        command.Parameters.AddWithValue("@jobId", job.Id); command.Parameters.AddWithValue("@attemptId", job.PublicationAttemptId); command.Parameters.AddWithValue("@jobNs", job.Namespace); command.Parameters.AddWithValue("@jobName", job.Name); command.Parameters.AddWithValue("@jobProvider", job.Provider); command.Parameters.AddWithValue("@jobVersion", job.Version); command.Parameters.AddWithValue("@jobState", job.State); command.Parameters.AddWithValue("@jobCreated", job.CreatedAt); command.Parameters.AddWithValue("@jobUpdated", job.UpdatedAt);
-        await command.ExecuteNonQueryAsync(); await transaction.CommitAsync();
+        await using var command = new NpgsqlCommand(
+            """
+            INSERT INTO module_publication_attempts (
+                id, namespace, name, provider, version, state, staging_key,
+                expected_revision, committed_revision, error, created_at, updated_at, completed_at)
+            VALUES (
+                @id, @namespace, @name, @provider, @version, @state, @stagingKey,
+                @expectedRevision, @committedRevision, @error, @createdAt, @updatedAt, @completedAt);
+
+            INSERT INTO module_extraction_jobs (
+                id, publication_attempt_id, namespace, name, provider, version, state, created_at, updated_at)
+            VALUES (
+                @jobId, @attemptId, @jobNamespace, @jobName, @jobProvider, @jobVersion, @jobState,
+                @jobCreatedAt, @jobUpdatedAt);
+            """,
+            connection,
+            transaction);
+        AddAttemptParameters(command, attempt);
+        AddJobParameters(command, job);
+
+        await command.ExecuteNonQueryAsync();
+        await transaction.CommitAsync();
     }
-    public async Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) { await using var c=new NpgsqlConnection(connectionString); await c.OpenAsync(); await using var q=new NpgsqlCommand("SELECT id,namespace,name,provider,version,state,staging_key,created_at,updated_at FROM module_publication_attempts WHERE id=@id",c); q.Parameters.AddWithValue("@id",id); await using var r=await q.ExecuteReaderAsync(); return await r.ReadAsync()?new ModulePublicationAttempt{Id=r.GetGuid(0),Namespace=r.GetString(1),Name=r.GetString(2),Provider=r.GetString(3),Version=r.GetString(4),State=r.GetString(5),StagingKey=r.GetString(6),CreatedAt=r.GetDateTime(7),UpdatedAt=r.GetDateTime(8)}:null; }
-    public async Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) { await using var c=new NpgsqlConnection(connectionString); await c.OpenAsync(); await using var q=new NpgsqlCommand("SELECT id,publication_attempt_id,namespace,name,provider,version,state,created_at,updated_at FROM module_extraction_jobs WHERE id=@id",c); q.Parameters.AddWithValue("@id",id); await using var r=await q.ExecuteReaderAsync(); return await r.ReadAsync()?new ModuleExtractionJob{Id=r.GetGuid(0),PublicationAttemptId=r.GetGuid(1),Namespace=r.GetString(2),Name=r.GetString(3),Provider=r.GetString(4),Version=r.GetString(5),State=r.GetString(6),CreatedAt=r.GetDateTime(7),UpdatedAt=r.GetDateTime(8)}:null; }
+
+    public async Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(
+            """
+            SELECT id, namespace, name, provider, version, state, staging_key,
+                   expected_revision, committed_revision, error, created_at, updated_at, completed_at
+            FROM module_publication_attempts
+            WHERE id = @id
+            """,
+            connection);
+        command.Parameters.AddWithValue("@id", id);
+        await using var reader = await command.ExecuteReaderAsync();
+
+        return await reader.ReadAsync() ? ReadAttempt(reader) : null;
+    }
+
+    public async Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(
+            """
+            SELECT id, publication_attempt_id, namespace, name, provider, version, state, created_at, updated_at
+            FROM module_extraction_jobs
+            WHERE id = @id
+            """,
+            connection);
+        command.Parameters.AddWithValue("@id", id);
+        await using var reader = await command.ExecuteReaderAsync();
+
+        return await reader.ReadAsync() ? ReadJob(reader) : null;
+    }
+
+    private static void AddAttemptParameters(NpgsqlCommand command, ModulePublicationAttempt attempt)
+    {
+        command.Parameters.AddWithValue("@id", attempt.Id);
+        command.Parameters.AddWithValue("@namespace", attempt.Namespace);
+        command.Parameters.AddWithValue("@name", attempt.Name);
+        command.Parameters.AddWithValue("@provider", attempt.Provider);
+        command.Parameters.AddWithValue("@version", attempt.Version);
+        command.Parameters.AddWithValue("@state", attempt.State);
+        command.Parameters.AddWithValue("@stagingKey", attempt.StagingKey);
+        command.Parameters.AddWithValue("@expectedRevision", (object?)attempt.ExpectedRevision ?? DBNull.Value);
+        command.Parameters.AddWithValue("@committedRevision", (object?)attempt.CommittedRevision ?? DBNull.Value);
+        command.Parameters.AddWithValue("@error", (object?)attempt.Error ?? DBNull.Value);
+        command.Parameters.AddWithValue("@createdAt", attempt.CreatedAt);
+        command.Parameters.AddWithValue("@updatedAt", attempt.UpdatedAt);
+        command.Parameters.AddWithValue("@completedAt", (object?)attempt.CompletedAt ?? DBNull.Value);
+    }
+
+    private static void AddJobParameters(NpgsqlCommand command, ModuleExtractionJob job)
+    {
+        command.Parameters.AddWithValue("@jobId", job.Id);
+        command.Parameters.AddWithValue("@attemptId", job.PublicationAttemptId);
+        command.Parameters.AddWithValue("@jobNamespace", job.Namespace);
+        command.Parameters.AddWithValue("@jobName", job.Name);
+        command.Parameters.AddWithValue("@jobProvider", job.Provider);
+        command.Parameters.AddWithValue("@jobVersion", job.Version);
+        command.Parameters.AddWithValue("@jobState", job.State);
+        command.Parameters.AddWithValue("@jobCreatedAt", job.CreatedAt);
+        command.Parameters.AddWithValue("@jobUpdatedAt", job.UpdatedAt);
+    }
+
+    private static ModulePublicationAttempt ReadAttempt(NpgsqlDataReader reader) => new()
+    {
+        Id = reader.GetGuid(0),
+        Namespace = reader.GetString(1),
+        Name = reader.GetString(2),
+        Provider = reader.GetString(3),
+        Version = reader.GetString(4),
+        State = reader.GetString(5),
+        StagingKey = reader.GetString(6),
+        ExpectedRevision = reader.IsDBNull(7) ? null : reader.GetString(7),
+        CommittedRevision = reader.IsDBNull(8) ? null : reader.GetString(8),
+        Error = reader.IsDBNull(9) ? null : reader.GetString(9),
+        CreatedAt = reader.GetDateTime(10),
+        UpdatedAt = reader.GetDateTime(11),
+        CompletedAt = reader.IsDBNull(12) ? null : reader.GetDateTime(12)
+    };
+
+    private static ModuleExtractionJob ReadJob(NpgsqlDataReader reader) => new()
+    {
+        Id = reader.GetGuid(0),
+        PublicationAttemptId = reader.GetGuid(1),
+        Namespace = reader.GetString(2),
+        Name = reader.GetString(3),
+        Provider = reader.GetString(4),
+        Version = reader.GetString(5),
+        State = reader.GetString(6),
+        CreatedAt = reader.GetDateTime(7),
+        UpdatedAt = reader.GetDateTime(8)
+    };
 }

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
@@ -1,4 +1,6 @@
 using Npgsql;
+using NpgsqlTypes;
+using System.Text.Json;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Models;
 
@@ -55,6 +57,50 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         return await reader.ReadAsync() ? ReadAttempt(reader) : null;
     }
 
+    public async Task<bool> TryCommitStagedPublicationAsync(
+        ModulePublicationAttempt attempt,
+        ModuleStorage newModule,
+        ModuleStorage? expectedModule)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var transaction = await connection.BeginTransactionAsync();
+
+        var catalogChanged = expectedModule is null
+            ? await TryInsertCatalogAsync(connection, transaction, newModule)
+            : await TryReplaceCatalogAsync(connection, transaction, expectedModule, newModule);
+        if (!catalogChanged)
+            return false;
+
+        await using var attemptCommand = new NpgsqlCommand(
+            """
+            UPDATE module_publication_attempts
+            SET state = @committed, updated_at = @updatedAt, completed_at = @completedAt, error = NULL
+            WHERE id = @id
+              AND namespace = @namespace
+              AND name = @name
+              AND provider = @provider
+              AND version = @version
+              AND state = @staged
+            """,
+            connection,
+            transaction);
+        attemptCommand.Parameters.AddWithValue("@committed", ModulePublicationAttemptState.Committed);
+        attemptCommand.Parameters.AddWithValue("@updatedAt", DateTime.UtcNow);
+        attemptCommand.Parameters.AddWithValue("@completedAt", DateTime.UtcNow);
+        attemptCommand.Parameters.AddWithValue("@id", attempt.Id);
+        attemptCommand.Parameters.AddWithValue("@namespace", newModule.Namespace);
+        attemptCommand.Parameters.AddWithValue("@name", newModule.Name);
+        attemptCommand.Parameters.AddWithValue("@provider", newModule.Provider);
+        attemptCommand.Parameters.AddWithValue("@version", newModule.Version);
+        attemptCommand.Parameters.AddWithValue("@staged", ModulePublicationAttemptState.Staged);
+        if (await attemptCommand.ExecuteNonQueryAsync() != 1)
+            return false;
+
+        await transaction.CommitAsync();
+        return true;
+    }
+
     public async Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id)
     {
         await using var connection = new NpgsqlConnection(connectionString);
@@ -88,6 +134,75 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         command.Parameters.AddWithValue("@updatedAt", attempt.UpdatedAt);
         command.Parameters.AddWithValue("@completedAt", (object?)attempt.CompletedAt ?? DBNull.Value);
     }
+
+    private static async Task<bool> TryInsertCatalogAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        ModuleStorage module)
+    {
+        await using var command = new NpgsqlCommand(
+            """
+            INSERT INTO modules (
+                namespace, name, provider, version, description, storage_path, published_at, dependencies, metadata)
+            VALUES (
+                @namespace, @name, @provider, @version, @description, @storagePath, @publishedAt, @dependencies, @metadata)
+            ON CONFLICT(namespace, name, provider, version) DO NOTHING
+            """,
+            connection,
+            transaction);
+        AddModuleParameters(command, module, string.Empty);
+        return await command.ExecuteNonQueryAsync() == 1;
+    }
+
+    private static async Task<bool> TryReplaceCatalogAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        ModuleStorage expected,
+        ModuleStorage replacement)
+    {
+        await using var command = new NpgsqlCommand(
+            """
+            UPDATE modules
+            SET description = @newDescription,
+                storage_path = @newStoragePath,
+                published_at = @newPublishedAt,
+                dependencies = @newDependencies,
+                metadata = @newMetadata
+            WHERE namespace = @namespace
+              AND name = @name
+              AND provider = @provider
+              AND version = @version
+              AND description = @description
+              AND storage_path = @storagePath
+              AND published_at = @publishedAt
+              AND dependencies = @dependencies
+              AND metadata = @metadata
+              AND deleted_at IS NULL
+            """,
+            connection,
+            transaction);
+        AddModuleParameters(command, expected, string.Empty);
+        AddModuleParameters(command, replacement, "new");
+        return await command.ExecuteNonQueryAsync() == 1;
+    }
+
+    private static void AddModuleParameters(NpgsqlCommand command, ModuleStorage module, string prefix)
+    {
+        command.Parameters.AddWithValue(ParameterName(prefix, "namespace"), module.Namespace);
+        command.Parameters.AddWithValue(ParameterName(prefix, "name"), module.Name);
+        command.Parameters.AddWithValue(ParameterName(prefix, "provider"), module.Provider);
+        command.Parameters.AddWithValue(ParameterName(prefix, "version"), module.Version);
+        command.Parameters.AddWithValue(ParameterName(prefix, "description"), module.Description);
+        command.Parameters.AddWithValue(ParameterName(prefix, "storagePath"), module.FilePath);
+        command.Parameters.AddWithValue(ParameterName(prefix, "publishedAt"), module.PublishedAt);
+        command.Parameters.AddWithValue(ParameterName(prefix, "dependencies"), JsonSerializer.Serialize(module.Dependencies)).NpgsqlDbType =
+            NpgsqlDbType.Jsonb;
+        command.Parameters.AddWithValue(ParameterName(prefix, "metadata"), JsonSerializer.Serialize(module.Metadata)).NpgsqlDbType =
+            NpgsqlDbType.Jsonb;
+    }
+
+    private static string ParameterName(string prefix, string name) =>
+        "@" + (string.IsNullOrEmpty(prefix) ? name : prefix + char.ToUpperInvariant(name[0]) + name[1..]);
 
     private static void AddJobParameters(NpgsqlCommand command, ModuleExtractionJob job)
     {

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
@@ -57,6 +57,26 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         return await reader.ReadAsync() ? ReadAttempt(reader) : null;
     }
 
+    public async Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(
+            """
+            UPDATE module_publication_attempts
+            SET state = @failed, error = @failureReason, updated_at = @updatedAt, completed_at = @completedAt
+            WHERE id = @id AND state = @staged
+            """,
+            connection);
+        command.Parameters.AddWithValue("@failed", ModulePublicationAttemptState.Failed);
+        command.Parameters.AddWithValue("@failureReason", failureReason);
+        command.Parameters.AddWithValue("@updatedAt", DateTime.UtcNow);
+        command.Parameters.AddWithValue("@completedAt", DateTime.UtcNow);
+        command.Parameters.AddWithValue("@id", attemptId);
+        command.Parameters.AddWithValue("@staged", ModulePublicationAttemptState.Staged);
+        return await command.ExecuteNonQueryAsync() == 1;
+    }
+
     public async Task<bool> TryCommitStagedPublicationAsync(
         ModulePublicationAttempt attempt,
         ModuleStorage newModule,

--- a/TerraformRegistry.Tests/DbUpMigratorTests.cs
+++ b/TerraformRegistry.Tests/DbUpMigratorTests.cs
@@ -62,6 +62,8 @@ public class DbUpMigratorTests : IDisposable
         Assert.Contains("mirror_module_versions", tables);
         Assert.Contains("mirror_module_packages", tables);
         Assert.Contains("mirror_cache_leases", tables);
+        Assert.Contains("module_publication_attempts", tables);
+        Assert.Contains("module_extraction_jobs", tables);
         Assert.Contains("SchemaVersions", tables);
     }
 

--- a/TerraformRegistry.Tests/UnitTests/Database/MirrorRepositoryTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/MirrorRepositoryTests.cs
@@ -51,6 +51,14 @@ public sealed class SqliteMirrorRepositoryTests : IDisposable
         await MirrorLeaseRepositoryContract.ManagesAcquireHeartbeatReleaseAndExpiredTakeover(repository);
     }
 
+    [Fact]
+    public async Task PublicationRepositoryRoundTripsAllAttemptFields()
+    {
+        var repository = new SqliteModulePublicationRepository(_connectionString);
+
+        await PublicationRepositoryContract.RoundTripsAllAttemptFields(repository);
+    }
+
     public void Dispose()
     {
         _connection.Dispose();
@@ -108,6 +116,58 @@ public sealed class PostgreSqlMirrorRepositoryTests : IAsyncLifetime
 
         await MirrorLeaseRepositoryContract.ManagesAcquireHeartbeatReleaseAndExpiredTakeover(repository);
     }
+
+    [Fact]
+    public async Task PublicationRepositoryRoundTripsAllAttemptFields()
+    {
+        var repository = new PostgreSqlModulePublicationRepository(_connectionString);
+
+        await PublicationRepositoryContract.RoundTripsAllAttemptFields(repository);
+    }
+}
+
+internal static class PublicationRepositoryContract
+{
+    public static async Task RoundTripsAllAttemptFields(IModulePublicationRepository repository)
+    {
+        var now = TruncateToMicroseconds(DateTime.UtcNow);
+        var attempt = new ModulePublicationAttempt
+        {
+            Id = Guid.NewGuid(),
+            Namespace = "acme",
+            Name = "network",
+            Provider = "aws",
+            Version = "1.0.0",
+            State = ModulePublicationAttemptState.Failed,
+            StagingKey = "publication-attempts/acme/network/aws/1.0.0/staged.zip",
+            ExpectedRevision = "catalog-r17",
+            CommittedRevision = "artifact-r17",
+            Error = "promotion failed after compare-and-swap",
+            CreatedAt = now,
+            UpdatedAt = now.AddMinutes(1),
+            CompletedAt = now.AddMinutes(2)
+        };
+        var job = new ModuleExtractionJob
+        {
+            Id = Guid.NewGuid(),
+            PublicationAttemptId = attempt.Id,
+            Namespace = attempt.Namespace,
+            Name = attempt.Name,
+            Provider = attempt.Provider,
+            Version = attempt.Version,
+            State = ModuleExtractionJobState.Pending,
+            CreatedAt = attempt.CreatedAt,
+            UpdatedAt = attempt.UpdatedAt
+        };
+
+        await repository.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+
+        Assert.Equal(attempt, await repository.GetPublicationAttemptAsync(attempt.Id));
+        Assert.Equal(job, await repository.GetExtractionJobAsync(job.Id));
+    }
+
+    private static DateTime TruncateToMicroseconds(DateTime value) =>
+        new(value.Ticks - value.Ticks % 10, DateTimeKind.Utc);
 }
 
 internal static class ProviderRepositoryContract

--- a/TerraformRegistry.Tests/UnitTests/Database/MirrorRepositoryTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/MirrorRepositoryTests.cs
@@ -225,6 +225,14 @@ internal static class PublicationCommitContract
         AssertModuleEquals(first, await modules.GetModuleStorageAsync("acme", "network", "aws", "1.0.0"));
         Assert.Equal(ModulePublicationAttemptState.Staged,
             (await publications.GetPublicationAttemptAsync(replacementAttempt.Id))!.State);
+
+        Assert.False(await publications.TryFailStagedPublicationAsync(firstAttempt.Id, "loser cleanup"));
+        Assert.True(await publications.TryFailStagedPublicationAsync(replacementAttempt.Id, "promotion failed"));
+        var failedReplacement = await publications.GetPublicationAttemptAsync(replacementAttempt.Id);
+        Assert.Equal(ModulePublicationAttemptState.Failed, failedReplacement!.State);
+        Assert.Equal("promotion failed", failedReplacement.Error);
+        Assert.NotNull(failedReplacement.CompletedAt);
+        AssertModuleEquals(first, await modules.GetModuleStorageAsync("acme", "network", "aws", "1.0.0"));
     }
 
     private static ModulePublicationAttempt CreateAttempt(ModuleStorage module, DateTime now) => new()

--- a/TerraformRegistry.Tests/UnitTests/Database/MirrorRepositoryTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/MirrorRepositoryTests.cs
@@ -2,11 +2,14 @@ using DotNet.Testcontainers.Builders;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Migrations;
 using TerraformRegistry.Models;
+using TerraformRegistry.PostgreSQL;
 using TerraformRegistry.PostgreSQL.Repositories;
+using TerraformRegistry.Services;
 using TerraformRegistry.Services.Sqlite;
 using Testcontainers.PostgreSql;
 
@@ -57,6 +60,18 @@ public sealed class SqliteMirrorRepositoryTests : IDisposable
         var repository = new SqliteModulePublicationRepository(_connectionString);
 
         await PublicationRepositoryContract.RoundTripsAllAttemptFields(repository);
+    }
+
+    [Fact]
+    public async Task PublicationRepositoryCommitsCatalogUsingExpectedSnapshot()
+    {
+        var database = new SqliteDatabaseService(
+            _connectionString,
+            "http://localhost",
+            NullLogger<SqliteDatabaseService>.Instance,
+            new DbUpMigrator(NullLogger<DbUpMigrator>.Instance));
+
+        await PublicationCommitContract.CommitsCatalogUsingExpectedSnapshot(database, database);
     }
 
     public void Dispose()
@@ -124,6 +139,18 @@ public sealed class PostgreSqlMirrorRepositoryTests : IAsyncLifetime
 
         await PublicationRepositoryContract.RoundTripsAllAttemptFields(repository);
     }
+
+    [Fact]
+    public async Task PublicationRepositoryCommitsCatalogUsingExpectedSnapshot()
+    {
+        var database = new PostgreSqlDatabaseService(
+            _connectionString,
+            "http://localhost",
+            NullLogger<PostgreSqlDatabaseService>.Instance,
+            new DbUpMigrator(NullLogger<DbUpMigrator>.Instance));
+
+        await PublicationCommitContract.CommitsCatalogUsingExpectedSnapshot(database, database);
+    }
 }
 
 internal static class PublicationRepositoryContract
@@ -164,6 +191,94 @@ internal static class PublicationRepositoryContract
 
         Assert.Equal(attempt, await repository.GetPublicationAttemptAsync(attempt.Id));
         Assert.Equal(job, await repository.GetExtractionJobAsync(job.Id));
+    }
+
+    private static DateTime TruncateToMicroseconds(DateTime value) =>
+        new(value.Ticks - value.Ticks % 10, DateTimeKind.Utc);
+}
+
+internal static class PublicationCommitContract
+{
+    public static async Task CommitsCatalogUsingExpectedSnapshot(
+        IModulePublicationRepository publications,
+        IModuleRepository modules)
+    {
+        var now = TruncateToMicroseconds(DateTime.UtcNow);
+        var first = CreateModule("artifacts/acme/network/aws/1.0.0/first.zip", now);
+        var firstAttempt = CreateAttempt(first, now);
+        await publications.CreatePublicationAttemptWithExtractionJobAsync(firstAttempt, CreateJob(firstAttempt));
+
+        Assert.True(await publications.TryCommitStagedPublicationAsync(firstAttempt, first, null));
+        AssertModuleEquals(first, await modules.GetModuleStorageAsync("acme", "network", "aws", "1.0.0"));
+        Assert.Equal(ModulePublicationAttemptState.Committed,
+            (await publications.GetPublicationAttemptAsync(firstAttempt.Id))!.State);
+
+        var replacement = CreateModule("artifacts/acme/network/aws/1.0.0/replacement.zip", now.AddMinutes(1));
+        replacement.Description = "replacement artifact";
+        var staleSnapshot = CreateModule("artifacts/acme/network/aws/1.0.0/stale.zip", now);
+        var replacementAttempt = CreateAttempt(replacement, now.AddMinutes(1));
+        await publications.CreatePublicationAttemptWithExtractionJobAsync(
+            replacementAttempt,
+            CreateJob(replacementAttempt));
+
+        Assert.False(await publications.TryCommitStagedPublicationAsync(replacementAttempt, replacement, staleSnapshot));
+        AssertModuleEquals(first, await modules.GetModuleStorageAsync("acme", "network", "aws", "1.0.0"));
+        Assert.Equal(ModulePublicationAttemptState.Staged,
+            (await publications.GetPublicationAttemptAsync(replacementAttempt.Id))!.State);
+    }
+
+    private static ModulePublicationAttempt CreateAttempt(ModuleStorage module, DateTime now) => new()
+    {
+        Id = Guid.NewGuid(),
+        Namespace = module.Namespace,
+        Name = module.Name,
+        Provider = module.Provider,
+        Version = module.Version,
+        State = ModulePublicationAttemptState.Staged,
+        StagingKey = $"staging/{Guid.NewGuid():N}",
+        ExpectedRevision = "catalog-r17",
+        CommittedRevision = "artifact-r17",
+        CreatedAt = now,
+        UpdatedAt = now
+    };
+
+    private static ModuleExtractionJob CreateJob(ModulePublicationAttempt attempt) => new()
+    {
+        Id = Guid.NewGuid(),
+        PublicationAttemptId = attempt.Id,
+        Namespace = attempt.Namespace,
+        Name = attempt.Name,
+        Provider = attempt.Provider,
+        Version = attempt.Version,
+        State = ModuleExtractionJobState.Pending,
+        CreatedAt = attempt.CreatedAt,
+        UpdatedAt = attempt.UpdatedAt
+    };
+
+    private static ModuleStorage CreateModule(string path, DateTime publishedAt) => new()
+    {
+        Namespace = "acme",
+        Name = "network",
+        Provider = "aws",
+        Version = "1.0.0",
+        Description = "network artifact",
+        FilePath = path,
+        PublishedAt = publishedAt,
+        Dependencies = ["hashicorp/aws"],
+        Metadata = new ModuleArtifactMetadata
+        {
+            Source = new ModuleSourceInfo { Kind = "manual", SourceUrl = "https://example.test/network" }
+        }
+    };
+
+    private static void AssertModuleEquals(ModuleStorage expected, ModuleStorage? actual)
+    {
+        Assert.NotNull(actual);
+        Assert.Equal(expected.Description, actual!.Description);
+        Assert.Equal(expected.FilePath, actual.FilePath);
+        Assert.Equal(expected.PublishedAt, actual.PublishedAt);
+        Assert.Equal(expected.Dependencies, actual.Dependencies);
+        Assert.Equal(JsonSerializer.Serialize(expected.Metadata), JsonSerializer.Serialize(actual.Metadata));
     }
 
     private static DateTime TruncateToMicroseconds(DateTime value) =>

--- a/TerraformRegistry.Tests/UnitTests/Database/SqliteDatabaseServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/SqliteDatabaseServiceTests.cs
@@ -88,6 +88,43 @@ public class SqliteDatabaseServiceTests : IAsyncLifetime
         Assert.IsAssignableFrom<IUserRepository>(svc);
         Assert.IsAssignableFrom<IApiKeyRepository>(svc);
         Assert.IsAssignableFrom<IModuleDownloadRecorder>(svc);
+        Assert.IsAssignableFrom<IModulePublicationRepository>(svc);
+    }
+
+    [Fact]
+    public async Task CreatePublicationAttemptWithExtractionJobPersistsBothRecordsAtomically()
+    {
+        var svc = CreateService(_connectionString);
+        await (svc as IInitializableDb).InitializeDatabase();
+        var attempt = new ModulePublicationAttempt
+        {
+            Id = Guid.NewGuid(),
+            Namespace = "acme",
+            Name = "network",
+            Provider = "aws",
+            Version = "1.0.0",
+            State = ModulePublicationAttemptState.Staged,
+            StagingKey = "attempts/staged.zip",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        var job = new ModuleExtractionJob
+        {
+            Id = Guid.NewGuid(),
+            PublicationAttemptId = attempt.Id,
+            Namespace = attempt.Namespace,
+            Name = attempt.Name,
+            Provider = attempt.Provider,
+            Version = attempt.Version,
+            State = ModuleExtractionJobState.Pending,
+            CreatedAt = attempt.CreatedAt,
+            UpdatedAt = attempt.UpdatedAt
+        };
+
+        await svc.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+
+        Assert.Equal(attempt, await svc.GetPublicationAttemptAsync(attempt.Id));
+        Assert.Equal(job, await svc.GetExtractionJobAsync(job.Id));
     }
 
     [Fact]

--- a/TerraformRegistry.Tests/UnitTests/Database/SqliteDatabaseServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/SqliteDatabaseServiceTests.cs
@@ -105,8 +105,12 @@ public class SqliteDatabaseServiceTests : IAsyncLifetime
             Version = "1.0.0",
             State = ModulePublicationAttemptState.Staged,
             StagingKey = "attempts/staged.zip",
+            ExpectedRevision = "catalog-r17",
+            CommittedRevision = "artifact-r17",
+            Error = "transient storage failure",
             CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow
+            UpdatedAt = DateTime.UtcNow,
+            CompletedAt = DateTime.UtcNow
         };
         var job = new ModuleExtractionJob
         {

--- a/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
@@ -1,0 +1,32 @@
+using Microsoft.Data.Sqlite;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Services.Sqlite;
+
+public sealed class SqliteModulePublicationRepository(string connectionString) : IModulePublicationRepository
+{
+    public async Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job)
+    {
+        await using var connection = new SqliteConnection(connectionString); await connection.OpenAsync();
+        await using var transaction = connection.BeginTransaction();
+        await using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = "INSERT INTO module_publication_attempts (id, namespace, name, provider, version, state, staging_key, created_at, updated_at) VALUES ($id,$ns,$name,$provider,$version,$state,$key,$created,$updated)";
+            command.Parameters.AddWithValue("$id", attempt.Id.ToString()); command.Parameters.AddWithValue("$ns", attempt.Namespace); command.Parameters.AddWithValue("$name", attempt.Name); command.Parameters.AddWithValue("$provider", attempt.Provider); command.Parameters.AddWithValue("$version", attempt.Version); command.Parameters.AddWithValue("$state", attempt.State); command.Parameters.AddWithValue("$key", attempt.StagingKey); command.Parameters.AddWithValue("$created", attempt.CreatedAt.ToString("O")); command.Parameters.AddWithValue("$updated", attempt.UpdatedAt.ToString("O"));
+            await command.ExecuteNonQueryAsync();
+        }
+        await using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = "INSERT INTO module_extraction_jobs (id, publication_attempt_id, namespace, name, provider, version, state, created_at, updated_at) VALUES ($id,$attempt,$ns,$name,$provider,$version,$state,$created,$updated)";
+            command.Parameters.AddWithValue("$id", job.Id.ToString()); command.Parameters.AddWithValue("$attempt", job.PublicationAttemptId.ToString()); command.Parameters.AddWithValue("$ns", job.Namespace); command.Parameters.AddWithValue("$name", job.Name); command.Parameters.AddWithValue("$provider", job.Provider); command.Parameters.AddWithValue("$version", job.Version); command.Parameters.AddWithValue("$state", job.State); command.Parameters.AddWithValue("$created", job.CreatedAt.ToString("O")); command.Parameters.AddWithValue("$updated", job.UpdatedAt.ToString("O"));
+            await command.ExecuteNonQueryAsync();
+        }
+        transaction.Commit();
+    }
+    public Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) => GetAttemptAsync(id);
+    private async Task<ModulePublicationAttempt?> GetAttemptAsync(Guid id) { await using var c=new SqliteConnection(connectionString); await c.OpenAsync(); await using var q=c.CreateCommand(); q.CommandText="SELECT id,namespace,name,provider,version,state,staging_key,created_at,updated_at FROM module_publication_attempts WHERE id=$id"; q.Parameters.AddWithValue("$id",id.ToString()); await using var r=await q.ExecuteReaderAsync(); return await r.ReadAsync()?new ModulePublicationAttempt{Id=Guid.Parse(r.GetString(0)),Namespace=r.GetString(1),Name=r.GetString(2),Provider=r.GetString(3),Version=r.GetString(4),State=r.GetString(5),StagingKey=r.GetString(6),CreatedAt=DateTime.Parse(r.GetString(7), null, System.Globalization.DateTimeStyles.RoundtripKind),UpdatedAt=DateTime.Parse(r.GetString(8), null, System.Globalization.DateTimeStyles.RoundtripKind)}:null; }
+    public async Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) { await using var c=new SqliteConnection(connectionString); await c.OpenAsync(); await using var q=c.CreateCommand(); q.CommandText="SELECT id,publication_attempt_id,namespace,name,provider,version,state,created_at,updated_at FROM module_extraction_jobs WHERE id=$id"; q.Parameters.AddWithValue("$id",id.ToString()); await using var r=await q.ExecuteReaderAsync(); return await r.ReadAsync()?new ModuleExtractionJob{Id=Guid.Parse(r.GetString(0)),PublicationAttemptId=Guid.Parse(r.GetString(1)),Namespace=r.GetString(2),Name=r.GetString(3),Provider=r.GetString(4),Version=r.GetString(5),State=r.GetString(6),CreatedAt=DateTime.Parse(r.GetString(7), null, System.Globalization.DateTimeStyles.RoundtripKind),UpdatedAt=DateTime.Parse(r.GetString(8), null, System.Globalization.DateTimeStyles.RoundtripKind)}:null; }
+}

--- a/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 using Microsoft.Data.Sqlite;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Models;
@@ -62,6 +63,49 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         return await reader.ReadAsync() ? ReadAttempt(reader) : null;
     }
 
+    public async Task<bool> TryCommitStagedPublicationAsync(
+        ModulePublicationAttempt attempt,
+        ModuleStorage newModule,
+        ModuleStorage? expectedModule)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync();
+        await using var transaction = connection.BeginTransaction();
+
+        var catalogChanged = expectedModule is null
+            ? await TryInsertCatalogAsync(connection, transaction, newModule)
+            : await TryReplaceCatalogAsync(connection, transaction, expectedModule, newModule);
+        if (!catalogChanged)
+            return false;
+
+        await using var attemptCommand = connection.CreateCommand();
+        attemptCommand.Transaction = transaction;
+        attemptCommand.CommandText = """
+            UPDATE module_publication_attempts
+            SET state = $committed, updated_at = $updatedAt, completed_at = $completedAt, error = NULL
+            WHERE id = $id
+              AND namespace = $namespace
+              AND name = $name
+              AND provider = $provider
+              AND version = $version
+              AND state = $staged
+            """;
+        attemptCommand.Parameters.AddWithValue("$committed", ModulePublicationAttemptState.Committed);
+        attemptCommand.Parameters.AddWithValue("$updatedAt", DateTime.UtcNow.ToString("O"));
+        attemptCommand.Parameters.AddWithValue("$completedAt", DateTime.UtcNow.ToString("O"));
+        attemptCommand.Parameters.AddWithValue("$id", attempt.Id.ToString());
+        attemptCommand.Parameters.AddWithValue("$namespace", newModule.Namespace);
+        attemptCommand.Parameters.AddWithValue("$name", newModule.Name);
+        attemptCommand.Parameters.AddWithValue("$provider", newModule.Provider);
+        attemptCommand.Parameters.AddWithValue("$version", newModule.Version);
+        attemptCommand.Parameters.AddWithValue("$staged", ModulePublicationAttemptState.Staged);
+        if (await attemptCommand.ExecuteNonQueryAsync() != 1)
+            return false;
+
+        transaction.Commit();
+        return true;
+    }
+
     public async Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id)
     {
         await using var connection = new SqliteConnection(connectionString);
@@ -94,6 +138,71 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         command.Parameters.AddWithValue("$updatedAt", attempt.UpdatedAt.ToString("O"));
         command.Parameters.AddWithValue("$completedAt", attempt.CompletedAt?.ToString("O") ?? (object)DBNull.Value);
     }
+
+    private static async Task<bool> TryInsertCatalogAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        ModuleStorage module)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO modules (
+                namespace, name, provider, version, description, storage_path, published_at, dependencies, metadata)
+            VALUES (
+                $namespace, $name, $provider, $version, $description, $storagePath, $publishedAt, $dependencies, $metadata)
+            ON CONFLICT(namespace, name, provider, version) DO NOTHING
+            """;
+        AddModuleParameters(command, module, "");
+        return await command.ExecuteNonQueryAsync() == 1;
+    }
+
+    private static async Task<bool> TryReplaceCatalogAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        ModuleStorage expected,
+        ModuleStorage replacement)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            UPDATE modules
+            SET description = $newDescription,
+                storage_path = $newStoragePath,
+                published_at = $newPublishedAt,
+                dependencies = $newDependencies,
+                metadata = $newMetadata
+            WHERE namespace = $namespace
+              AND name = $name
+              AND provider = $provider
+              AND version = $version
+              AND description = $description
+              AND storage_path = $storagePath
+              AND published_at = $publishedAt
+              AND dependencies = $dependencies
+              AND metadata = $metadata
+              AND deleted_at IS NULL
+            """;
+        AddModuleParameters(command, expected, "");
+        AddModuleParameters(command, replacement, "new");
+        return await command.ExecuteNonQueryAsync() == 1;
+    }
+
+    private static void AddModuleParameters(SqliteCommand command, ModuleStorage module, string prefix)
+    {
+        command.Parameters.AddWithValue(ParameterName(prefix, "namespace"), module.Namespace);
+        command.Parameters.AddWithValue(ParameterName(prefix, "name"), module.Name);
+        command.Parameters.AddWithValue(ParameterName(prefix, "provider"), module.Provider);
+        command.Parameters.AddWithValue(ParameterName(prefix, "version"), module.Version);
+        command.Parameters.AddWithValue(ParameterName(prefix, "description"), module.Description);
+        command.Parameters.AddWithValue(ParameterName(prefix, "storagePath"), module.FilePath);
+        command.Parameters.AddWithValue(ParameterName(prefix, "publishedAt"), module.PublishedAt.ToString("O"));
+        command.Parameters.AddWithValue(ParameterName(prefix, "dependencies"), JsonSerializer.Serialize(module.Dependencies));
+        command.Parameters.AddWithValue(ParameterName(prefix, "metadata"), JsonSerializer.Serialize(module.Metadata));
+    }
+
+    private static string ParameterName(string prefix, string name) =>
+        "$" + (string.IsNullOrEmpty(prefix) ? name : prefix + char.ToUpperInvariant(name[0]) + name[1..]);
 
     private static void AddJobParameters(SqliteCommand command, ModuleExtractionJob job)
     {

--- a/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Data.Sqlite;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Models;
@@ -6,27 +7,136 @@ namespace TerraformRegistry.Services.Sqlite;
 
 public sealed class SqliteModulePublicationRepository(string connectionString) : IModulePublicationRepository
 {
-    public async Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job)
+    public async Task CreatePublicationAttemptWithExtractionJobAsync(
+        ModulePublicationAttempt attempt,
+        ModuleExtractionJob job)
     {
-        await using var connection = new SqliteConnection(connectionString); await connection.OpenAsync();
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync();
         await using var transaction = connection.BeginTransaction();
+
         await using (var command = connection.CreateCommand())
         {
             command.Transaction = transaction;
-            command.CommandText = "INSERT INTO module_publication_attempts (id, namespace, name, provider, version, state, staging_key, created_at, updated_at) VALUES ($id,$ns,$name,$provider,$version,$state,$key,$created,$updated)";
-            command.Parameters.AddWithValue("$id", attempt.Id.ToString()); command.Parameters.AddWithValue("$ns", attempt.Namespace); command.Parameters.AddWithValue("$name", attempt.Name); command.Parameters.AddWithValue("$provider", attempt.Provider); command.Parameters.AddWithValue("$version", attempt.Version); command.Parameters.AddWithValue("$state", attempt.State); command.Parameters.AddWithValue("$key", attempt.StagingKey); command.Parameters.AddWithValue("$created", attempt.CreatedAt.ToString("O")); command.Parameters.AddWithValue("$updated", attempt.UpdatedAt.ToString("O"));
+            command.CommandText = """
+                INSERT INTO module_publication_attempts (
+                    id, namespace, name, provider, version, state, staging_key,
+                    expected_revision, committed_revision, error, created_at, updated_at, completed_at)
+                VALUES (
+                    $id, $namespace, $name, $provider, $version, $state, $stagingKey,
+                    $expectedRevision, $committedRevision, $error, $createdAt, $updatedAt, $completedAt)
+                """;
+            AddAttemptParameters(command, attempt);
             await command.ExecuteNonQueryAsync();
         }
+
         await using (var command = connection.CreateCommand())
         {
             command.Transaction = transaction;
-            command.CommandText = "INSERT INTO module_extraction_jobs (id, publication_attempt_id, namespace, name, provider, version, state, created_at, updated_at) VALUES ($id,$attempt,$ns,$name,$provider,$version,$state,$created,$updated)";
-            command.Parameters.AddWithValue("$id", job.Id.ToString()); command.Parameters.AddWithValue("$attempt", job.PublicationAttemptId.ToString()); command.Parameters.AddWithValue("$ns", job.Namespace); command.Parameters.AddWithValue("$name", job.Name); command.Parameters.AddWithValue("$provider", job.Provider); command.Parameters.AddWithValue("$version", job.Version); command.Parameters.AddWithValue("$state", job.State); command.Parameters.AddWithValue("$created", job.CreatedAt.ToString("O")); command.Parameters.AddWithValue("$updated", job.UpdatedAt.ToString("O"));
+            command.CommandText = """
+                INSERT INTO module_extraction_jobs (
+                    id, publication_attempt_id, namespace, name, provider, version, state, created_at, updated_at)
+                VALUES ($id, $attemptId, $namespace, $name, $provider, $version, $state, $createdAt, $updatedAt)
+                """;
+            AddJobParameters(command, job);
             await command.ExecuteNonQueryAsync();
         }
+
         transaction.Commit();
     }
-    public Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) => GetAttemptAsync(id);
-    private async Task<ModulePublicationAttempt?> GetAttemptAsync(Guid id) { await using var c=new SqliteConnection(connectionString); await c.OpenAsync(); await using var q=c.CreateCommand(); q.CommandText="SELECT id,namespace,name,provider,version,state,staging_key,created_at,updated_at FROM module_publication_attempts WHERE id=$id"; q.Parameters.AddWithValue("$id",id.ToString()); await using var r=await q.ExecuteReaderAsync(); return await r.ReadAsync()?new ModulePublicationAttempt{Id=Guid.Parse(r.GetString(0)),Namespace=r.GetString(1),Name=r.GetString(2),Provider=r.GetString(3),Version=r.GetString(4),State=r.GetString(5),StagingKey=r.GetString(6),CreatedAt=DateTime.Parse(r.GetString(7), null, System.Globalization.DateTimeStyles.RoundtripKind),UpdatedAt=DateTime.Parse(r.GetString(8), null, System.Globalization.DateTimeStyles.RoundtripKind)}:null; }
-    public async Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) { await using var c=new SqliteConnection(connectionString); await c.OpenAsync(); await using var q=c.CreateCommand(); q.CommandText="SELECT id,publication_attempt_id,namespace,name,provider,version,state,created_at,updated_at FROM module_extraction_jobs WHERE id=$id"; q.Parameters.AddWithValue("$id",id.ToString()); await using var r=await q.ExecuteReaderAsync(); return await r.ReadAsync()?new ModuleExtractionJob{Id=Guid.Parse(r.GetString(0)),PublicationAttemptId=Guid.Parse(r.GetString(1)),Namespace=r.GetString(2),Name=r.GetString(3),Provider=r.GetString(4),Version=r.GetString(5),State=r.GetString(6),CreatedAt=DateTime.Parse(r.GetString(7), null, System.Globalization.DateTimeStyles.RoundtripKind),UpdatedAt=DateTime.Parse(r.GetString(8), null, System.Globalization.DateTimeStyles.RoundtripKind)}:null; }
+
+    public async Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT id, namespace, name, provider, version, state, staging_key,
+                   expected_revision, committed_revision, error, created_at, updated_at, completed_at
+            FROM module_publication_attempts
+            WHERE id = $id
+            """;
+        command.Parameters.AddWithValue("$id", id.ToString());
+        await using var reader = await command.ExecuteReaderAsync();
+
+        return await reader.ReadAsync() ? ReadAttempt(reader) : null;
+    }
+
+    public async Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT id, publication_attempt_id, namespace, name, provider, version, state, created_at, updated_at
+            FROM module_extraction_jobs
+            WHERE id = $id
+            """;
+        command.Parameters.AddWithValue("$id", id.ToString());
+        await using var reader = await command.ExecuteReaderAsync();
+
+        return await reader.ReadAsync() ? ReadJob(reader) : null;
+    }
+
+    private static void AddAttemptParameters(SqliteCommand command, ModulePublicationAttempt attempt)
+    {
+        command.Parameters.AddWithValue("$id", attempt.Id.ToString());
+        command.Parameters.AddWithValue("$namespace", attempt.Namespace);
+        command.Parameters.AddWithValue("$name", attempt.Name);
+        command.Parameters.AddWithValue("$provider", attempt.Provider);
+        command.Parameters.AddWithValue("$version", attempt.Version);
+        command.Parameters.AddWithValue("$state", attempt.State);
+        command.Parameters.AddWithValue("$stagingKey", attempt.StagingKey);
+        command.Parameters.AddWithValue("$expectedRevision", (object?)attempt.ExpectedRevision ?? DBNull.Value);
+        command.Parameters.AddWithValue("$committedRevision", (object?)attempt.CommittedRevision ?? DBNull.Value);
+        command.Parameters.AddWithValue("$error", (object?)attempt.Error ?? DBNull.Value);
+        command.Parameters.AddWithValue("$createdAt", attempt.CreatedAt.ToString("O"));
+        command.Parameters.AddWithValue("$updatedAt", attempt.UpdatedAt.ToString("O"));
+        command.Parameters.AddWithValue("$completedAt", attempt.CompletedAt?.ToString("O") ?? (object)DBNull.Value);
+    }
+
+    private static void AddJobParameters(SqliteCommand command, ModuleExtractionJob job)
+    {
+        command.Parameters.AddWithValue("$id", job.Id.ToString());
+        command.Parameters.AddWithValue("$attemptId", job.PublicationAttemptId.ToString());
+        command.Parameters.AddWithValue("$namespace", job.Namespace);
+        command.Parameters.AddWithValue("$name", job.Name);
+        command.Parameters.AddWithValue("$provider", job.Provider);
+        command.Parameters.AddWithValue("$version", job.Version);
+        command.Parameters.AddWithValue("$state", job.State);
+        command.Parameters.AddWithValue("$createdAt", job.CreatedAt.ToString("O"));
+        command.Parameters.AddWithValue("$updatedAt", job.UpdatedAt.ToString("O"));
+    }
+
+    private static ModulePublicationAttempt ReadAttempt(SqliteDataReader reader) => new()
+    {
+        Id = Guid.Parse(reader.GetString(0)),
+        Namespace = reader.GetString(1),
+        Name = reader.GetString(2),
+        Provider = reader.GetString(3),
+        Version = reader.GetString(4),
+        State = reader.GetString(5),
+        StagingKey = reader.GetString(6),
+        ExpectedRevision = reader.IsDBNull(7) ? null : reader.GetString(7),
+        CommittedRevision = reader.IsDBNull(8) ? null : reader.GetString(8),
+        Error = reader.IsDBNull(9) ? null : reader.GetString(9),
+        CreatedAt = DateTime.Parse(reader.GetString(10), null, DateTimeStyles.RoundtripKind),
+        UpdatedAt = DateTime.Parse(reader.GetString(11), null, DateTimeStyles.RoundtripKind),
+        CompletedAt = reader.IsDBNull(12)
+            ? null
+            : DateTime.Parse(reader.GetString(12), null, DateTimeStyles.RoundtripKind)
+    };
+
+    private static ModuleExtractionJob ReadJob(SqliteDataReader reader) => new()
+    {
+        Id = Guid.Parse(reader.GetString(0)),
+        PublicationAttemptId = Guid.Parse(reader.GetString(1)),
+        Namespace = reader.GetString(2),
+        Name = reader.GetString(3),
+        Provider = reader.GetString(4),
+        Version = reader.GetString(5),
+        State = reader.GetString(6),
+        CreatedAt = DateTime.Parse(reader.GetString(7), null, DateTimeStyles.RoundtripKind),
+        UpdatedAt = DateTime.Parse(reader.GetString(8), null, DateTimeStyles.RoundtripKind)
+    };
 }

--- a/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
@@ -63,6 +63,25 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         return await reader.ReadAsync() ? ReadAttempt(reader) : null;
     }
 
+    public async Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE module_publication_attempts
+            SET state = $failed, error = $failureReason, updated_at = $updatedAt, completed_at = $completedAt
+            WHERE id = $id AND state = $staged
+            """;
+        command.Parameters.AddWithValue("$failed", ModulePublicationAttemptState.Failed);
+        command.Parameters.AddWithValue("$failureReason", failureReason);
+        command.Parameters.AddWithValue("$updatedAt", DateTime.UtcNow.ToString("O"));
+        command.Parameters.AddWithValue("$completedAt", DateTime.UtcNow.ToString("O"));
+        command.Parameters.AddWithValue("$id", attemptId.ToString());
+        command.Parameters.AddWithValue("$staged", ModulePublicationAttemptState.Staged);
+        return await command.ExecuteNonQueryAsync() == 1;
+    }
+
     public async Task<bool> TryCommitStagedPublicationAsync(
         ModulePublicationAttempt attempt,
         ModuleStorage newModule,

--- a/TerraformRegistry/Services/SqliteDatabaseService.cs
+++ b/TerraformRegistry/Services/SqliteDatabaseService.cs
@@ -43,6 +43,12 @@ public class SqliteDatabaseService : IDatabaseService, IModulePublicationReposit
     public Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job) =>
         _publications.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
 
+    public Task<bool> TryCommitStagedPublicationAsync(
+        ModulePublicationAttempt attempt,
+        ModuleStorage newModule,
+        ModuleStorage? expectedModule) =>
+        _publications.TryCommitStagedPublicationAsync(attempt, newModule, expectedModule);
+
     public Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) => _publications.GetPublicationAttemptAsync(id);
 
     public Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) => _publications.GetExtractionJobAsync(id);

--- a/TerraformRegistry/Services/SqliteDatabaseService.cs
+++ b/TerraformRegistry/Services/SqliteDatabaseService.cs
@@ -10,7 +10,7 @@ namespace TerraformRegistry.Services;
 /// <summary>
 ///     SQLite compatibility facade for local development/storage.
 /// </summary>
-public class SqliteDatabaseService : IDatabaseService, IInitializableDb
+public class SqliteDatabaseService : IDatabaseService, IModulePublicationRepository, IInitializableDb
 {
     private readonly string _connectionString;
     private readonly DbUpMigrator _dbUpMigrator;
@@ -18,6 +18,7 @@ public class SqliteDatabaseService : IDatabaseService, IInitializableDb
     private readonly SqliteModuleDownloadRecorder _downloads;
     private readonly SqliteModuleExtractionRepository _moduleExtractions;
     private readonly SqliteModuleRepository _modules;
+    private readonly SqliteModulePublicationRepository _publications;
     private readonly SqliteUserRepository _users;
 
     public SqliteDatabaseService(string connectionString, string baseUrl, ILogger<SqliteDatabaseService> logger,
@@ -26,6 +27,7 @@ public class SqliteDatabaseService : IDatabaseService, IInitializableDb
         _connectionString = connectionString;
         _dbUpMigrator = dbUpMigrator;
         _modules = new SqliteModuleRepository(connectionString, baseUrl, logger);
+        _publications = new SqliteModulePublicationRepository(connectionString);
         _moduleExtractions = new SqliteModuleExtractionRepository(connectionString);
         _users = new SqliteUserRepository(connectionString);
         _apiKeys = new SqliteApiKeyRepository(connectionString);
@@ -37,6 +39,13 @@ public class SqliteDatabaseService : IDatabaseService, IInitializableDb
         _dbUpMigrator.Migrate("sqlite", _connectionString);
         return Task.CompletedTask;
     }
+
+    public Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job) =>
+        _publications.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+
+    public Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) => _publications.GetPublicationAttemptAsync(id);
+
+    public Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) => _publications.GetExtractionJobAsync(id);
 
     public Task<ModuleList> ListModulesAsync(ModuleSearchRequest request) =>
         _modules.ListModulesAsync(request);

--- a/TerraformRegistry/Services/SqliteDatabaseService.cs
+++ b/TerraformRegistry/Services/SqliteDatabaseService.cs
@@ -49,6 +49,9 @@ public class SqliteDatabaseService : IDatabaseService, IModulePublicationReposit
         ModuleStorage? expectedModule) =>
         _publications.TryCommitStagedPublicationAsync(attempt, newModule, expectedModule);
 
+    public Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason) =>
+        _publications.TryFailStagedPublicationAsync(attemptId, failureReason);
+
     public Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) => _publications.GetPublicationAttemptAsync(id);
 
     public Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) => _publications.GetExtractionJobAsync(id);


### PR DESCRIPTION
## Scope

Introduces the shared persistence contract and schema for publication attempts and durable extraction jobs.

## Completed in this draft

- SQLite and PostgreSQL migration tables
- Atomic creation of an attempt plus extraction job
- Transactional catalog create/replace compare-and-swap with attempt commit
- Guarded failure transition: only staged attempts can be failed
- SQLite and PostgreSQL round-trip and transaction coverage
- Real PostgreSQL container coverage

## Remaining before review/merge

- connect the contract to storage backend promotion and rollback cleanup
- full package verification and review

This remains a draft until backend integration is represented by the follow-on storage packages.