### PR TITLE
fix: commit local module publications safely

### DIFF
--- a/TerraformRegistry.Models/ModuleExtractionJob.cs
+++ b/TerraformRegistry.Models/ModuleExtractionJob.cs
@@ -2,6 +2,7 @@ namespace TerraformRegistry.Models;
 
 public static class ModuleExtractionJobState
 {
+    public const string Staged = "staged";
     public const string Pending = "pending";
     public const string Processing = "processing";
     public const string Retry = "retry";

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
@@ -121,6 +121,21 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         if (await attemptCommand.ExecuteNonQueryAsync() != 1)
             return false;
 
+        await using var jobCommand = new NpgsqlCommand(
+            """
+            UPDATE module_extraction_jobs
+            SET state = @pending, updated_at = @updatedAt
+            WHERE publication_attempt_id = @attemptId AND state = @staged
+            """,
+            connection,
+            transaction);
+        jobCommand.Parameters.AddWithValue("@pending", ModuleExtractionJobState.Pending);
+        jobCommand.Parameters.AddWithValue("@updatedAt", DateTime.UtcNow);
+        jobCommand.Parameters.AddWithValue("@attemptId", attempt.Id);
+        jobCommand.Parameters.AddWithValue("@staged", ModuleExtractionJobState.Staged);
+        if (await jobCommand.ExecuteNonQueryAsync() != 1)
+            return false;
+
         await transaction.CommitAsync();
         return true;
     }

--- a/TerraformRegistry.Tests/UnitTests/Database/MirrorRepositoryTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/MirrorRepositoryTests.cs
@@ -222,12 +222,18 @@ internal static class PublicationCommitContract
         var now = TruncateToMicroseconds(DateTime.UtcNow);
         var first = CreateModule("artifacts/acme/network/aws/1.0.0/first.zip", now);
         var firstAttempt = CreateAttempt(first, now);
-        await publications.CreatePublicationAttemptWithExtractionJobAsync(firstAttempt, CreateJob(firstAttempt));
+        var firstJob = CreateJob(firstAttempt);
+        await publications.CreatePublicationAttemptWithExtractionJobAsync(firstAttempt, firstJob);
+
+        Assert.Null(await ((IModuleExtractionJobRepository)publications)
+            .TryClaimNextExtractionJobAsync("worker", TimeSpan.FromMinutes(1)));
 
         Assert.True(await publications.TryCommitStagedPublicationAsync(firstAttempt, first, null));
         AssertModuleEquals(first, await modules.GetModuleStorageAsync("acme", "network", "aws", "1.0.0"));
         Assert.Equal(ModulePublicationAttemptState.Committed,
             (await publications.GetPublicationAttemptAsync(firstAttempt.Id))!.State);
+        Assert.Equal(ModuleExtractionJobState.Pending,
+            (await publications.GetExtractionJobAsync(firstJob.Id))!.State);
 
         var replacement = CreateModule("artifacts/acme/network/aws/1.0.0/replacement.zip", now.AddMinutes(1));
         replacement.Description = "replacement artifact";
@@ -274,7 +280,7 @@ internal static class PublicationCommitContract
         Name = attempt.Name,
         Provider = attempt.Provider,
         Version = attempt.Version,
-        State = ModuleExtractionJobState.Pending,
+        State = ModuleExtractionJobState.Staged,
         CreatedAt = attempt.CreatedAt,
         UpdatedAt = attempt.UpdatedAt
     };

--- a/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
@@ -243,7 +243,7 @@ public class LocalModuleServiceTests
         var content = new MemoryStream(Encoding.UTF8.GetBytes("dummy"));
         ModuleStorage? committed = null;
         _mockDbService.Setup(x => x.GetModuleStorageAsync(ns, name, provider, version))
-            .ReturnsAsync((ModuleStorage?)null);
+            .ReturnsAsync((ModuleStorage)null!);
         _mockDbService.Setup(x => x.TryCommitStagedPublicationAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null))
             .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?>((_, module, _) => committed = module)
@@ -266,7 +266,7 @@ public class LocalModuleServiceTests
         ModuleStorage? capturedModule = null;
 
         _mockDbService.Setup(x => x.GetModuleStorageAsync("ns", "name", "provider", "1.0.0"))
-            .ReturnsAsync((ModuleStorage?)null);
+            .ReturnsAsync((ModuleStorage)null!);
         _mockDbService.Setup(x => x.CreatePublicationAttemptWithExtractionJobAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
             .Callback<ModulePublicationAttempt, ModuleExtractionJob>((attempt, job) =>
@@ -307,7 +307,7 @@ public class LocalModuleServiceTests
             Provider = "provider",
             Version = "1.0.0",
             Description = "winner",
-            FilePath = Path.Combine(_testModulePath, "ns", ".published", "winner", "module.zip"),
+            FilePath = Path.Combine(_testModulePath, "ns/.published/winner/module.zip"),
             PublishedAt = DateTime.UtcNow.AddMinutes(-1),
             Dependencies = []
         };
@@ -342,7 +342,7 @@ public class LocalModuleServiceTests
     public async Task PurgeModuleVersionAsyncDeletesOwnedArtifactBeforeRemovingCatalogRow()
     {
         var service = new LocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);
-        var filePath = Path.Combine(_testModulePath, "ns", ".published", "attempt", "module.zip");
+        var filePath = Path.Combine(_testModulePath, "ns/.published/attempt/module.zip");
         Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
         await File.WriteAllTextAsync(filePath, "artifact");
         var module = new ModuleStorage

--- a/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
@@ -243,7 +243,7 @@ public class LocalModuleServiceTests
         var content = new MemoryStream(Encoding.UTF8.GetBytes("dummy"));
         ModuleStorage? committed = null;
         _mockDbService.Setup(x => x.GetModuleStorageAsync(ns, name, provider, version))
-            .ReturnsAsync((ModuleStorage)null!);
+            .Returns(Task.FromResult<ModuleStorage?>(null));
         _mockDbService.Setup(x => x.TryCommitStagedPublicationAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null))
             .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?>((_, module, _) => committed = module)
@@ -266,7 +266,7 @@ public class LocalModuleServiceTests
         ModuleStorage? capturedModule = null;
 
         _mockDbService.Setup(x => x.GetModuleStorageAsync("ns", "name", "provider", "1.0.0"))
-            .ReturnsAsync((ModuleStorage)null!);
+            .Returns(Task.FromResult<ModuleStorage?>(null));
         _mockDbService.Setup(x => x.CreatePublicationAttemptWithExtractionJobAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
             .Callback<ModulePublicationAttempt, ModuleExtractionJob>((attempt, job) =>
@@ -307,7 +307,7 @@ public class LocalModuleServiceTests
             Provider = "provider",
             Version = "1.0.0",
             Description = "winner",
-            FilePath = Path.Combine(_testModulePath, "ns/.published/winner/module.zip"),
+            FilePath = Path.Join(_testModulePath, "ns/.published/winner/module.zip"),
             PublishedAt = DateTime.UtcNow.AddMinutes(-1),
             Dependencies = []
         };
@@ -342,7 +342,7 @@ public class LocalModuleServiceTests
     public async Task PurgeModuleVersionAsyncDeletesOwnedArtifactBeforeRemovingCatalogRow()
     {
         var service = new LocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);
-        var filePath = Path.Combine(_testModulePath, "ns/.published/attempt/module.zip");
+        var filePath = Path.Join(_testModulePath, "ns/.published/attempt/module.zip");
         Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
         await File.WriteAllTextAsync(filePath, "artifact");
         var module = new ModuleStorage

--- a/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
@@ -229,9 +229,9 @@ public class LocalModuleServiceTests
         Assert.Equal(string.Empty, filePath);
     }
 
-    // Verifies that UploadModuleAsyncCore saves the file and adds the module to the database
+    // Verifies that UploadModuleAsyncCore promotes a unique artifact only after the catalog commit succeeds.
     [Fact]
-    public async Task UploadModuleAsyncCoreSavesFileAndAddsToDatabase()
+    public async Task UploadModuleAsyncCorePromotesFileAfterCatalogCommit()
     {
         // Arrange
         var service = new TestableLocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);
@@ -241,13 +241,131 @@ public class LocalModuleServiceTests
         var version = "1.0.0";
         var desc = "desc";
         var content = new MemoryStream(Encoding.UTF8.GetBytes("dummy"));
-        _mockDbService.Setup(x => x.AddModuleAsync(It.IsAny<ModuleStorage>())).ReturnsAsync(true);
+        ModuleStorage? committed = null;
+        _mockDbService.Setup(x => x.GetModuleStorageAsync(ns, name, provider, version))
+            .ReturnsAsync((ModuleStorage?)null);
+        _mockDbService.Setup(x => x.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null))
+            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?>((_, module, _) => committed = module)
+            .ReturnsAsync(true);
         // Act
         var result = await service.CallUploadModuleAsyncCore(ns, name, provider, version, content, desc);
         // Assert
         Assert.True(result);
-        var filePath = Path.Combine(_testModulePath, ns, $"{name}-{provider}-{version}.zip");
-        Assert.True(File.Exists(filePath));
+        Assert.NotNull(committed);
+        Assert.True(File.Exists(committed!.FilePath));
+    }
+
+    [Fact]
+    public async Task UploadModuleAsyncCoreStagesAndCommitsAUniquePublicationAttempt()
+    {
+        var service = new TestableLocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);
+        await using var content = new MemoryStream(Encoding.UTF8.GetBytes("dummy"));
+        ModulePublicationAttempt? capturedAttempt = null;
+        ModuleExtractionJob? capturedJob = null;
+        ModuleStorage? capturedModule = null;
+
+        _mockDbService.Setup(x => x.GetModuleStorageAsync("ns", "name", "provider", "1.0.0"))
+            .ReturnsAsync((ModuleStorage?)null);
+        _mockDbService.Setup(x => x.CreatePublicationAttemptWithExtractionJobAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
+            .Callback<ModulePublicationAttempt, ModuleExtractionJob>((attempt, job) =>
+            {
+                capturedAttempt = attempt;
+                capturedJob = job;
+            })
+            .Returns(Task.CompletedTask);
+        _mockDbService.Setup(x => x.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null))
+            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?>((_, module, _) => capturedModule = module)
+            .ReturnsAsync(true);
+
+        var result = await service.CallUploadModuleAsyncCore("ns", "name", "provider", "1.0.0", content, "desc");
+
+        Assert.True(result);
+        Assert.NotNull(capturedAttempt);
+        Assert.NotNull(capturedJob);
+        Assert.NotNull(capturedModule);
+        Assert.Equal(ModulePublicationAttemptState.Staged, capturedAttempt!.State);
+        Assert.Equal(capturedAttempt.Id, capturedJob!.PublicationAttemptId);
+        Assert.Contains(capturedAttempt.Id.ToString("N"), capturedAttempt.StagingKey, StringComparison.Ordinal);
+        Assert.Contains(capturedAttempt.Id.ToString("N"), capturedModule!.FilePath, StringComparison.Ordinal);
+        Assert.True(File.Exists(capturedModule.FilePath));
+    }
+
+    [Fact]
+    public async Task UploadModuleAsyncCoreRemovesOnlyItsArtifactWhenCatalogCommitLoses()
+    {
+        var service = new TestableLocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);
+        await using var content = new MemoryStream(Encoding.UTF8.GetBytes("loser"));
+        ModuleStorage? attemptedModule = null;
+        ModulePublicationAttempt? attemptedPublication = null;
+        var existing = new ModuleStorage
+        {
+            Namespace = "ns",
+            Name = "name",
+            Provider = "provider",
+            Version = "1.0.0",
+            Description = "winner",
+            FilePath = Path.Combine(_testModulePath, "ns", ".published", "winner", "module.zip"),
+            PublishedAt = DateTime.UtcNow.AddMinutes(-1),
+            Dependencies = []
+        };
+        Directory.CreateDirectory(Path.GetDirectoryName(existing.FilePath)!);
+        await File.WriteAllTextAsync(existing.FilePath, "winner");
+
+        _mockDbService.Setup(x => x.GetModuleStorageAsync("ns", "name", "provider", "1.0.0"))
+            .ReturnsAsync(existing);
+        _mockDbService.Setup(x => x.CreatePublicationAttemptWithExtractionJobAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
+            .Callback<ModulePublicationAttempt, ModuleExtractionJob>((attempt, _) => attemptedPublication = attempt)
+            .Returns(Task.CompletedTask);
+        _mockDbService.Setup(x => x.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), existing))
+            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?>((_, module, _) => attemptedModule = module)
+            .ReturnsAsync(false);
+        _mockDbService.Setup(x => x.TryFailStagedPublicationAsync(It.IsAny<Guid>(), It.IsAny<string>()))
+            .ReturnsAsync(true);
+
+        var result = await service.CallUploadModuleAsyncCore("ns", "name", "provider", "1.0.0", content, "desc",
+            replace: true);
+
+        Assert.False(result);
+        Assert.NotNull(attemptedModule);
+        Assert.False(File.Exists(attemptedModule!.FilePath));
+        Assert.True(File.Exists(existing.FilePath));
+        _mockDbService.Verify(x => x.TryFailStagedPublicationAsync(attemptedPublication!.Id,
+            It.Is<string>(reason => reason.Contains("Catalog changed", StringComparison.Ordinal))), Times.Once);
+    }
+
+    [Fact]
+    public async Task PurgeModuleVersionAsyncDeletesOwnedArtifactBeforeRemovingCatalogRow()
+    {
+        var service = new LocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);
+        var filePath = Path.Combine(_testModulePath, "ns", ".published", "attempt", "module.zip");
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+        await File.WriteAllTextAsync(filePath, "artifact");
+        var module = new ModuleStorage
+        {
+            Namespace = "ns",
+            Name = "name",
+            Provider = "provider",
+            Version = "1.0.0",
+            Description = "desc",
+            FilePath = filePath,
+            PublishedAt = DateTime.UtcNow,
+            Dependencies = []
+        };
+        _mockDbService.Setup(x => x.GetModuleStorageIncludingDeletedAsync("ns", "name", "provider", "1.0.0"))
+            .ReturnsAsync(module);
+        _mockDbService.Setup(x => x.RemoveModuleAsync(module))
+            .Callback(() => Assert.False(File.Exists(filePath)))
+            .ReturnsAsync(true);
+
+        var result = await service.PurgeModuleVersionAsync("ns", "name", "provider", "1.0.0");
+
+        Assert.True(result);
+        Assert.False(File.Exists(filePath));
     }
 
     [Fact]

--- a/TerraformRegistry/Services/LocalModuleService.cs
+++ b/TerraformRegistry/Services/LocalModuleService.cs
@@ -274,20 +274,56 @@ public class LocalModuleService : ModuleService
         if (coordinateError != null)
             throw new ArgumentException(coordinateError);
 
-        var namespaceDir = GetNamespaceDirectory(moduleNamespace);
-        if (!Directory.Exists(namespaceDir)) Directory.CreateDirectory(namespaceDir);
+        var existing = await _databaseService.GetModuleStorageAsync(moduleNamespace, name, provider, version);
+        if (!replace && existing is not null)
+            return false;
 
+        var now = DateTime.UtcNow;
+        var attemptId = Guid.NewGuid();
+        var namespaceDir = GetNamespaceDirectory(moduleNamespace);
+        var stagingDirectory = GetContainedPath(_moduleStorageRoot, ".staging");
+        var publicationDirectory = GetContainedPath(namespaceDir, ".published");
         var fileName = $"{name}-{provider}-{version}{ModuleArchiveFormat.GetFileSuffix(metadata)}";
-        var tempFileName = $"{fileName}.tmp";
-        var tempFilePath = GetContainedPath(namespaceDir, tempFileName);
-        var finalFilePath = GetContainedPath(namespaceDir, fileName);
+        var stagingFilePath = GetContainedPath(stagingDirectory, $"{attemptId:N}-{fileName}");
+        var finalDirectory = GetContainedPath(publicationDirectory, attemptId.ToString("N"));
+        var finalFilePath = GetContainedPath(finalDirectory, fileName);
+        var attempt = new ModulePublicationAttempt
+        {
+            Id = attemptId,
+            Namespace = moduleNamespace,
+            Name = name,
+            Provider = provider,
+            Version = version,
+            State = ModulePublicationAttemptState.Staged,
+            StagingKey = Path.GetRelativePath(_moduleStorageRoot, stagingFilePath).Replace(Path.DirectorySeparatorChar, '/'),
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        var job = new ModuleExtractionJob
+        {
+            Id = Guid.NewGuid(),
+            PublicationAttemptId = attemptId,
+            Namespace = moduleNamespace,
+            Name = name,
+            Provider = provider,
+            Version = version,
+            State = ModuleExtractionJobState.Staged,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        var committed = false;
 
         try
         {
-            await using (var fileStream = File.Create(tempFilePath))
+            await _databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+            Directory.CreateDirectory(stagingDirectory);
+            await using (var fileStream = File.Create(stagingFilePath))
             {
                 await moduleContent.CopyToAsync(fileStream);
             }
+
+            Directory.CreateDirectory(finalDirectory);
+            File.Move(stagingFilePath, finalFilePath);
 
             var module = new ModuleStorage
             {
@@ -297,73 +333,29 @@ public class LocalModuleService : ModuleService
                 Version = version,
                 Description = description,
                 FilePath = finalFilePath,
-                PublishedAt = DateTime.UtcNow,
+                PublishedAt = now,
                 Dependencies = [],
                 Metadata = metadata ?? new ModuleArtifactMetadata()
             };
 
-            if (replace)
-            {
-                try
-                {
-                    await _databaseService.RemoveModuleAsync(module);
-                }
-                catch (Exception ex)
-                {
-                    RegistryLog.Warning(_logger, ex,
-                        "Failed to remove existing database module {Namespace}/{Name}/{Provider}/{Version}; continuing with add",
-                        moduleNamespace, name, provider, version);
-                }
+            committed = await _databaseService.TryCommitStagedPublicationAsync(attempt, module, existing);
+            if (committed)
+                return true;
 
-                try
-                {
-                    if (File.Exists(finalFilePath)) File.Delete(finalFilePath);
-                }
-                catch (Exception ex)
-                {
-                    RegistryLog.Warning(_logger, ex,
-                        "Failed to delete existing module file {Path}; continuing with overwrite", finalFilePath);
-                }
-            }
-
-            var dbResult = await _databaseService.AddModuleAsync(module);
-            if (dbResult)
-            {
-                try
-                {
-                    if (File.Exists(finalFilePath)) File.Delete(finalFilePath);
-                    File.Move(tempFilePath, finalFilePath);
-                    return true;
-                }
-                catch (Exception fileMoveEx)
-                {
-                    try
-                    {
-                        await _databaseService.RemoveModuleAsync(module);
-                    }
-                    catch (Exception dbRollbackEx)
-                    {
-                        RegistryLog.Error(_logger, dbRollbackEx,
-                            "Failed to rollback DB entry after file move failure for {Namespace}/{Name}/{Provider}/{Version}",
-                            moduleNamespace, name, provider, version);
-                    }
-
-                    RegistryLog.Error(_logger, fileMoveEx,
-                        "Failed to move file, rolled back DB entry for {Namespace}/{Name}/{Provider}/{Version}",
-                        moduleNamespace, name, provider, version);
-                    if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
-                    return false;
-                }
-            }
-
-            File.Delete(tempFilePath);
+            CleanupOwnedArtifact(finalDirectory, stagingFilePath);
+            await _databaseService.TryFailStagedPublicationAsync(attemptId, "Catalog changed before publication could commit.");
             return false;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            RegistryLog.Error(_logger, ex, "Failed to upload module {Namespace}/{Name}/{Provider}/{Version}", moduleNamespace, name,
-                provider, version);
-            if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
+            RegistryLog.Error(_logger, ex, "Failed to publish module {Namespace}/{Name}/{Provider}/{Version}", moduleNamespace,
+                name, provider, version);
+            if (!committed)
+            {
+                CleanupOwnedArtifact(finalDirectory, stagingFilePath);
+                await TryFailPublicationAttemptAsync(attemptId, ex.Message);
+            }
+
             return false;
         }
     }
@@ -394,25 +386,19 @@ public class LocalModuleService : ModuleService
             return false;
         }
 
-        // Delete from database first (permanent delete)
-        var dbResult = await _databaseService.RemoveModuleAsync(moduleStorage);
-        if (!dbResult)
-            return false;
-
-        // Delete the file from disk
         try
         {
             if (File.Exists(moduleStorage.FilePath))
                 File.Delete(moduleStorage.FilePath);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(_logger, ex, "Failed to delete file for purged module {Namespace}/{Name}/{Provider}/{Version}",
                 moduleNamespace, name, provider, version);
-            // DB deletion succeeded, file deletion may have failed - still return true
+            return false;
         }
 
-        return true;
+        return await _databaseService.RemoveModuleAsync(moduleStorage);
     }
 
     public override Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request)
@@ -459,6 +445,33 @@ public class LocalModuleService : ModuleService
             throw new ArgumentException("Module file path resolves outside the storage root.", nameof(fileName));
 
         return path;
+    }
+
+    private void CleanupOwnedArtifact(string finalDirectory, string stagingFilePath)
+    {
+        try
+        {
+            if (File.Exists(stagingFilePath))
+                File.Delete(stagingFilePath);
+            if (Directory.Exists(finalDirectory))
+                Directory.Delete(finalDirectory, true);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            RegistryLog.Warning(_logger, ex, "Failed to clean up the owned local publication artifact.");
+        }
+    }
+
+    private async Task TryFailPublicationAttemptAsync(Guid attemptId, string reason)
+    {
+        try
+        {
+            await _databaseService.TryFailStagedPublicationAsync(attemptId, reason);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            RegistryLog.Error(_logger, ex, "Failed to mark local publication attempt {AttemptId} as failed.", attemptId);
+        }
     }
 
     private bool IsInsideStorageRoot(string path)

--- a/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
@@ -125,6 +125,20 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         if (await attemptCommand.ExecuteNonQueryAsync() != 1)
             return false;
 
+        await using var jobCommand = connection.CreateCommand();
+        jobCommand.Transaction = transaction;
+        jobCommand.CommandText = """
+            UPDATE module_extraction_jobs
+            SET state = $pending, updated_at = $updatedAt
+            WHERE publication_attempt_id = $attemptId AND state = $staged
+            """;
+        jobCommand.Parameters.AddWithValue("$pending", ModuleExtractionJobState.Pending);
+        jobCommand.Parameters.AddWithValue("$updatedAt", DateTime.UtcNow.ToString("O"));
+        jobCommand.Parameters.AddWithValue("$attemptId", attempt.Id.ToString());
+        jobCommand.Parameters.AddWithValue("$staged", ModuleExtractionJobState.Staged);
+        if (await jobCommand.ExecuteNonQueryAsync() != 1)
+            return false;
+
         transaction.Commit();
         return true;
     }


### PR DESCRIPTION
## Summary
- stage every local module upload in an attempt-owned path
- commit catalog replacement and extraction-job activation atomically
- make purge report artifact deletion failures without dropping the catalog row

## Verification
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --configuration Release --logger "console;verbosity=minimal" --blame-hang --blame-hang-timeout 5m` (689 passed)
- SQLite and PostgreSQL publication contract tests
- `slopwatch analyze -d . --hook --no-baseline --fail-on warning`