### PR TITLE
fix: publish Azure modules transactionally

### DIFF
--- a/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
+++ b/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
@@ -216,52 +216,56 @@ public class AzureBlobModuleService : ModuleService
     protected override async Task<bool> UploadModuleAsyncCore(string moduleNamespace, string name, string provider,
         string version, Stream moduleContent, string description, bool replace, ModuleArtifactMetadata? metadata)
     {
-        // Create a consistent blob path format for easy retrieval
-        var blobPath = $"{moduleNamespace}/{name}-{provider}-{version}{ModuleArchiveFormat.GetFileSuffix(metadata)}";
+        var existing = await _databaseService.GetModuleStorageAsync(moduleNamespace, name, provider, version);
+        if (!replace && existing is not null)
+            return false;
+
+        var now = DateTime.UtcNow;
+        var attemptId = Guid.NewGuid();
+        var fileName = $"{name}-{provider}-{version}{ModuleArchiveFormat.GetFileSuffix(metadata)}";
+        var blobPath = $"publications/{attemptId:N}/{fileName}";
         var blobClient = _containerClient.GetBlobClient(blobPath);
-
-        // Check if blob already exists to avoid duplication or allow replacement
-        if (await blobClient.ExistsAsync())
+        var attempt = new ModulePublicationAttempt
         {
-            if (!replace)
-            {
-                RegistryLog.Warning(_logger, "Module {Namespace}/{Name}/{Provider}/{Version} already exists in blob storage",
-                    moduleNamespace, name, provider, version);
-                return false;
-            }
-
-            // Replace requested: delete existing blob
-            try
-            {
-                await blobClient.DeleteIfExistsAsync();
-            }
-            catch (Exception ex)
-            {
-                RegistryLog.Error(_logger, ex, "Failed to delete existing blob for {Namespace}/{Name}/{Provider}/{Version}",
-                    moduleNamespace, name, provider, version);
-                return false;
-            }
-        }
-
+            Id = attemptId,
+            Namespace = moduleNamespace,
+            Name = name,
+            Provider = provider,
+            Version = version,
+            State = ModulePublicationAttemptState.Staged,
+            StagingKey = blobPath,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        var job = new ModuleExtractionJob
+        {
+            Id = Guid.NewGuid(),
+            PublicationAttemptId = attemptId,
+            Namespace = moduleNamespace,
+            Name = name,
+            Provider = provider,
+            Version = version,
+            State = ModuleExtractionJobState.Staged,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        var committed = false;
         try
         {
-            // Step 1: Upload the actual module content to Azure Blob Storage
-            // We store metadata in the blob properties for redundancy and easier recovery
+            await _databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
             await blobClient.UploadAsync(moduleContent, new BlobUploadOptions
             {
-                Metadata = new Dictionary<string, string>
-(StringComparer.Ordinal)
+                Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
                 {
                     { "namespace", moduleNamespace },
                     { "name", name },
                     { "provider", provider },
                     { "version", version },
                     { "description", description },
-                    { "publishedAt", DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture) }
+                    { "publishedAt", now.ToString("o", CultureInfo.InvariantCulture) }
                 }
             });
 
-            // Step 2: Store module metadata in PostgreSQL database with a reference to the blob
             var module = new ModuleStorage
             {
                 Namespace = moduleNamespace,
@@ -269,58 +273,25 @@ public class AzureBlobModuleService : ModuleService
                 Provider = provider,
                 Version = version,
                 Description = description,
-                FilePath = blobPath, // This is the crucial link between database and blob storage
-                PublishedAt = DateTime.UtcNow,
-                Dependencies = new List<string>(), // Simplified, no dependencies
+                FilePath = blobPath,
+                PublishedAt = now,
+                Dependencies = [],
                 Metadata = metadata ?? new ModuleArtifactMetadata()
             };
 
-            if (replace)
-            {
-                try
-                {
-                    await _databaseService.RemoveModuleAsync(module);
-                }
-                catch (Exception ex)
-                {
-                    RegistryLog.Warning(_logger, ex,
-                        "Failed to remove existing database module {Namespace}/{Name}/{Provider}/{Version}; continuing with upsert",
-                        moduleNamespace, name, provider, version);
-                }
-            }
+            committed = await _databaseService.TryCommitStagedPublicationAsync(attempt, module, existing);
+            if (committed)
+                return true;
 
-            // Add to database - this stores metadata and the blob path reference
-            var result = await _databaseService.AddModuleAsync(module);
-
-            if (!result)
-            {
-                // Clean up the blob if database insertion fails to maintain consistency
-                await blobClient.DeleteAsync();
-                RegistryLog.Error(_logger,
-                    "Failed to add module {Namespace}/{Name}/{Provider}/{Version} to database, cleaned up blob storage",
-                    moduleNamespace, name, provider, version);
-            }
-
-            return result;
+            await CleanupFailedPublicationAsync(blobClient, attemptId, "Catalog changed before publication could commit.");
+            return false;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            // Log any errors during upload
-            RegistryLog.Error(_logger, ex, "Error uploading module {Namespace}/{Name}/{Provider}/{Version}",
+            RegistryLog.Error(_logger, ex, "Error publishing module {Namespace}/{Name}/{Provider}/{Version}",
                 moduleNamespace, name, provider, version);
-
-            // Try to clean up the blob if an error occurred
-            try
-            {
-                if (await blobClient.ExistsAsync()) await blobClient.DeleteAsync();
-            }
-            catch (Exception cleanupEx)
-            {
-                RegistryLog.Warning(_logger, cleanupEx,
-                    "Failed to clean up blob for module {Namespace}/{Name}/{Provider}/{Version} after upload error",
-                    moduleNamespace, name, provider, version);
-            }
-
+            if (!committed)
+                await CleanupFailedPublicationAsync(blobClient, attemptId, ex.Message);
             return false;
         }
     }
@@ -344,6 +315,9 @@ public class AzureBlobModuleService : ModuleService
             // List all blobs in the container
             await foreach (var blobItem in _containerClient.GetBlobsAsync(cancellationToken: cancellationToken))
             {
+                if (blobItem.Name.StartsWith("publications/", StringComparison.Ordinal))
+                    continue;
+
                 try
                 {
                     // Get the blob client
@@ -473,25 +447,19 @@ public class AzureBlobModuleService : ModuleService
         if (moduleStorage == null)
             return false;
 
-        // Delete from database first (permanent delete)
-        var dbResult = await _databaseService.RemoveModuleAsync(moduleStorage);
-        if (!dbResult)
-            return false;
-
-        // Delete the blob from Azure Storage
         try
         {
             var blobClient = _containerClient.GetBlobClient(moduleStorage.FilePath);
             await blobClient.DeleteIfExistsAsync();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(_logger, ex, "Failed to delete blob for purged module {Namespace}/{Name}/{Provider}/{Version}",
                 moduleNamespace, name, provider, version);
-            // DB deletion succeeded, blob deletion may have failed - still return true
+            return false;
         }
 
-        return true;
+        return await _databaseService.RemoveModuleAsync(moduleStorage);
     }
 
     public override Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request)
@@ -503,6 +471,27 @@ public class AzureBlobModuleService : ModuleService
         string description)
     {
         return _databaseService.UpdateModuleDescriptionAsync(moduleNamespace, name, provider, description);
+    }
+
+    private async Task CleanupFailedPublicationAsync(BlobClient blobClient, Guid attemptId, string reason)
+    {
+        try
+        {
+            await blobClient.DeleteIfExistsAsync();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            RegistryLog.Warning(_logger, ex, "Failed to clean up Azure publication attempt {AttemptId}.", attemptId);
+        }
+
+        try
+        {
+            await _databaseService.TryFailStagedPublicationAsync(attemptId, reason);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            RegistryLog.Error(_logger, ex, "Failed to mark Azure publication attempt {AttemptId} as failed.", attemptId);
+        }
     }
 
     public override async Task<(bool Healthy, string? Reason)> CheckStorageAsync()

--- a/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceConstructorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceConstructorTests.cs
@@ -241,4 +241,28 @@ public class AzureBlobModuleServiceConstructorTests
             m.FilePath == blobName
         )), Times.Once);
     }
+
+    [Fact]
+    public async Task InitializationDoesNotImportStagedPublicationBlobs()
+    {
+        var settings = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            { "ContainerName", _containerName },
+            { "SasTokenExpiryMinutes", "5" }
+        };
+        var configuration = CreateConfiguration(settings);
+        const string stagedBlobName = "publications/5f7d39dc3bb84fef8b61cf0e84b33117/network-aws-1.10.0.zip";
+        var stagedBlob = BlobsModelFactory.BlobItem(stagedBlobName, false, null, null, null);
+        var page = Page<BlobItem>.FromValues([stagedBlob], null, Mock.Of<Response>());
+        _mockBlobContainerClient.Setup(c => c.GetBlobsAsync(BlobTraits.None, BlobStates.None, null, default))
+            .Returns(AsyncPageable<BlobItem>.FromPages([page]));
+
+        var service = new AzureBlobModuleService(configuration, _mockDatabaseService.Object, _mockLogger.Object,
+            _mockBlobServiceClient.Object);
+
+        await service.InitializeStorageAsync(CancellationToken.None);
+
+        _mockBlobContainerClient.Verify(c => c.GetBlobClient(stagedBlobName), Times.Never);
+        _mockDatabaseService.Verify(db => db.AddModuleAsync(It.IsAny<TerraformRegistry.Models.ModuleStorage>()), Times.Never);
+    }
 }

--- a/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceUploadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceUploadTests.cs
@@ -57,16 +57,26 @@ public class AzureBlobModuleServiceUploadTests
         return service;
     }
 
-    // Test: Should return false and log a warning if the blob already exists in storage
+    // Test: Should return false before staging when the catalog already owns the coordinate.
     [Fact]
-    public async Task UploadModuleAsyncReturnsFalseIfBlobAlreadyExists()
+    public async Task UploadModuleAsyncReturnsFalseWhenCatalogAlreadyOwnsCoordinate()
     {
         // Arrange
         var mockBlobClient = new Mock<BlobClient>();
-        mockBlobClient.Setup(bc => bc.ExistsAsync(default)).ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
-
         _mockContainerClient.Setup(cc => cc.GetBlobClient(It.IsAny<string>()))
             .Returns(mockBlobClient.Object);
+        _mockDatabaseService.Setup(db => db.GetModuleStorageAsync("ns", "name", "prov", "1.0.0"))
+            .ReturnsAsync(new ModuleStorage
+            {
+                Namespace = "ns",
+                Name = "name",
+                Provider = "prov",
+                Version = "1.0.0",
+                Description = "desc",
+                FilePath = "publications/winner/module.zip",
+                PublishedAt = DateTime.UtcNow,
+                Dependencies = []
+            });
 
         var service = CreateService();
         using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
@@ -78,31 +88,27 @@ public class AzureBlobModuleServiceUploadTests
         Assert.False(result);
         mockBlobClient.Verify(bc => bc.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), default),
             Times.Never);
-        _mockLogger.Verify(
-            x => x.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("already exists in blob storage")),
-                null,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 
-    // Test: Should return true on successful upload to blob storage and successful database add
+    // Test: Should return true on successful upload and transactional catalog commit.
     [Fact]
-    public async Task UploadModuleAsyncReturnsTrueOnSuccessfulUploadAndDbAdd()
+    public async Task UploadModuleAsyncReturnsTrueAfterTransactionalCatalogCommit()
     {
         // Arrange
         var mockBlobClient = new Mock<BlobClient>();
-        mockBlobClient.Setup(bc => bc.ExistsAsync(default))
-            .ReturnsAsync(Response.FromValue(false, Mock.Of<Response>()));
         mockBlobClient.Setup(bc => bc.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), default))
             .ReturnsAsync(Mock.Of<Response<BlobContentInfo>>());
 
         _mockContainerClient.Setup(cc => cc.GetBlobClient(It.IsAny<string>()))
             .Returns(mockBlobClient.Object);
 
-        _mockDatabaseService.Setup(db => db.AddModuleAsync(It.IsAny<ModuleStorage>()))
+        _mockDatabaseService.Setup(db => db.GetModuleStorageAsync("ns", "name", "prov", "1.0.0"))
+            .Returns(Task.FromResult<ModuleStorage?>(null));
+        _mockDatabaseService.Setup(db => db.CreatePublicationAttemptWithExtractionJobAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
+            .Returns(Task.CompletedTask);
+        _mockDatabaseService.Setup(db => db.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null))
             .ReturnsAsync(true);
 
         var service = CreateService();
@@ -115,31 +121,70 @@ public class AzureBlobModuleServiceUploadTests
         Assert.True(result);
         mockBlobClient.Verify(bc => bc.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), default),
             Times.Once);
-        _mockDatabaseService.Verify(db => db.AddModuleAsync(It.Is<ModuleStorage>(m =>
+        _mockDatabaseService.Verify(db => db.TryCommitStagedPublicationAsync(It.IsAny<ModulePublicationAttempt>(), It.Is<ModuleStorage>(m =>
             m.Namespace == "ns" && m.Name == "name" && m.Provider == "prov" && m.Version == "1.0.0"
-        )), Times.Once);
+        ), null), Times.Once);
     }
 
-    // Test: Should delete the blob and return false if the database add fails after upload
     [Fact]
-    public async Task UploadModuleAsyncDeletesBlobAndReturnsFalseIfDbAddFails()
+    public async Task UploadModuleAsyncStagesAnAttemptOwnedBlobAndCommitsTheCatalog()
     {
-        // Arrange
+        var blobPaths = new List<string>();
         var mockBlobClient = new Mock<BlobClient>();
         mockBlobClient.Setup(bc => bc.ExistsAsync(default))
             .ReturnsAsync(Response.FromValue(false, Mock.Of<Response>()));
         mockBlobClient.Setup(bc => bc.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), default))
             .ReturnsAsync(Mock.Of<Response<BlobContentInfo>>());
-        mockBlobClient.Setup(bc =>
-                bc.DeleteAsync(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), default))
-            .ReturnsAsync(Mock.Of<Response>());
+        _mockContainerClient.Setup(cc => cc.GetBlobClient(It.IsAny<string>()))
+            .Callback<string>(blobPaths.Add)
+            .Returns(mockBlobClient.Object);
+        _mockDatabaseService.Setup(db => db.GetModuleStorageAsync("ns", "name", "prov", "1.0.0"))
+            .Returns(Task.FromResult<ModuleStorage?>(null));
+        _mockDatabaseService.Setup(db => db.CreatePublicationAttemptWithExtractionJobAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
+            .Returns(Task.CompletedTask);
+        _mockDatabaseService.Setup(db => db.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null))
+            .ReturnsAsync(true);
+        var service = CreateService();
+        using var stream = new MemoryStream([1, 2, 3]);
+
+        var result = await service.UploadModuleAsync("ns", "name", "prov", "1.0.0", stream, "desc");
+
+        Assert.True(result);
+        var path = Assert.Single(blobPaths);
+        Assert.Contains("publications/", path, StringComparison.Ordinal);
+        Assert.Contains("name-prov-1.0.0.zip", path, StringComparison.Ordinal);
+        _mockDatabaseService.Verify(db => db.TryCommitStagedPublicationAsync(
+            It.Is<ModulePublicationAttempt>(attempt => attempt.State == ModulePublicationAttemptState.Staged),
+            It.Is<ModuleStorage>(module => module.FilePath == path), null), Times.Once);
+        _mockDatabaseService.Verify(db => db.AddModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
+    }
+
+    // Test: Should delete the attempt-owned blob and return false if the catalog commit loses.
+    [Fact]
+    public async Task UploadModuleAsyncDeletesBlobAndReturnsFalseIfDbAddFails()
+    {
+        // Arrange
+        var mockBlobClient = new Mock<BlobClient>();
+        mockBlobClient.Setup(bc => bc.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), default))
+            .ReturnsAsync(Mock.Of<Response<BlobContentInfo>>());
+        mockBlobClient.Setup(bc => bc.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(),
+                It.IsAny<BlobRequestConditions>(), default))
+            .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
 
 
         _mockContainerClient.Setup(cc => cc.GetBlobClient(It.IsAny<string>()))
             .Returns(mockBlobClient.Object);
 
-        _mockDatabaseService.Setup(db => db.AddModuleAsync(It.IsAny<ModuleStorage>()))
-            .ReturnsAsync(false); // Simulate database add failure
+        _mockDatabaseService.Setup(db => db.GetModuleStorageAsync("ns", "name", "prov", "1.0.0"))
+            .Returns(Task.FromResult<ModuleStorage?>(null));
+        _mockDatabaseService.Setup(db => db.CreatePublicationAttemptWithExtractionJobAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
+            .Returns(Task.CompletedTask);
+        _mockDatabaseService.Setup(db => db.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null))
+            .ReturnsAsync(false);
 
         var service = CreateService();
         using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
@@ -151,18 +196,7 @@ public class AzureBlobModuleServiceUploadTests
         Assert.False(result);
         mockBlobClient.Verify(bc => bc.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), default),
             Times.Once);
-        mockBlobClient.Verify(bc => bc.DeleteAsync(DeleteSnapshotsOption.None, null, default),
-            Times.Once); // Verify cleanup
-        _mockLogger.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) =>
-                    v.ToString()!.Contains("Failed to add module") &&
-                    v.ToString()!.Contains("to database, cleaned up blob storage")),
-                null,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
+        mockBlobClient.Verify(bc => bc.DeleteIfExistsAsync(DeleteSnapshotsOption.None, null, default), Times.Once);
     }
 
     // Test: Should handle exceptions during blob upload, attempt cleanup, and return false
@@ -171,20 +205,20 @@ public class AzureBlobModuleServiceUploadTests
     {
         // Arrange
         var mockBlobClient = new Mock<BlobClient>();
-        // First ExistsAsync returns false (blob does not exist)
-        mockBlobClient.SetupSequence(bc => bc.ExistsAsync(default))
-            .ReturnsAsync(Response.FromValue(false, Mock.Of<Response>())) // For initial check
-            .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>())); // For cleanup check if upload fails mid-way
-
         mockBlobClient.Setup(bc => bc.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), default))
             .ThrowsAsync(new RequestFailedException("Upload failed"));
-        mockBlobClient.Setup(bc =>
-                bc.DeleteAsync(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), default))
-            .ReturnsAsync(Mock.Of<Response>());
+        mockBlobClient.Setup(bc => bc.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(),
+                It.IsAny<BlobRequestConditions>(), default))
+            .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
 
 
         _mockContainerClient.Setup(cc => cc.GetBlobClient(It.IsAny<string>()))
             .Returns(mockBlobClient.Object);
+        _mockDatabaseService.Setup(db => db.GetModuleStorageAsync("ns", "name", "prov", "1.0.0"))
+            .Returns(Task.FromResult<ModuleStorage?>(null));
+        _mockDatabaseService.Setup(db => db.CreatePublicationAttemptWithExtractionJobAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
+            .Returns(Task.CompletedTask);
 
         var service = CreateService();
         using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
@@ -194,15 +228,160 @@ public class AzureBlobModuleServiceUploadTests
 
         // Assert
         Assert.False(result);
-        mockBlobClient.Verify(bc => bc.DeleteAsync(DeleteSnapshotsOption.None, null, default),
+        mockBlobClient.Verify(bc => bc.DeleteIfExistsAsync(DeleteSnapshotsOption.None, null, default),
             Times.Once); // Verify cleanup attempt
         _mockLogger.Verify(
             x => x.Log(
                 LogLevel.Error,
                 It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error uploading module")),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error publishing module")),
                 It.IsAny<RequestFailedException>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task PurgeModuleVersionAsyncDeletesBlobBeforeRemovingCatalogRow()
+    {
+        var mockBlobClient = new Mock<BlobClient>();
+        mockBlobClient.Setup(bc => bc.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(),
+                It.IsAny<BlobRequestConditions>(), default))
+            .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
+        _mockContainerClient.Setup(cc => cc.GetBlobClient("publications/attempt/module.zip"))
+            .Returns(mockBlobClient.Object);
+        var module = new ModuleStorage
+        {
+            Namespace = "ns",
+            Name = "name",
+            Provider = "prov",
+            Version = "1.0.0",
+            Description = "desc",
+            FilePath = "publications/attempt/module.zip",
+            PublishedAt = DateTime.UtcNow,
+            Dependencies = []
+        };
+        _mockDatabaseService.Setup(db => db.GetModuleStorageIncludingDeletedAsync("ns", "name", "prov", "1.0.0"))
+            .ReturnsAsync(module);
+        _mockDatabaseService.Setup(db => db.RemoveModuleAsync(module))
+            .Callback(() => mockBlobClient.Verify(bc => bc.DeleteIfExistsAsync(
+                DeleteSnapshotsOption.None, null, default), Times.Once))
+            .ReturnsAsync(true);
+        var service = CreateService();
+
+        var result = await service.PurgeModuleVersionAsync("ns", "name", "prov", "1.0.0");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task PurgeModuleVersionAsyncKeepsCatalogRowWhenBlobDeletionFails()
+    {
+        var mockBlobClient = new Mock<BlobClient>();
+        mockBlobClient.Setup(bc => bc.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(),
+                It.IsAny<BlobRequestConditions>(), default))
+            .ThrowsAsync(new RequestFailedException("Delete failed"));
+        _mockContainerClient.Setup(cc => cc.GetBlobClient("publications/attempt/module.zip"))
+            .Returns(mockBlobClient.Object);
+        var module = new ModuleStorage
+        {
+            Namespace = "ns",
+            Name = "name",
+            Provider = "prov",
+            Version = "1.0.0",
+            Description = "desc",
+            FilePath = "publications/attempt/module.zip",
+            PublishedAt = DateTime.UtcNow,
+            Dependencies = []
+        };
+        _mockDatabaseService.Setup(db => db.GetModuleStorageIncludingDeletedAsync("ns", "name", "prov", "1.0.0"))
+            .ReturnsAsync(module);
+        var service = CreateService();
+
+        var result = await service.PurgeModuleVersionAsync("ns", "name", "prov", "1.0.0");
+
+        Assert.False(result);
+        _mockDatabaseService.Verify(db => db.RemoveModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadModuleAsyncCleansOnlyItsAttemptBlobWhenCatalogCommitLoses()
+    {
+        var attemptBlob = new Mock<BlobClient>();
+        attemptBlob.Setup(bc => bc.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), default))
+            .ReturnsAsync(Mock.Of<Response<BlobContentInfo>>());
+        attemptBlob.Setup(bc => bc.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(),
+                It.IsAny<BlobRequestConditions>(), default))
+            .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
+        var winner = new ModuleStorage
+        {
+            Namespace = "ns",
+            Name = "name",
+            Provider = "prov",
+            Version = "1.0.0",
+            Description = "winner",
+            FilePath = "publications/winner/module.zip",
+            PublishedAt = DateTime.UtcNow,
+            Dependencies = []
+        };
+        _mockContainerClient.Setup(cc => cc.GetBlobClient(It.IsAny<string>())).Returns(attemptBlob.Object);
+        _mockDatabaseService.Setup(db => db.GetModuleStorageAsync("ns", "name", "prov", "1.0.0"))
+            .ReturnsAsync(winner);
+        _mockDatabaseService.Setup(db => db.CreatePublicationAttemptWithExtractionJobAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
+            .Returns(Task.CompletedTask);
+        _mockDatabaseService.Setup(db => db.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), winner))
+            .ReturnsAsync(false);
+        _mockDatabaseService.Setup(db => db.TryFailStagedPublicationAsync(It.IsAny<Guid>(), It.IsAny<string>()))
+            .ReturnsAsync(true);
+        var service = CreateService();
+        using var stream = new MemoryStream([1, 2, 3]);
+
+        var result = await service.UploadModuleAsync("ns", "name", "prov", "1.0.0", stream, "desc", replace: true);
+
+        Assert.False(result);
+        attemptBlob.Verify(bc => bc.DeleteIfExistsAsync(DeleteSnapshotsOption.None, null, default), Times.Once);
+        _mockContainerClient.Verify(cc => cc.GetBlobClient(winner.FilePath), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadModuleAsyncCommitsReplacementMetadataInsteadOfStaleCatalogMetadata()
+    {
+        var mockBlobClient = new Mock<BlobClient>();
+        mockBlobClient.Setup(bc => bc.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), default))
+            .ReturnsAsync(Mock.Of<Response<BlobContentInfo>>());
+        _mockContainerClient.Setup(cc => cc.GetBlobClient(It.IsAny<string>())).Returns(mockBlobClient.Object);
+        var existing = new ModuleStorage
+        {
+            Namespace = "ns",
+            Name = "name",
+            Provider = "prov",
+            Version = "1.0.0",
+            Description = "old",
+            FilePath = "publications/winner/module.zip",
+            PublishedAt = DateTime.UtcNow,
+            Dependencies = [],
+            Metadata = new ModuleArtifactMetadata { RootSubdirectory = "old" }
+        };
+        var replacementMetadata = new ModuleArtifactMetadata { RootSubdirectory = "replacement" };
+        _mockDatabaseService.Setup(db => db.GetModuleStorageAsync("ns", "name", "prov", "1.0.0"))
+            .ReturnsAsync(existing);
+        _mockDatabaseService.Setup(db => db.CreatePublicationAttemptWithExtractionJobAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
+            .Returns(Task.CompletedTask);
+        _mockDatabaseService.Setup(db => db.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), existing))
+            .ReturnsAsync(true);
+        var service = CreateService();
+        using var stream = new MemoryStream([1, 2, 3]);
+
+        var result = await service.UploadModuleAsync("ns", "name", "prov", "1.0.0", stream, "replacement",
+            replace: true, metadata: replacementMetadata);
+
+        Assert.True(result);
+        _mockDatabaseService.Verify(db => db.TryCommitStagedPublicationAsync(
+            It.IsAny<ModulePublicationAttempt>(),
+            It.Is<ModuleStorage>(module => module.Description == "replacement" && module.Metadata == replacementMetadata),
+            existing), Times.Once);
     }
 }


### PR DESCRIPTION
Summary: stage Azure module publications under unique attempt-owned blob paths; commit catalog updates through the staged-publication CAS contract; preserve catalog rows when blob deletion fails; exclude staged blobs from startup recovery.

Verified: full diagnostic suite 695 passed; Azure Azurite/Terraform smoke passed; slopwatch passed.