### PR TITLE
feat: persist extraction jobs with leases

### DIFF
--- a/TerraformRegistry.API/Interfaces/IDatabaseService.cs
+++ b/TerraformRegistry.API/Interfaces/IDatabaseService.cs
@@ -9,7 +9,8 @@ public interface IDatabaseService :
     IUserRepository,
     IApiKeyRepository,
     IModuleDownloadRecorder,
-    IModulePublicationRepository
+    IModulePublicationRepository,
+    IModuleExtractionJobRepository
 {
     /// <summary>
     ///     Checks that the database connection is healthy.

--- a/TerraformRegistry.API/Interfaces/IModuleExtractionJobRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleExtractionJobRepository.cs
@@ -1,0 +1,34 @@
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.API.Interfaces;
+
+/// <summary>
+/// Provides durable, lease-based coordination for module extraction work.
+/// </summary>
+public interface IModuleExtractionJobRepository
+{
+    Task<ModuleExtractionJob?> TryClaimNextExtractionJobAsync(
+        string ownerId,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> TryHeartbeatExtractionJobAsync(
+        Guid jobId,
+        string ownerId,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> TryCompleteExtractionJobAsync(
+        Guid jobId,
+        string ownerId,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> TryFailExtractionJobAsync(
+        Guid jobId,
+        string ownerId,
+        string failureReason,
+        int maximumAttempts,
+        CancellationToken cancellationToken = default);
+
+    Task<int> CountPendingExtractionJobsAsync(CancellationToken cancellationToken = default);
+}

--- a/TerraformRegistry.Models/ModuleExtractionJob.cs
+++ b/TerraformRegistry.Models/ModuleExtractionJob.cs
@@ -1,6 +1,13 @@
 namespace TerraformRegistry.Models;
 
-public static class ModuleExtractionJobState { public const string Pending = "pending"; }
+public static class ModuleExtractionJobState
+{
+    public const string Pending = "pending";
+    public const string Processing = "processing";
+    public const string Retry = "retry";
+    public const string Succeeded = "succeeded";
+    public const string DeadLetter = "dead-letter";
+}
 
 public sealed record ModuleExtractionJob
 {
@@ -11,6 +18,11 @@ public sealed record ModuleExtractionJob
     public required string Provider { get; init; }
     public required string Version { get; init; }
     public required string State { get; init; }
+    public string? OwnerId { get; init; }
+    public DateTime? LeaseExpiresAt { get; init; }
+    public int AttemptCount { get; init; }
+    public string? LastError { get; init; }
     public required DateTime CreatedAt { get; init; }
     public required DateTime UpdatedAt { get; init; }
+    public DateTime? CompletedAt { get; init; }
 }

--- a/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
@@ -10,7 +10,7 @@ namespace TerraformRegistry.PostgreSQL;
 /// <summary>
 ///     PostgreSQL compatibility facade for registry database storage.
 /// </summary>
-public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRepository, IInitializableDb
+public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRepository, IModuleExtractionJobRepository, IInitializableDb
 {
     private readonly string _connectionString;
     private readonly DbUpMigrator _dbUpMigrator;
@@ -47,6 +47,21 @@ public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRep
         _publications.TryFailStagedPublicationAsync(attemptId, failureReason);
     public Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) => _publications.GetPublicationAttemptAsync(id);
     public Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) => _publications.GetExtractionJobAsync(id);
+
+    public Task<ModuleExtractionJob?> TryClaimNextExtractionJobAsync(string ownerId, TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default) =>
+        _publications.TryClaimNextExtractionJobAsync(ownerId, leaseDuration, cancellationToken);
+    public Task<bool> TryHeartbeatExtractionJobAsync(Guid jobId, string ownerId, TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default) =>
+        _publications.TryHeartbeatExtractionJobAsync(jobId, ownerId, leaseDuration, cancellationToken);
+    public Task<bool> TryCompleteExtractionJobAsync(Guid jobId, string ownerId,
+        CancellationToken cancellationToken = default) =>
+        _publications.TryCompleteExtractionJobAsync(jobId, ownerId, cancellationToken);
+    public Task<bool> TryFailExtractionJobAsync(Guid jobId, string ownerId, string failureReason, int maximumAttempts,
+        CancellationToken cancellationToken = default) =>
+        _publications.TryFailExtractionJobAsync(jobId, ownerId, failureReason, maximumAttempts, cancellationToken);
+    public Task<int> CountPendingExtractionJobsAsync(CancellationToken cancellationToken = default) =>
+        _publications.CountPendingExtractionJobsAsync(cancellationToken);
 
     public Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version) =>
         _modules.GetModuleAsync(moduleNamespace, name, provider, version);

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
@@ -6,7 +6,9 @@ using TerraformRegistry.Models;
 
 namespace TerraformRegistry.PostgreSQL.Repositories;
 
-public sealed class PostgreSqlModulePublicationRepository(string connectionString) : IModulePublicationRepository
+public sealed class PostgreSqlModulePublicationRepository(string connectionString) :
+    IModulePublicationRepository,
+    IModuleExtractionJobRepository
 {
     public async Task CreatePublicationAttemptWithExtractionJobAsync(
         ModulePublicationAttempt attempt,
@@ -25,10 +27,12 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
                 @expectedRevision, @committedRevision, @error, @createdAt, @updatedAt, @completedAt);
 
             INSERT INTO module_extraction_jobs (
-                id, publication_attempt_id, namespace, name, provider, version, state, created_at, updated_at)
+                id, publication_attempt_id, namespace, name, provider, version, state, owner_id,
+                lease_expires_at, attempt_count, last_error, created_at, updated_at, completed_at)
             VALUES (
                 @jobId, @attemptId, @jobNamespace, @jobName, @jobProvider, @jobVersion, @jobState,
-                @jobCreatedAt, @jobUpdatedAt);
+                @jobOwnerId, @jobLeaseExpiresAt, @jobAttemptCount, @jobLastError,
+                @jobCreatedAt, @jobUpdatedAt, @jobCompletedAt);
             """,
             connection,
             transaction);
@@ -127,7 +131,8 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         await connection.OpenAsync();
         await using var command = new NpgsqlCommand(
             """
-            SELECT id, publication_attempt_id, namespace, name, provider, version, state, created_at, updated_at
+            SELECT id, publication_attempt_id, namespace, name, provider, version, state, owner_id,
+                   lease_expires_at, attempt_count, last_error, created_at, updated_at, completed_at
             FROM module_extraction_jobs
             WHERE id = @id
             """,
@@ -136,6 +141,92 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         await using var reader = await command.ExecuteReaderAsync();
 
         return await reader.ReadAsync() ? ReadJob(reader) : null;
+    }
+
+    public async Task<ModuleExtractionJob?> TryClaimNextExtractionJobAsync(
+        string ownerId,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = new NpgsqlCommand("""
+            WITH candidate AS (
+                SELECT id
+                FROM module_extraction_jobs
+                WHERE state IN (@pending, @retry)
+                   OR (state = @processing AND lease_expires_at <= @now)
+                ORDER BY created_at, id
+                FOR UPDATE SKIP LOCKED
+                LIMIT 1)
+            UPDATE module_extraction_jobs AS jobs
+            SET state = @processing, owner_id = @ownerId, lease_expires_at = @leaseExpiresAt,
+                attempt_count = jobs.attempt_count + 1, updated_at = @updatedAt,
+                last_error = CASE WHEN jobs.state = @processing THEN jobs.last_error ELSE NULL END
+            FROM candidate
+            WHERE jobs.id = candidate.id
+            RETURNING jobs.id, jobs.publication_attempt_id, jobs.namespace, jobs.name, jobs.provider, jobs.version,
+                      jobs.state, jobs.owner_id, jobs.lease_expires_at, jobs.attempt_count, jobs.last_error,
+                      jobs.created_at, jobs.updated_at, jobs.completed_at
+            """, connection);
+        AddClaimParameters(command, ownerId, leaseDuration, now);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        return await reader.ReadAsync(cancellationToken) ? ReadJob(reader) : null;
+    }
+
+    public Task<bool> TryHeartbeatExtractionJobAsync(Guid jobId, string ownerId, TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default) =>
+        UpdateLeasedJobAsync(jobId, ownerId, """
+            UPDATE module_extraction_jobs
+            SET lease_expires_at = @leaseExpiresAt, updated_at = @updatedAt
+            WHERE id = @id AND state = @processing AND owner_id = @ownerId
+            """, leaseDuration, cancellationToken);
+
+    public Task<bool> TryCompleteExtractionJobAsync(Guid jobId, string ownerId,
+        CancellationToken cancellationToken = default) =>
+        UpdateLeasedJobAsync(jobId, ownerId, """
+            UPDATE module_extraction_jobs
+            SET state = @succeeded, owner_id = NULL, lease_expires_at = NULL,
+                updated_at = @updatedAt, completed_at = @completedAt, last_error = NULL
+            WHERE id = @id AND state = @processing AND owner_id = @ownerId
+            """, TimeSpan.Zero, cancellationToken);
+
+    public async Task<bool> TryFailExtractionJobAsync(Guid jobId, string ownerId, string failureReason,
+        int maximumAttempts, CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = new NpgsqlCommand("""
+            UPDATE module_extraction_jobs
+            SET state = CASE WHEN attempt_count >= @maximumAttempts THEN @deadLetter ELSE @retry END,
+                owner_id = NULL, lease_expires_at = NULL, last_error = @failureReason,
+                updated_at = @updatedAt,
+                completed_at = CASE WHEN attempt_count >= @maximumAttempts THEN @completedAt ELSE NULL END
+            WHERE id = @id AND state = @processing AND owner_id = @ownerId
+            """, connection);
+        command.Parameters.AddWithValue("@maximumAttempts", maximumAttempts);
+        command.Parameters.AddWithValue("@deadLetter", ModuleExtractionJobState.DeadLetter);
+        command.Parameters.AddWithValue("@retry", ModuleExtractionJobState.Retry);
+        command.Parameters.AddWithValue("@failureReason", failureReason);
+        command.Parameters.AddWithValue("@updatedAt", now);
+        command.Parameters.AddWithValue("@completedAt", now);
+        command.Parameters.AddWithValue("@id", jobId);
+        command.Parameters.AddWithValue("@processing", ModuleExtractionJobState.Processing);
+        command.Parameters.AddWithValue("@ownerId", ownerId);
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
+    }
+
+    public async Task<int> CountPendingExtractionJobsAsync(CancellationToken cancellationToken = default)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(
+            "SELECT COUNT(*) FROM module_extraction_jobs WHERE state IN (@pending, @retry)", connection);
+        command.Parameters.AddWithValue("@pending", ModuleExtractionJobState.Pending);
+        command.Parameters.AddWithValue("@retry", ModuleExtractionJobState.Retry);
+        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken), System.Globalization.CultureInfo.InvariantCulture);
     }
 
     private static void AddAttemptParameters(NpgsqlCommand command, ModulePublicationAttempt attempt)
@@ -233,8 +324,13 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         command.Parameters.AddWithValue("@jobProvider", job.Provider);
         command.Parameters.AddWithValue("@jobVersion", job.Version);
         command.Parameters.AddWithValue("@jobState", job.State);
+        command.Parameters.AddWithValue("@jobOwnerId", (object?)job.OwnerId ?? DBNull.Value);
+        command.Parameters.AddWithValue("@jobLeaseExpiresAt", (object?)job.LeaseExpiresAt ?? DBNull.Value);
+        command.Parameters.AddWithValue("@jobAttemptCount", job.AttemptCount);
+        command.Parameters.AddWithValue("@jobLastError", (object?)job.LastError ?? DBNull.Value);
         command.Parameters.AddWithValue("@jobCreatedAt", job.CreatedAt);
         command.Parameters.AddWithValue("@jobUpdatedAt", job.UpdatedAt);
+        command.Parameters.AddWithValue("@jobCompletedAt", (object?)job.CompletedAt ?? DBNull.Value);
     }
 
     private static ModulePublicationAttempt ReadAttempt(NpgsqlDataReader reader) => new()
@@ -263,7 +359,40 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         Provider = reader.GetString(4),
         Version = reader.GetString(5),
         State = reader.GetString(6),
-        CreatedAt = reader.GetDateTime(7),
-        UpdatedAt = reader.GetDateTime(8)
+        OwnerId = reader.IsDBNull(7) ? null : reader.GetString(7),
+        LeaseExpiresAt = reader.IsDBNull(8) ? null : reader.GetDateTime(8),
+        AttemptCount = reader.GetInt32(9),
+        LastError = reader.IsDBNull(10) ? null : reader.GetString(10),
+        CreatedAt = reader.GetDateTime(11),
+        UpdatedAt = reader.GetDateTime(12),
+        CompletedAt = reader.IsDBNull(13) ? null : reader.GetDateTime(13)
     };
+
+    private static void AddClaimParameters(NpgsqlCommand command, string ownerId, TimeSpan leaseDuration, DateTime now)
+    {
+        command.Parameters.AddWithValue("@pending", ModuleExtractionJobState.Pending);
+        command.Parameters.AddWithValue("@retry", ModuleExtractionJobState.Retry);
+        command.Parameters.AddWithValue("@processing", ModuleExtractionJobState.Processing);
+        command.Parameters.AddWithValue("@now", now);
+        command.Parameters.AddWithValue("@ownerId", ownerId);
+        command.Parameters.AddWithValue("@leaseExpiresAt", now.Add(leaseDuration));
+        command.Parameters.AddWithValue("@updatedAt", now);
+    }
+
+    private async Task<bool> UpdateLeasedJobAsync(Guid jobId, string ownerId, string sql, TimeSpan leaseDuration,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@id", jobId);
+        command.Parameters.AddWithValue("@ownerId", ownerId);
+        command.Parameters.AddWithValue("@processing", ModuleExtractionJobState.Processing);
+        command.Parameters.AddWithValue("@succeeded", ModuleExtractionJobState.Succeeded);
+        command.Parameters.AddWithValue("@leaseExpiresAt", now.Add(leaseDuration));
+        command.Parameters.AddWithValue("@updatedAt", now);
+        command.Parameters.AddWithValue("@completedAt", now);
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
+    }
 }

--- a/TerraformRegistry.Tests/UnitTests/Database/ExtractionJobRepositoryContract.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/ExtractionJobRepositoryContract.cs
@@ -1,0 +1,69 @@
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Tests.UnitTests.Database;
+
+internal static class ExtractionJobRepositoryContract
+{
+    public static async Task LeasesClaimsRetriesAndDeadLetters(
+        IModulePublicationRepository publications,
+        IModuleExtractionJobRepository jobs)
+    {
+        var now = DateTime.UtcNow;
+        var attempt = new ModulePublicationAttempt
+        {
+            Id = Guid.NewGuid(),
+            Namespace = "acme",
+            Name = "network",
+            Provider = "aws",
+            Version = "1.0.0",
+            State = ModulePublicationAttemptState.Staged,
+            StagingKey = $"staging/{Guid.NewGuid():N}",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        var job = new ModuleExtractionJob
+        {
+            Id = Guid.NewGuid(),
+            PublicationAttemptId = attempt.Id,
+            Namespace = attempt.Namespace,
+            Name = attempt.Name,
+            Provider = attempt.Provider,
+            Version = attempt.Version,
+            State = ModuleExtractionJobState.Pending,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        await publications.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+        Assert.Equal(1, await jobs.CountPendingExtractionJobsAsync());
+
+        var firstClaim = await jobs.TryClaimNextExtractionJobAsync("worker-a", TimeSpan.FromMilliseconds(1));
+        Assert.NotNull(firstClaim);
+        Assert.Equal(ModuleExtractionJobState.Processing, firstClaim.State);
+        Assert.Equal("worker-a", firstClaim.OwnerId);
+        Assert.Equal(1, firstClaim.AttemptCount);
+        Assert.False(await jobs.TryHeartbeatExtractionJobAsync(job.Id, "worker-b", TimeSpan.FromMinutes(1)));
+        Assert.True(await jobs.TryHeartbeatExtractionJobAsync(job.Id, "worker-a", TimeSpan.FromMilliseconds(1)));
+
+        await Task.Delay(25);
+        var reclaimed = await jobs.TryClaimNextExtractionJobAsync("worker-b", TimeSpan.FromMinutes(1));
+        Assert.NotNull(reclaimed);
+        Assert.Equal("worker-b", reclaimed.OwnerId);
+        Assert.Equal(2, reclaimed.AttemptCount);
+        Assert.False(await jobs.TryCompleteExtractionJobAsync(job.Id, "worker-a"));
+        Assert.True(await jobs.TryFailExtractionJobAsync(job.Id, "worker-b", "transient failure", 3));
+
+        var retry = await jobs.TryClaimNextExtractionJobAsync("worker-c", TimeSpan.FromMinutes(1));
+        Assert.NotNull(retry);
+        Assert.Equal(3, retry.AttemptCount);
+        Assert.True(await jobs.TryFailExtractionJobAsync(job.Id, "worker-c", "terminal failure", 3));
+
+        var deadLetter = await publications.GetExtractionJobAsync(job.Id);
+        Assert.NotNull(deadLetter);
+        Assert.Equal(ModuleExtractionJobState.DeadLetter, deadLetter.State);
+        Assert.Equal("terminal failure", deadLetter.LastError);
+        Assert.NotNull(deadLetter.CompletedAt);
+        Assert.Equal(0, await jobs.CountPendingExtractionJobsAsync());
+    }
+}

--- a/TerraformRegistry.Tests/UnitTests/Database/MirrorRepositoryTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/MirrorRepositoryTests.cs
@@ -74,6 +74,14 @@ public sealed class SqliteMirrorRepositoryTests : IDisposable
         await PublicationCommitContract.CommitsCatalogUsingExpectedSnapshot(database, database);
     }
 
+    [Fact]
+    public async Task ExtractionJobsLeaseClaimRetryAndDeadLetter()
+    {
+        var repository = new SqliteModulePublicationRepository(_connectionString);
+
+        await ExtractionJobRepositoryContract.LeasesClaimsRetriesAndDeadLetters(repository, repository);
+    }
+
     public void Dispose()
     {
         _connection.Dispose();
@@ -150,6 +158,14 @@ public sealed class PostgreSqlMirrorRepositoryTests : IAsyncLifetime
             new DbUpMigrator(NullLogger<DbUpMigrator>.Instance));
 
         await PublicationCommitContract.CommitsCatalogUsingExpectedSnapshot(database, database);
+    }
+
+    [Fact]
+    public async Task ExtractionJobsLeaseClaimRetryAndDeadLetter()
+    {
+        var repository = new PostgreSqlModulePublicationRepository(_connectionString);
+
+        await ExtractionJobRepositoryContract.LeasesClaimsRetriesAndDeadLetters(repository, repository);
     }
 }
 

--- a/TerraformRegistry.Tests/UnitTests/ModuleExtractionQueueRuntimeTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleExtractionQueueRuntimeTests.cs
@@ -52,6 +52,11 @@ public class ModuleExtractionQueueRuntimeTests
         Assert.NotNull(metadata.LlmContext);
         Assert.Equal("pending", metadata.LlmContext.Status);
         Assert.NotNull(metadata.LlmContext.LastUpdatedAt);
+        database.Verify(x => x.CreatePublicationAttemptWithExtractionJobAsync(
+            It.Is<ModulePublicationAttempt>(attempt =>
+                attempt.Namespace == "acme" && attempt.State == ModulePublicationAttemptState.Committed),
+            It.Is<ModuleExtractionJob>(job =>
+                job.Namespace == "acme" && job.State == ModuleExtractionJobState.Pending)), Times.Once);
     }
 
     [Fact]
@@ -162,9 +167,28 @@ public class ModuleExtractionQueueRuntimeTests
         Assert.Equal("tool missing", metadata.Extraction.Error);
     }
 
+    [Fact]
+    public async Task QueueAsyncRejectsWorkWhenDurableBacklogIsFull()
+    {
+        var config = new Mock<IModuleExtractionConfigService>();
+        config.Setup(x => x.IsEnabledAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        var database = new Mock<IDatabaseService>();
+        database.Setup(x => x.CountPendingExtractionJobsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var service = CreateService(config.Object, database.Object, new ModuleExtractionOptions { MaxPendingJobs = 1 });
+
+        var queued = await service.QueueAsync(new ModuleExtractionRequest("acme", "network", "aws", "1.0.0"),
+            CancellationToken.None);
+
+        Assert.False(queued);
+        database.Verify(x => x.CreatePublicationAttemptWithExtractionJobAsync(
+            It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()), Times.Never);
+    }
+
     private static ModuleExtractionService CreateService(
         IModuleExtractionConfigService config,
-        IDatabaseService? database = null)
+        IDatabaseService? database = null,
+        ModuleExtractionOptions? options = null)
     {
         return new ModuleExtractionService(
             Mock.Of<IModuleService>(),
@@ -173,6 +197,7 @@ public class ModuleExtractionQueueRuntimeTests
             Mock.Of<ITerraformModuleInspector>(),
             Mock.Of<IModuleLlmContextGenerator>(),
             config,
-            NullLogger<ModuleExtractionService>.Instance);
+            NullLogger<ModuleExtractionService>.Instance,
+            options);
     }
 }

--- a/TerraformRegistry/Services/ModuleExtraction/IModuleExtractionService.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/IModuleExtractionService.cs
@@ -4,7 +4,7 @@ public interface IModuleExtractionService
 {
     Task<bool> QueueAsync(ModuleExtractionRequest request, CancellationToken cancellationToken);
     Task<IReadOnlyList<ModuleExtractionRequest>> QueueBackfillAsync(int limit, CancellationToken cancellationToken);
-    IAsyncEnumerable<ModuleExtractionRequest> ReadQueuedAsync(CancellationToken cancellationToken);
+    Task<bool> ProcessNextAsync(string ownerId, CancellationToken cancellationToken);
     Task ExtractAsync(ModuleExtractionRequest request, CancellationToken cancellationToken);
     Task RegenerateLlmContextAsync(ModuleExtractionRequest request, CancellationToken cancellationToken);
 }

--- a/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionHostedService.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionHostedService.cs
@@ -26,28 +26,9 @@ public sealed class ModuleExtractionHostedService : BackgroundService
     {
         await QueueBackfillAsync(stoppingToken);
 
-        await foreach (var request in _extractionService.ReadQueuedAsync(stoppingToken))
-        {
-            try
-            {
-                await WaitUntilEnabledAsync(stoppingToken);
-                await _extractionService.ExtractAsync(request, stoppingToken);
-            }
-            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                RegistryLog.Error(_logger,
-                    ex,
-                    "Module extraction failed for {Namespace}/{Name}/{Provider}/{Version}",
-                    request.Namespace,
-                    request.Name,
-                    request.Provider,
-                    request.Version);
-            }
-        }
+        var workers = Enumerable.Range(0, _options.WorkerConcurrency)
+            .Select(index => RunWorkerAsync($"{Environment.MachineName}-{Environment.ProcessId}-{index}", stoppingToken));
+        await Task.WhenAll(workers);
     }
 
     private async Task QueueBackfillAsync(CancellationToken stoppingToken)
@@ -79,6 +60,28 @@ public sealed class ModuleExtractionHostedService : BackgroundService
         {
             RegistryLog.Information(_logger, "Module extraction is disabled. Waiting before processing queued work.");
             await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+        }
+    }
+
+    private async Task RunWorkerAsync(string ownerId, CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await WaitUntilEnabledAsync(stoppingToken);
+                if (!await _extractionService.ProcessNextAsync(ownerId, stoppingToken))
+                    await Task.Delay(_options.JobPollIntervalMilliseconds, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                RegistryLog.Error(_logger, ex, "Durable module extraction worker {OwnerId} failed.", ownerId);
+                await Task.Delay(_options.JobPollIntervalMilliseconds, stoppingToken);
+            }
         }
     }
 }

--- a/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionService.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionService.cs
@@ -1,4 +1,3 @@
-using System.Threading.Channels;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.API.Logging;
 using TerraformRegistry.Models;
@@ -7,13 +6,6 @@ namespace TerraformRegistry.Services.ModuleExtraction;
 
 public sealed class ModuleExtractionService : IModuleExtractionService
 {
-    private readonly Channel<ModuleExtractionRequest> _queue =
-        Channel.CreateUnbounded<ModuleExtractionRequest>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false
-        });
-
     private readonly IDatabaseService _databaseService;
     private readonly IModuleExtractionConfigService _configService;
     private readonly ITerraformModuleInspector _inspector;
@@ -21,6 +13,7 @@ public sealed class ModuleExtractionService : IModuleExtractionService
     private readonly ILogger<ModuleExtractionService> _logger;
     private readonly IModuleService _moduleService;
     private readonly IArchiveWorkspaceFactory _workspaceFactory;
+    private readonly ModuleExtractionOptions _options;
 
     public ModuleExtractionService(
         IModuleService moduleService,
@@ -29,7 +22,8 @@ public sealed class ModuleExtractionService : IModuleExtractionService
         ITerraformModuleInspector inspector,
         IModuleLlmContextGenerator llmContextGenerator,
         IModuleExtractionConfigService configService,
-        ILogger<ModuleExtractionService> logger)
+        ILogger<ModuleExtractionService> logger,
+        ModuleExtractionOptions? options = null)
     {
         _moduleService = moduleService;
         _databaseService = databaseService;
@@ -38,6 +32,7 @@ public sealed class ModuleExtractionService : IModuleExtractionService
         _llmContextGenerator = llmContextGenerator;
         _configService = configService;
         _logger = logger;
+        _options = options ?? new ModuleExtractionOptions();
     }
 
     public async Task<bool> QueueAsync(ModuleExtractionRequest request, CancellationToken cancellationToken)
@@ -45,10 +40,10 @@ public sealed class ModuleExtractionService : IModuleExtractionService
         if (!await _configService.IsEnabledAsync(cancellationToken))
             return false;
 
-        if (!_queue.Writer.TryWrite(request))
+        if (await _databaseService.CountPendingExtractionJobsAsync(cancellationToken) >= _options.MaxPendingJobs)
         {
             RegistryLog.Warning(_logger,
-                "Unable to queue extraction for module {Namespace}/{Name}/{Provider}/{Version}",
+                "Extraction backlog is full; rejecting module {Namespace}/{Name}/{Provider}/{Version}",
                 request.Namespace,
                 request.Name,
                 request.Provider,
@@ -56,6 +51,33 @@ public sealed class ModuleExtractionService : IModuleExtractionService
             return false;
         }
 
+        var now = DateTime.UtcNow;
+        var attempt = new ModulePublicationAttempt
+        {
+            Id = Guid.NewGuid(),
+            Namespace = request.Namespace,
+            Name = request.Name,
+            Provider = request.Provider,
+            Version = request.Version,
+            State = ModulePublicationAttemptState.Committed,
+            StagingKey = $"extraction-jobs/{Guid.NewGuid():N}",
+            CreatedAt = now,
+            UpdatedAt = now,
+            CompletedAt = now
+        };
+        var job = new ModuleExtractionJob
+        {
+            Id = Guid.NewGuid(),
+            PublicationAttemptId = attempt.Id,
+            Namespace = request.Namespace,
+            Name = request.Name,
+            Provider = request.Provider,
+            Version = request.Version,
+            State = ModuleExtractionJobState.Pending,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        await _databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
         await MarkPendingAsync(request);
         return true;
     }
@@ -79,19 +101,69 @@ public sealed class ModuleExtractionService : IModuleExtractionService
                 module.Provider,
                 module.Version);
 
-            if (_queue.Writer.TryWrite(request))
-            {
-                await MarkPendingAsync(request);
+            if (await QueueAsync(request, cancellationToken))
                 queued.Add(request);
-            }
         }
 
         return queued;
     }
 
-    public IAsyncEnumerable<ModuleExtractionRequest> ReadQueuedAsync(CancellationToken cancellationToken)
+    public async Task<bool> ProcessNextAsync(string ownerId, CancellationToken cancellationToken)
     {
-        return _queue.Reader.ReadAllAsync(cancellationToken);
+        var leaseDuration = TimeSpan.FromSeconds(_options.JobLeaseSeconds);
+        var job = await _databaseService.TryClaimNextExtractionJobAsync(ownerId, leaseDuration, cancellationToken);
+        if (job is null)
+            return false;
+
+        var request = new ModuleExtractionRequest(job.Namespace, job.Name, job.Provider, job.Version);
+        using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var heartbeat = MaintainLeaseAsync(job.Id, ownerId, leaseDuration, linkedCancellation);
+        try
+        {
+            await ExtractAsync(request, linkedCancellation.Token);
+            if (!await _databaseService.TryCompleteExtractionJobAsync(job.Id, ownerId, cancellationToken))
+                RegistryLog.Warning(_logger, "Extraction lease was lost before completion for job {JobId}", job.Id);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await _databaseService.TryFailExtractionJobAsync(job.Id, ownerId, Truncate(ex.Message, 2048),
+                _options.JobRetryLimit, cancellationToken);
+            RegistryLog.Error(_logger, ex, "Module extraction job {JobId} failed", job.Id);
+        }
+        finally
+        {
+            await linkedCancellation.CancelAsync();
+            await heartbeat;
+        }
+
+        return true;
+    }
+
+    private async Task MaintainLeaseAsync(Guid jobId, string ownerId, TimeSpan leaseDuration,
+        CancellationTokenSource cancellation)
+    {
+        try
+        {
+            while (!cancellation.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromTicks(Math.Max(leaseDuration.Ticks / 2, TimeSpan.FromSeconds(1).Ticks)),
+                    cancellation.Token);
+                if (!await _databaseService.TryHeartbeatExtractionJobAsync(jobId, ownerId, leaseDuration,
+                        cancellation.Token))
+                {
+                    cancellation.Cancel();
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+            RegistryLog.Debug(_logger, "Extraction job lease maintenance stopped because the worker is shutting down.");
+        }
     }
 
     public async Task ExtractAsync(ModuleExtractionRequest request, CancellationToken cancellationToken)

--- a/TerraformRegistry/Services/ModuleExtraction/NoOpModuleExtractionService.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/NoOpModuleExtractionService.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace TerraformRegistry.Services.ModuleExtraction;
 
 public sealed class NoOpModuleExtractionService : IModuleExtractionService
@@ -14,12 +12,7 @@ public sealed class NoOpModuleExtractionService : IModuleExtractionService
         return Task.FromResult<IReadOnlyList<ModuleExtractionRequest>>([]);
     }
 
-    public async IAsyncEnumerable<ModuleExtractionRequest> ReadQueuedAsync(
-        [EnumeratorCancellation] CancellationToken cancellationToken)
-    {
-        await Task.CompletedTask;
-        yield break;
-    }
+    public Task<bool> ProcessNextAsync(string ownerId, CancellationToken cancellationToken) => Task.FromResult(false);
 
     public Task ExtractAsync(ModuleExtractionRequest request, CancellationToken cancellationToken)
     {

--- a/TerraformRegistry/Services/ModuleExtractionOptions.cs
+++ b/TerraformRegistry/Services/ModuleExtractionOptions.cs
@@ -13,6 +13,11 @@ public class ModuleExtractionOptions
     public int TimeoutSeconds { get; set; } = 15;
     public string TempRoot { get; set; } = Path.Combine(Path.GetTempPath(), "terraform-registry-extraction");
     public int StartupBackfillBatchSize { get; set; } = 25;
+    public int MaxPendingJobs { get; set; } = 1_000;
+    public int WorkerConcurrency { get; set; } = 2;
+    public int JobLeaseSeconds { get; set; } = 60;
+    public int JobRetryLimit { get; set; } = 3;
+    public int JobPollIntervalMilliseconds { get; set; } = 500;
     public long MaxArchiveBytes { get; set; } = DefaultMaxArchiveBytes;
     public long MaxExpandedArchiveBytes { get; set; } = DefaultMaxExpandedArchiveBytes;
     public int MaxArchiveEntries { get; set; } = DefaultMaxArchiveEntries;
@@ -25,6 +30,12 @@ public class ModuleExtractionOptions
             MaxArchiveEntries <= 0 || MaxCompressionRatio <= 0)
         {
             throw new InvalidOperationException("Archive ingestion limits must all be greater than zero.");
+        }
+
+        if (MaxPendingJobs <= 0 || WorkerConcurrency <= 0 || JobLeaseSeconds <= 0 || JobRetryLimit <= 0 ||
+            JobPollIntervalMilliseconds <= 0)
+        {
+            throw new InvalidOperationException("Extraction job limits must all be greater than zero.");
         }
     }
 }

--- a/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
@@ -6,7 +6,9 @@ using TerraformRegistry.Models;
 
 namespace TerraformRegistry.Services.Sqlite;
 
-public sealed class SqliteModulePublicationRepository(string connectionString) : IModulePublicationRepository
+public sealed class SqliteModulePublicationRepository(string connectionString) :
+    IModulePublicationRepository,
+    IModuleExtractionJobRepository
 {
     public async Task CreatePublicationAttemptWithExtractionJobAsync(
         ModulePublicationAttempt attempt,
@@ -36,8 +38,10 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
             command.Transaction = transaction;
             command.CommandText = """
                 INSERT INTO module_extraction_jobs (
-                    id, publication_attempt_id, namespace, name, provider, version, state, created_at, updated_at)
-                VALUES ($id, $attemptId, $namespace, $name, $provider, $version, $state, $createdAt, $updatedAt)
+                    id, publication_attempt_id, namespace, name, provider, version, state, owner_id,
+                    lease_expires_at, attempt_count, last_error, created_at, updated_at, completed_at)
+                VALUES ($id, $attemptId, $namespace, $name, $provider, $version, $state, $ownerId,
+                    $leaseExpiresAt, $attemptCount, $lastError, $createdAt, $updatedAt, $completedAt)
                 """;
             AddJobParameters(command, job);
             await command.ExecuteNonQueryAsync();
@@ -131,7 +135,8 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         await connection.OpenAsync();
         await using var command = connection.CreateCommand();
         command.CommandText = """
-            SELECT id, publication_attempt_id, namespace, name, provider, version, state, created_at, updated_at
+            SELECT id, publication_attempt_id, namespace, name, provider, version, state, owner_id,
+                   lease_expires_at, attempt_count, last_error, created_at, updated_at, completed_at
             FROM module_extraction_jobs
             WHERE id = $id
             """;
@@ -139,6 +144,88 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         await using var reader = await command.ExecuteReaderAsync();
 
         return await reader.ReadAsync() ? ReadJob(reader) : null;
+    }
+
+    public async Task<ModuleExtractionJob?> TryClaimNextExtractionJobAsync(
+        string ownerId,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE module_extraction_jobs
+            SET state = $processing, owner_id = $ownerId, lease_expires_at = $leaseExpiresAt,
+                attempt_count = attempt_count + 1, updated_at = $updatedAt,
+                last_error = CASE WHEN state = $processing THEN last_error ELSE NULL END
+            WHERE id = (
+                SELECT id FROM module_extraction_jobs
+                WHERE state IN ($pending, $retry)
+                   OR (state = $processing AND lease_expires_at <= $now)
+                ORDER BY created_at, id LIMIT 1)
+            RETURNING id, publication_attempt_id, namespace, name, provider, version, state, owner_id,
+                      lease_expires_at, attempt_count, last_error, created_at, updated_at, completed_at
+            """;
+        AddClaimParameters(command, ownerId, leaseDuration, now);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        return await reader.ReadAsync(cancellationToken) ? ReadJob(reader) : null;
+    }
+
+    public Task<bool> TryHeartbeatExtractionJobAsync(Guid jobId, string ownerId, TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default) =>
+        UpdateLeasedJobAsync(jobId, ownerId, """
+            UPDATE module_extraction_jobs
+            SET lease_expires_at = $leaseExpiresAt, updated_at = $updatedAt
+            WHERE id = $id AND state = $processing AND owner_id = $ownerId
+            """, leaseDuration, cancellationToken);
+
+    public Task<bool> TryCompleteExtractionJobAsync(Guid jobId, string ownerId,
+        CancellationToken cancellationToken = default) =>
+        UpdateLeasedJobAsync(jobId, ownerId, """
+            UPDATE module_extraction_jobs
+            SET state = $succeeded, owner_id = NULL, lease_expires_at = NULL,
+                updated_at = $updatedAt, completed_at = $completedAt, last_error = NULL
+            WHERE id = $id AND state = $processing AND owner_id = $ownerId
+            """, TimeSpan.Zero, cancellationToken);
+
+    public async Task<bool> TryFailExtractionJobAsync(Guid jobId, string ownerId, string failureReason,
+        int maximumAttempts, CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE module_extraction_jobs
+            SET state = CASE WHEN attempt_count >= $maximumAttempts THEN $deadLetter ELSE $retry END,
+                owner_id = NULL, lease_expires_at = NULL, last_error = $failureReason,
+                updated_at = $updatedAt,
+                completed_at = CASE WHEN attempt_count >= $maximumAttempts THEN $completedAt ELSE NULL END
+            WHERE id = $id AND state = $processing AND owner_id = $ownerId
+            """;
+        command.Parameters.AddWithValue("$maximumAttempts", maximumAttempts);
+        command.Parameters.AddWithValue("$deadLetter", ModuleExtractionJobState.DeadLetter);
+        command.Parameters.AddWithValue("$retry", ModuleExtractionJobState.Retry);
+        command.Parameters.AddWithValue("$failureReason", failureReason);
+        command.Parameters.AddWithValue("$updatedAt", now.ToString("O"));
+        command.Parameters.AddWithValue("$completedAt", now.ToString("O"));
+        command.Parameters.AddWithValue("$id", jobId.ToString());
+        command.Parameters.AddWithValue("$processing", ModuleExtractionJobState.Processing);
+        command.Parameters.AddWithValue("$ownerId", ownerId);
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
+    }
+
+    public async Task<int> CountPendingExtractionJobsAsync(CancellationToken cancellationToken = default)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM module_extraction_jobs WHERE state IN ($pending, $retry)";
+        command.Parameters.AddWithValue("$pending", ModuleExtractionJobState.Pending);
+        command.Parameters.AddWithValue("$retry", ModuleExtractionJobState.Retry);
+        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken), System.Globalization.CultureInfo.InvariantCulture);
     }
 
     private static void AddAttemptParameters(SqliteCommand command, ModulePublicationAttempt attempt)
@@ -223,6 +310,35 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
     private static string ParameterName(string prefix, string name) =>
         "$" + (string.IsNullOrEmpty(prefix) ? name : prefix + char.ToUpperInvariant(name[0]) + name[1..]);
 
+    private static void AddClaimParameters(SqliteCommand command, string ownerId, TimeSpan leaseDuration, DateTime now)
+    {
+        command.Parameters.AddWithValue("$processing", ModuleExtractionJobState.Processing);
+        command.Parameters.AddWithValue("$ownerId", ownerId);
+        command.Parameters.AddWithValue("$leaseExpiresAt", now.Add(leaseDuration).ToString("O"));
+        command.Parameters.AddWithValue("$updatedAt", now.ToString("O"));
+        command.Parameters.AddWithValue("$pending", ModuleExtractionJobState.Pending);
+        command.Parameters.AddWithValue("$retry", ModuleExtractionJobState.Retry);
+        command.Parameters.AddWithValue("$now", now.ToString("O"));
+    }
+
+    private async Task<bool> UpdateLeasedJobAsync(Guid jobId, string ownerId, string sql, TimeSpan leaseDuration,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("$id", jobId.ToString());
+        command.Parameters.AddWithValue("$ownerId", ownerId);
+        command.Parameters.AddWithValue("$processing", ModuleExtractionJobState.Processing);
+        command.Parameters.AddWithValue("$succeeded", ModuleExtractionJobState.Succeeded);
+        command.Parameters.AddWithValue("$leaseExpiresAt", now.Add(leaseDuration).ToString("O"));
+        command.Parameters.AddWithValue("$updatedAt", now.ToString("O"));
+        command.Parameters.AddWithValue("$completedAt", now.ToString("O"));
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
+    }
+
     private static void AddJobParameters(SqliteCommand command, ModuleExtractionJob job)
     {
         command.Parameters.AddWithValue("$id", job.Id.ToString());
@@ -232,8 +348,13 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         command.Parameters.AddWithValue("$provider", job.Provider);
         command.Parameters.AddWithValue("$version", job.Version);
         command.Parameters.AddWithValue("$state", job.State);
+        command.Parameters.AddWithValue("$ownerId", (object?)job.OwnerId ?? DBNull.Value);
+        command.Parameters.AddWithValue("$leaseExpiresAt", job.LeaseExpiresAt?.ToString("O") ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("$attemptCount", job.AttemptCount);
+        command.Parameters.AddWithValue("$lastError", (object?)job.LastError ?? DBNull.Value);
         command.Parameters.AddWithValue("$createdAt", job.CreatedAt.ToString("O"));
         command.Parameters.AddWithValue("$updatedAt", job.UpdatedAt.ToString("O"));
+        command.Parameters.AddWithValue("$completedAt", job.CompletedAt?.ToString("O") ?? (object)DBNull.Value);
     }
 
     private static ModulePublicationAttempt ReadAttempt(SqliteDataReader reader) => new()
@@ -264,7 +385,12 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         Provider = reader.GetString(4),
         Version = reader.GetString(5),
         State = reader.GetString(6),
-        CreatedAt = DateTime.Parse(reader.GetString(7), null, DateTimeStyles.RoundtripKind),
-        UpdatedAt = DateTime.Parse(reader.GetString(8), null, DateTimeStyles.RoundtripKind)
+        OwnerId = reader.IsDBNull(7) ? null : reader.GetString(7),
+        LeaseExpiresAt = reader.IsDBNull(8) ? null : DateTime.Parse(reader.GetString(8), null, DateTimeStyles.RoundtripKind),
+        AttemptCount = reader.GetInt32(9),
+        LastError = reader.IsDBNull(10) ? null : reader.GetString(10),
+        CreatedAt = DateTime.Parse(reader.GetString(11), null, DateTimeStyles.RoundtripKind),
+        UpdatedAt = DateTime.Parse(reader.GetString(12), null, DateTimeStyles.RoundtripKind),
+        CompletedAt = reader.IsDBNull(13) ? null : DateTime.Parse(reader.GetString(13), null, DateTimeStyles.RoundtripKind)
     };
 }

--- a/TerraformRegistry/Services/SqliteDatabaseService.cs
+++ b/TerraformRegistry/Services/SqliteDatabaseService.cs
@@ -10,7 +10,7 @@ namespace TerraformRegistry.Services;
 /// <summary>
 ///     SQLite compatibility facade for local development/storage.
 /// </summary>
-public class SqliteDatabaseService : IDatabaseService, IModulePublicationRepository, IInitializableDb
+public class SqliteDatabaseService : IDatabaseService, IModulePublicationRepository, IModuleExtractionJobRepository, IInitializableDb
 {
     private readonly string _connectionString;
     private readonly DbUpMigrator _dbUpMigrator;
@@ -55,6 +55,25 @@ public class SqliteDatabaseService : IDatabaseService, IModulePublicationReposit
     public Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) => _publications.GetPublicationAttemptAsync(id);
 
     public Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) => _publications.GetExtractionJobAsync(id);
+
+    public Task<ModuleExtractionJob?> TryClaimNextExtractionJobAsync(string ownerId, TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default) =>
+        _publications.TryClaimNextExtractionJobAsync(ownerId, leaseDuration, cancellationToken);
+
+    public Task<bool> TryHeartbeatExtractionJobAsync(Guid jobId, string ownerId, TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default) =>
+        _publications.TryHeartbeatExtractionJobAsync(jobId, ownerId, leaseDuration, cancellationToken);
+
+    public Task<bool> TryCompleteExtractionJobAsync(Guid jobId, string ownerId,
+        CancellationToken cancellationToken = default) =>
+        _publications.TryCompleteExtractionJobAsync(jobId, ownerId, cancellationToken);
+
+    public Task<bool> TryFailExtractionJobAsync(Guid jobId, string ownerId, string failureReason, int maximumAttempts,
+        CancellationToken cancellationToken = default) =>
+        _publications.TryFailExtractionJobAsync(jobId, ownerId, failureReason, maximumAttempts, cancellationToken);
+
+    public Task<int> CountPendingExtractionJobsAsync(CancellationToken cancellationToken = default) =>
+        _publications.CountPendingExtractionJobsAsync(cancellationToken);
 
     public Task<ModuleList> ListModulesAsync(ModuleSearchRequest request) =>
         _modules.ListModulesAsync(request);

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -421,7 +421,15 @@ internal static class ServiceRegistrationExtensions
         services.AddSingleton<ITerraformModuleInspector, TerraformConfigInspectRunner>();
         services.AddSingleton<IModuleLlmContextGenerator, ModuleLlmContextGenerator>();
         services.AddSingleton<IModuleExtractionConfigService, ModuleExtractionConfigService>();
-        services.AddSingleton<IModuleExtractionService, ModuleExtractionService>();
+        services.AddSingleton<IModuleExtractionService>(provider => new ModuleExtractionService(
+            provider.GetRequiredService<IModuleService>(),
+            provider.GetRequiredService<IDatabaseService>(),
+            provider.GetRequiredService<IArchiveWorkspaceFactory>(),
+            provider.GetRequiredService<ITerraformModuleInspector>(),
+            provider.GetRequiredService<IModuleLlmContextGenerator>(),
+            provider.GetRequiredService<IModuleExtractionConfigService>(),
+            provider.GetRequiredService<ILogger<ModuleExtractionService>>(),
+            provider.GetRequiredService<IOptions<ModuleExtractionOptions>>().Value));
         services.AddHostedService<ModuleExtractionHostedService>();
         services.AddSingleton<IModulePublishCoordinator, ModulePublishCoordinator>();
 


### PR DESCRIPTION
## Summary
- replace the process-local extraction channel with persisted, lease-controlled jobs
- add bounded backlog admission, retry/dead-letter transitions, and configurable worker concurrency
- verify the shared job contract against SQLite and PostgreSQL Testcontainers

## Validation
- Test run for /home/rocky/terraform-registry/.worktrees/remediation/durable-extraction-jobs/TerraformRegistry.Tests/bin/Release/net10.0/TerraformRegistry.Tests.dll (.NETCoreApp,Version=v10.0)
VSTest version 18.0.2 (x64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    35, Skipped:     0, Total:    35, Duration: 26 s - TerraformRegistry.Tests.dll (net10.0)

Closes the durable extraction-work package in the remediation plan.