### PR TITLE
fix: commit S3 module publications transactionally

### DIFF
--- a/TerraformRegistry.S3/S3ModuleUploadWorkflow.cs
+++ b/TerraformRegistry.S3/S3ModuleUploadWorkflow.cs
@@ -25,7 +25,7 @@ internal sealed class S3ModuleUploadWorkflow(
         {
             existingModule = await databaseService.GetModuleStorageAsync(@namespace, name, provider, version);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger,
                 ex,
@@ -100,7 +100,7 @@ internal sealed class S3ModuleUploadWorkflow(
         {
             await databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger, ex,
                 "Error creating staged S3 publication for {Namespace}/{Name}/{Provider}/{Version}.",
@@ -140,7 +140,7 @@ internal sealed class S3ModuleUploadWorkflow(
                 version);
             return false;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger,
                 ex,
@@ -171,7 +171,7 @@ internal sealed class S3ModuleUploadWorkflow(
         {
             committed = await databaseService.TryCommitStagedPublicationAsync(attempt, newModule, existingModule);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger, ex,
                 "Error committing staged S3 publication for {Namespace}/{Name}/{Provider}/{Version}.",

--- a/TerraformRegistry.S3/S3ModuleUploadWorkflow.cs
+++ b/TerraformRegistry.S3/S3ModuleUploadWorkflow.cs
@@ -209,6 +209,6 @@ internal sealed class S3ModuleUploadWorkflow(
     private async Task TryFailPublicationAsync(Guid attemptId, string reason)
     {
         try { await databaseService.TryFailStagedPublicationAsync(attemptId, reason); }
-        catch (Exception ex) { RegistryLog.Error(logger, ex, "Failed to mark staged S3 publication {AttemptId} as failed.", attemptId); }
+        catch (Exception ex) when (ex is not OperationCanceledException) { RegistryLog.Error(logger, ex, "Failed to mark staged S3 publication {AttemptId} as failed.", attemptId); }
     }
 }

--- a/TerraformRegistry.S3/S3ModuleUploadWorkflow.cs
+++ b/TerraformRegistry.S3/S3ModuleUploadWorkflow.cs
@@ -56,6 +56,8 @@ internal sealed class S3ModuleUploadWorkflow(
         var logicalObjectKey = S3ModuleObjectKeys.CreateLogicalObjectKey(@namespace, name, provider, version,
             ModuleArchiveFormat.GetFileSuffix(metadata));
         var objectKey = S3ModuleObjectKeys.CreateFinalObjectKey(logicalObjectKey);
+        var now = DateTime.UtcNow;
+        var attemptId = Guid.NewGuid();
         var newModule = new ModuleStorage
         {
             Namespace = @namespace,
@@ -64,18 +66,55 @@ internal sealed class S3ModuleUploadWorkflow(
             Version = version,
             Description = description,
             FilePath = objectKey,
-            PublishedAt = DateTime.UtcNow,
+            PublishedAt = now,
             Dependencies = [],
             Metadata = metadata ?? new ModuleArtifactMetadata()
         };
 
         var tempKey = S3ModuleObjectKeys.CreateTemporaryObjectKey(objectKey);
-        if (!await objectStore.UploadTemporaryObjectAsync(newModule, moduleContent, tempKey))
+        var attempt = new ModulePublicationAttempt
         {
+            Id = attemptId,
+            Namespace = @namespace,
+            Name = name,
+            Provider = provider,
+            Version = version,
+            State = ModulePublicationAttemptState.Staged,
+            StagingKey = tempKey,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        var job = new ModuleExtractionJob
+        {
+            Id = Guid.NewGuid(),
+            PublicationAttemptId = attemptId,
+            Namespace = @namespace,
+            Name = name,
+            Provider = provider,
+            Version = version,
+            State = ModuleExtractionJobState.Staged,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        try
+        {
+            await databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+        }
+        catch (Exception ex)
+        {
+            RegistryLog.Error(logger, ex,
+                "Error creating staged S3 publication for {Namespace}/{Name}/{Provider}/{Version}.",
+                @namespace, name, provider, version);
             return false;
         }
 
-        return await FinalizeUploadAsync(existingModule, newModule, tempKey, replace && existingModule != null);
+        if (!await objectStore.UploadTemporaryObjectAsync(newModule, moduleContent, tempKey))
+        {
+            await TryFailPublicationAsync(attemptId, "Temporary S3 upload failed.");
+            return false;
+        }
+
+        return await FinalizeUploadAsync(existingModule, newModule, tempKey, attempt, replace && existingModule != null);
     }
 
     private async Task<bool> EnsureNoDeletedModuleBlocksUploadAsync(
@@ -118,100 +157,58 @@ internal sealed class S3ModuleUploadWorkflow(
         ModuleStorage? existingModule,
         ModuleStorage newModule,
         string tempKey,
+        ModulePublicationAttempt attempt,
         bool replacingExisting)
     {
         if (!await objectStore.TryPromoteTemporaryObjectAsync(tempKey, newModule, replacingExisting ? "replace" : "create"))
         {
-            await objectStore.TryDeleteObjectAsync(newModule.FilePath, "final");
-            await objectStore.TryDeleteTemporaryObjectAsync(tempKey);
+            await CleanupFailedPublicationAsync(newModule, tempKey, attempt.Id, "S3 finalization failed.");
             return false;
         }
 
-        if (replacingExisting)
-        {
-            if (!await TryReplaceExistingModuleSnapshotAsync(existingModule, newModule))
-            {
-                await objectStore.TryDeleteObjectAsync(newModule.FilePath, "final");
-                await objectStore.TryDeleteTemporaryObjectAsync(tempKey);
-                return false;
-            }
-
-            if (existingModule != null)
-            {
-                await objectStore.TryDeleteObjectAsync(existingModule.FilePath, "superseded final");
-            }
-
-            await objectStore.TryDeleteTemporaryObjectAsync(tempKey);
-            return true;
-        }
-
+        bool committed;
         try
         {
-            var added = await databaseService.AddModuleAsync(newModule);
-            if (!added)
-            {
-                await objectStore.TryDeleteObjectAsync(newModule.FilePath, "final");
-                await objectStore.TryDeleteTemporaryObjectAsync(tempKey);
-                RegistryLog.Error(logger,
-                    "Failed to add module {Namespace}/{Name}/{Provider}/{Version} to database after S3 finalization.",
-                    newModule.Namespace,
-                    newModule.Name,
-                    newModule.Provider,
-                    newModule.Version);
-                return false;
-            }
+            committed = await databaseService.TryCommitStagedPublicationAsync(attempt, newModule, existingModule);
         }
         catch (Exception ex)
         {
-            await objectStore.TryDeleteObjectAsync(newModule.FilePath, "final");
-            await objectStore.TryDeleteTemporaryObjectAsync(tempKey);
-            RegistryLog.Error(logger,
-                ex,
-                "Error adding module {Namespace}/{Name}/{Provider}/{Version} to database after S3 finalization.",
-                newModule.Namespace,
-                newModule.Name,
-                newModule.Provider,
-                newModule.Version);
+            RegistryLog.Error(logger, ex,
+                "Error committing staged S3 publication for {Namespace}/{Name}/{Provider}/{Version}.",
+                newModule.Namespace, newModule.Name, newModule.Provider, newModule.Version);
+            await CleanupFailedPublicationAsync(newModule, tempKey, attempt.Id, ex.Message);
+            return false;
+        }
+
+        if (!committed)
+        {
+            await CleanupFailedPublicationAsync(newModule, tempKey, attempt.Id,
+                "Catalog changed before publication could commit.");
             return false;
         }
 
         await objectStore.TryDeleteTemporaryObjectAsync(tempKey);
+        if (replacingExisting && existingModule != null)
+        {
+            await objectStore.TryDeleteObjectAsync(existingModule.FilePath, "superseded final");
+        }
         return true;
     }
 
-    private async Task<bool> TryReplaceExistingModuleSnapshotAsync(ModuleStorage? existingModule, ModuleStorage newModule)
+    private async Task CleanupFailedPublicationAsync(
+        ModuleStorage newModule,
+        string tempKey,
+        Guid attemptId,
+        string reason)
     {
-        if (existingModule == null)
-        {
-            return false;
-        }
+        await objectStore.TryDeleteObjectAsync(newModule.FilePath, "final");
+        await objectStore.TryDeleteTemporaryObjectAsync(tempKey);
+        await TryFailPublicationAsync(attemptId, reason);
+    }
 
-        try
-        {
-            var replaced = await databaseService.ReplaceModuleExactAsync(existingModule, newModule);
-            if (replaced)
-            {
-                return true;
-            }
-
-            RegistryLog.Warning(logger,
-                "Failed to replace exact existing module row for {Namespace}/{Name}/{Provider}/{Version} after S3 finalization.",
-                existingModule.Namespace,
-                existingModule.Name,
-                existingModule.Provider,
-                existingModule.Version);
-            return false;
-        }
-        catch (Exception ex)
-        {
-            RegistryLog.Warning(logger,
-                ex,
-                "Error replacing exact existing module row for {Namespace}/{Name}/{Provider}/{Version} after S3 finalization.",
-                existingModule.Namespace,
-                existingModule.Name,
-                existingModule.Provider,
-                existingModule.Version);
-            return false;
-        }
+    private async Task TryFailPublicationAsync(Guid attemptId, string reason)
+    {
+        try { await databaseService.TryFailStagedPublicationAsync(attemptId, reason); }
+        catch (Exception ex) { RegistryLog.Error(logger, ex, "Failed to mark staged S3 publication {AttemptId} as failed.", attemptId); }
     }
 }

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceUploadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceUploadTests.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Microsoft.Extensions.Configuration;
@@ -12,700 +11,161 @@ namespace TerraformRegistry.Tests.UnitTests.S3;
 
 public class S3ModuleServiceUploadTests
 {
-    private const string BucketName = "modules";
-    private const string LogicalKey = "ns/name-aws-1.0.0.zip";
-
-    private readonly Mock<IDatabaseService> _mockDatabaseService = new();
-    private readonly Mock<ILogger<S3ModuleService>> _mockLogger = new();
-    private readonly Mock<IAmazonS3> _mockS3Client = new();
+    private readonly Mock<IDatabaseService> _database = new();
+    private readonly Mock<ILogger<S3ModuleService>> _logger = new();
+    private readonly Mock<IAmazonS3> _s3 = new();
 
     public S3ModuleServiceUploadTests()
     {
-        _mockLogger.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
-        _mockS3Client
-            .Setup(x => x.ListObjectsV2Async(It.IsAny<ListObjectsV2Request>(), default))
-            .ReturnsAsync(new ListObjectsV2Response());
-
-        _mockDatabaseService
-            .Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0"))
+        _logger.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        _database.Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0"))
             .ReturnsAsync(value: null);
+        _database.Setup(x => x.CreatePublicationAttemptWithExtractionJobAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
+            .Returns(Task.CompletedTask);
+        _database.Setup(x => x.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), It.IsAny<ModuleStorage?>()))
+            .ReturnsAsync(true);
+        _s3.Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
+            .ReturnsAsync(new PutObjectResponse());
+        _s3.Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
+            .ReturnsAsync(new CopyObjectResponse());
+        _s3.Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
+            .ReturnsAsync(new DeleteObjectResponse());
     }
 
-    private static IConfiguration CreateConfiguration()
-    {
-        return new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-(StringComparer.Ordinal)
-            {
-                ["S3:BucketName"] = BucketName,
-                ["S3:Region"] = "eu-west-2",
-                ["S3:PresignedUrlExpiryMinutes"] = "11"
-            })
-            .Build();
-    }
-
-    private static ModuleStorage CreateExistingModuleStorage()
-    {
-        return new ModuleStorage
+    private S3ModuleService CreateService() => new(
+        new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
         {
-            Namespace = "ns",
-            Name = "name",
-            Provider = "aws",
-            Version = "1.0.0",
-            Description = "existing-desc",
-            FilePath = $"{LogicalKey}.existing",
-            PublishedAt = new DateTime(2024, 4, 1, 12, 34, 56, DateTimeKind.Utc),
-            Dependencies = []
-        };
-    }
+            ["S3:BucketName"] = "modules",
+            ["S3:Region"] = "eu-west-2"
+        }).Build(), _database.Object, _logger.Object, _s3.Object);
 
-    private static GetObjectMetadataResponse CreateMetadataResponse(
-        string @namespace,
-        string name,
-        string provider,
-        string version,
-        string description,
-        string publishedAt)
+    private static ModuleStorage Existing(string filePath = "ns/name-aws-1.0.0.winner.zip") => new()
     {
-        var response = new GetObjectMetadataResponse
-        {
-            ETag = "\"etag\""
-        };
-        response.Metadata["namespace"] = @namespace;
-        response.Metadata["name"] = name;
-        response.Metadata["provider"] = provider;
-        response.Metadata["version"] = version;
-        response.Metadata["description"] = description;
-        response.Metadata["publishedAt"] = publishedAt;
-        return response;
-    }
-
-    private S3ModuleService CreateService()
-    {
-        return new S3ModuleService(
-            CreateConfiguration(),
-            _mockDatabaseService.Object,
-            _mockLogger.Object,
-            _mockS3Client.Object);
-    }
+        Namespace = "ns",
+        Name = "name",
+        Provider = "aws",
+        Version = "1.0.0",
+        Description = "old",
+        FilePath = filePath,
+        PublishedAt = DateTime.UtcNow.AddMinutes(-1),
+        Dependencies = [],
+        Metadata = new ModuleArtifactMetadata { RootSubdirectory = "old" }
+    };
 
     [Fact]
-    public async Task UploadModuleAsyncReturnsFalseWhenDatabaseRowAlreadyExistsAndReplaceIsFalse()
+    public async Task UploadModuleAsyncRejectsExistingCatalogCoordinateWithoutStaging()
     {
-        _mockDatabaseService
-            .Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0"))
-            .ReturnsAsync(CreateExistingModuleStorage());
+        _database.Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0")).ReturnsAsync(Existing());
+        using var content = new MemoryStream([1]);
 
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc");
+        var result = await CreateService().UploadModuleAsync("ns", "name", "aws", "1.0.0", content, "desc");
 
         Assert.False(result);
-        _mockS3Client.Verify(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default), Times.Never);
-        _mockS3Client.Verify(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default), Times.Never);
-        _mockS3Client.Verify(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default), Times.Never);
-        _mockDatabaseService.Verify(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
-        _mockDatabaseService.Verify(x => x.RemoveModuleExactAsync(It.IsAny<ModuleStorage>()), Times.Never);
+        _database.Verify(x => x.CreatePublicationAttemptWithExtractionJobAsync(
+            It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()), Times.Never);
+        _s3.Verify(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default), Times.Never);
     }
 
     [Fact]
-    public async Task UploadModuleAsyncAddsDatabaseRowWithUniqueFinalKeyAndFinalizesFromTempOnCreateSuccess()
+    public async Task UploadModuleAsyncStagesAndCommitsAttemptOwnedObjects()
     {
-        PutObjectRequest? putRequest = null;
-        CopyObjectRequest? finalizeRequest = null;
-        DeleteObjectRequest? deleteRequest = null;
-        ModuleStorage? addedModule = null;
-        var operations = new List<string>();
-
-        _mockS3Client
-            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-            .Callback<PutObjectRequest, CancellationToken>((request, _) =>
-            {
-                putRequest = request;
-                operations.Add("put-temp");
-            })
+        PutObjectRequest? stagedPut = null;
+        CopyObjectRequest? promotion = null;
+        ModulePublicationAttempt? attempt = null;
+        ModuleStorage? committed = null;
+        _s3.Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
+            .Callback<PutObjectRequest, CancellationToken>((request, _) => stagedPut = request)
             .ReturnsAsync(new PutObjectResponse());
-
-        _mockS3Client
-            .Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
-            .Callback<CopyObjectRequest, CancellationToken>((request, _) =>
-            {
-                finalizeRequest = request;
-                operations.Add("copy-finalize");
-            })
+        _s3.Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
+            .Callback<CopyObjectRequest, CancellationToken>((request, _) => promotion = request)
             .ReturnsAsync(new CopyObjectResponse());
-
-        _mockDatabaseService
-            .Setup(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()))
-            .Callback<ModuleStorage>(module =>
-            {
-                addedModule = module;
-                operations.Add("add-db");
-            })
+        _database.Setup(x => x.CreatePublicationAttemptWithExtractionJobAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
+            .Callback<ModulePublicationAttempt, ModuleExtractionJob>((value, _) => attempt = value)
+            .Returns(Task.CompletedTask);
+        _database.Setup(x => x.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null))
+            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?>((_, module, _) => committed = module)
             .ReturnsAsync(true);
+        using var content = new MemoryStream([1]);
 
-        _mockS3Client
-            .Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
-            .Callback<DeleteObjectRequest, CancellationToken>((request, _) =>
-            {
-                deleteRequest = request;
-                operations.Add("delete-temp");
-            })
-            .ReturnsAsync(new DeleteObjectResponse());
-
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc");
+        var result = await CreateService().UploadModuleAsync("ns", "name", "aws", "1.0.0", content, "desc");
 
         Assert.True(result);
-        Assert.NotNull(putRequest);
-        Assert.NotNull(finalizeRequest);
-        Assert.NotNull(addedModule);
-        Assert.NotNull(deleteRequest);
-        Assert.NotEqual(LogicalKey, finalizeRequest!.DestinationKey);
-        Assert.StartsWith("ns/name-aws-1.0.0.", finalizeRequest.DestinationKey, StringComparison.Ordinal);
-        Assert.EndsWith(".zip", finalizeRequest.DestinationKey, StringComparison.Ordinal);
-        Assert.Equal(putRequest!.Key, finalizeRequest.SourceKey);
-        Assert.Equal(finalizeRequest.DestinationKey, addedModule!.FilePath);
-        Assert.Equal(putRequest.Key, deleteRequest!.Key);
-        Assert.Equal("ns", putRequest.Metadata["namespace"]);
-        Assert.Equal("name", putRequest.Metadata["name"]);
-        Assert.Equal("aws", putRequest.Metadata["provider"]);
-        Assert.Equal("1.0.0", putRequest.Metadata["version"]);
-        Assert.Equal("desc", putRequest.Metadata["description"]);
-        Assert.False(string.IsNullOrWhiteSpace(putRequest.Metadata["publishedAt"]));
-        Assert.Equal(["put-temp", "copy-finalize", "add-db", "delete-temp"], operations);
-        _mockDatabaseService.Verify(x => x.RemoveModuleExactAsync(It.IsAny<ModuleStorage>()), Times.Never);
-        _mockS3Client.Verify(x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), default), Times.Never);
+        Assert.NotNull(attempt);
+        Assert.NotNull(stagedPut);
+        Assert.NotNull(promotion);
+        Assert.NotNull(committed);
+        Assert.Equal(ModulePublicationAttemptState.Staged, attempt!.State);
+        Assert.Equal(stagedPut!.Key, attempt.StagingKey);
+        Assert.Equal(stagedPut.Key, promotion!.SourceKey);
+        Assert.Equal(promotion.DestinationKey, committed!.FilePath);
+        _database.Verify(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
+        _database.Verify(x => x.ReplaceModuleExactAsync(It.IsAny<ModuleStorage>(), It.IsAny<ModuleStorage>()), Times.Never);
     }
 
     [Fact]
-    public async Task UploadModuleAsyncPreservesModuleMetadataOnCreate()
+    public async Task UploadModuleAsyncCleansOnlyAttemptObjectsWhenCatalogCommitLoses()
     {
-        ModuleStorage? addedModule = null;
-        var metadata = new ModuleArtifactMetadata
-        {
-            Source = new ModuleSourceInfo
-            {
-                Kind = "mirror",
-                Origin = "registry.example.com",
-                ArchiveFormat = "tar.gz"
-            }
-        };
-
-        _mockS3Client
-            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-            .ReturnsAsync(new PutObjectResponse());
-
-        _mockS3Client
-            .Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
-            .ReturnsAsync(new CopyObjectResponse());
-
-        _mockDatabaseService
-            .Setup(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()))
-            .Callback<ModuleStorage>(module => addedModule = module)
-            .ReturnsAsync(true);
-
-        _mockS3Client
-            .Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
-            .ReturnsAsync(new DeleteObjectResponse());
-
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc", metadata: metadata);
-
-        Assert.True(result);
-        Assert.NotNull(addedModule);
-        Assert.Equal("mirror", addedModule!.Metadata.Source?.Kind);
-        Assert.Equal("registry.example.com", addedModule.Metadata.Source?.Origin);
-        Assert.EndsWith(".tar.gz", addedModule.FilePath, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public async Task UploadModuleAsyncDeletesUniqueFinalObjectWhenCreateDbAddFails()
-    {
-        PutObjectRequest? putRequest = null;
-        string? finalKey = null;
-        var deleteKeys = new List<string>();
-
-        _mockS3Client
-            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-            .Callback<PutObjectRequest, CancellationToken>((request, _) => putRequest = request)
-            .ReturnsAsync(new PutObjectResponse());
-
-        _mockS3Client
-            .Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
-            .Callback<CopyObjectRequest, CancellationToken>((request, _) => finalKey = request.DestinationKey)
-            .ReturnsAsync(new CopyObjectResponse());
-
-        _mockDatabaseService
-            .Setup(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()))
+        var deleted = new List<string>();
+        var winner = Existing();
+        _database.Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0")).ReturnsAsync(winner);
+        _database.Setup(x => x.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), winner))
             .ReturnsAsync(false);
-
-        _mockS3Client
-            .Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
-            .Callback<DeleteObjectRequest, CancellationToken>((request, _) => deleteKeys.Add(request.Key))
+        _database.Setup(x => x.TryFailStagedPublicationAsync(It.IsAny<Guid>(), It.IsAny<string>())).ReturnsAsync(true);
+        _s3.Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
+            .Callback<DeleteObjectRequest, CancellationToken>((request, _) => deleted.Add(request.Key))
             .ReturnsAsync(new DeleteObjectResponse());
+        using var content = new MemoryStream([1]);
 
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc");
+        var result = await CreateService().UploadModuleAsync("ns", "name", "aws", "1.0.0", content, "desc", replace: true);
 
         Assert.False(result);
-        Assert.NotNull(putRequest);
-        Assert.NotNull(finalKey);
-        Assert.Contains(putRequest!.Key, deleteKeys);
-        Assert.Contains(finalKey!, deleteKeys);
-        _mockS3Client.Verify(x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), default), Times.Never);
+        Assert.DoesNotContain(winner.FilePath, deleted);
+        Assert.Equal(2, deleted.Count);
+        _database.Verify(x => x.TryFailStagedPublicationAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Once);
     }
 
     [Fact]
-    public async Task UploadModuleAsyncAllowsReplaceWhenCurrentDatabaseRowIsMissing()
+    public async Task UploadModuleAsyncCommitsReplacementMetadataAndDeletesSupersededObjectAfterCas()
     {
-        ModuleStorage? addedModule = null;
-
-        _mockS3Client
-            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-            .ReturnsAsync(new PutObjectResponse());
-
-        _mockS3Client
-            .Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
-            .ReturnsAsync(new CopyObjectResponse());
-
-        _mockDatabaseService
-            .Setup(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()))
-            .Callback<ModuleStorage>(module => addedModule = module)
-            .ReturnsAsync(true);
-
-        _mockS3Client
-            .Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
+        var winner = Existing();
+        var replacementMetadata = new ModuleArtifactMetadata { RootSubdirectory = "replacement" };
+        var deleted = new List<string>();
+        _database.Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0")).ReturnsAsync(winner);
+        _database.Setup(x => x.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(),
+                It.Is<ModuleStorage>(module => module.Metadata == replacementMetadata && module.Description == "new"),
+                winner)).ReturnsAsync(true);
+        _s3.Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
+            .Callback<DeleteObjectRequest, CancellationToken>((request, _) => deleted.Add(request.Key))
             .ReturnsAsync(new DeleteObjectResponse());
+        using var content = new MemoryStream([1]);
 
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc", replace: true);
+        var result = await CreateService().UploadModuleAsync("ns", "name", "aws", "1.0.0", content, "new",
+            replace: true, metadata: replacementMetadata);
 
         Assert.True(result);
-        Assert.NotNull(addedModule);
-        Assert.StartsWith("ns/name-aws-1.0.0.", addedModule!.FilePath, StringComparison.Ordinal);
-        Assert.EndsWith(".zip", addedModule.FilePath, StringComparison.Ordinal);
-        _mockDatabaseService.Verify(x => x.RemoveModuleExactAsync(It.IsAny<ModuleStorage>()), Times.Never);
+        Assert.Contains(winner.FilePath, deleted);
+        _database.Verify(x => x.ReplaceModuleExactAsync(It.IsAny<ModuleStorage>(), It.IsAny<ModuleStorage>()), Times.Never);
     }
 
     [Fact]
-    public async Task UploadModuleAsyncReturnsFalseWhenModuleRowExistsInTrash()
+    public async Task UploadModuleAsyncMarksAttemptFailedWhenPromotionFails()
     {
-        _mockDatabaseService
-            .Setup(x => x.GetModuleStorageIncludingDeletedAsync("ns", "name", "aws", "1.0.0"))
-            .ReturnsAsync(CreateExistingModuleStorage());
+        _s3.Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
+            .ThrowsAsync(new AmazonS3Exception("copy failed"));
+        _database.Setup(x => x.TryFailStagedPublicationAsync(It.IsAny<Guid>(), It.IsAny<string>())).ReturnsAsync(true);
+        using var content = new MemoryStream([1]);
 
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc");
+        var result = await CreateService().UploadModuleAsync("ns", "name", "aws", "1.0.0", content, "desc");
 
         Assert.False(result);
-        _mockS3Client.Verify(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default), Times.Never);
-        _mockS3Client.Verify(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default), Times.Never);
-        _mockDatabaseService.Verify(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
-        _mockDatabaseService.Verify(x => x.ReplaceModuleExactAsync(It.IsAny<ModuleStorage>(), It.IsAny<ModuleStorage>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task UploadModuleAsyncRemovesDbRowAndDeletesTempKeyWhenCreateFinalizeCopyFails()
-    {
-        PutObjectRequest? putRequest = null;
-        CopyObjectRequest? copyRequest = null;
-        var deleteKeys = new List<string>();
-
-        _mockS3Client
-            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-            .Callback<PutObjectRequest, CancellationToken>((request, _) => putRequest = request)
-            .ReturnsAsync(new PutObjectResponse());
-
-        _mockS3Client
-            .Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
-            .Callback<CopyObjectRequest, CancellationToken>((request, _) => copyRequest = request)
-            .ThrowsAsync(new AmazonS3Exception("copy failed")
-            {
-                StatusCode = HttpStatusCode.PreconditionFailed
-            });
-
-        _mockS3Client
-            .Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
-            .Callback<DeleteObjectRequest, CancellationToken>((request, _) => deleteKeys.Add(request.Key))
-            .ReturnsAsync(new DeleteObjectResponse());
-
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc");
-
-        Assert.False(result);
-        Assert.NotNull(putRequest);
-        Assert.NotNull(copyRequest);
-        Assert.Equal("*", copyRequest!.IfNoneMatch);
-        Assert.Contains(putRequest!.Key, deleteKeys);
-        Assert.Contains(copyRequest.DestinationKey, deleteKeys);
-        _mockDatabaseService.Verify(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
-        _mockDatabaseService.Verify(x => x.RemoveModuleExactAsync(It.IsAny<ModuleStorage>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task UploadModuleAsyncContinuesWhenCreateFinalizeCopyThrowsButFinalMetadataMatchesUpload()
-    {
-        PutObjectRequest? putRequest = null;
-        string? finalKey = null;
-        var finalObjectExists = false;
-        Dictionary<string, string>? finalObjectMetadata = null;
-
-        _mockS3Client
-            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-            .Callback<PutObjectRequest, CancellationToken>((request, _) => putRequest = request)
-            .ReturnsAsync(new PutObjectResponse());
-
-        _mockS3Client
-            .Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
-            .Callback<CopyObjectRequest, CancellationToken>((request, _) =>
-            {
-                finalKey = request.DestinationKey;
-                finalObjectExists = true;
-                finalObjectMetadata = new Dictionary<string, string>
-(StringComparer.Ordinal)
-                {
-                    ["namespace"] = putRequest!.Metadata["namespace"],
-                    ["name"] = putRequest.Metadata["name"],
-                    ["provider"] = putRequest.Metadata["provider"],
-                    ["version"] = putRequest.Metadata["version"],
-                    ["description"] = putRequest.Metadata["description"],
-                    ["publishedAt"] = putRequest.Metadata["publishedAt"]
-                };
-            })
-            .ThrowsAsync(new AmazonS3Exception("copy failed")
-            {
-                StatusCode = HttpStatusCode.InternalServerError
-            });
-
-        _mockS3Client
-            .Setup(x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), default))
-            .Returns<GetObjectMetadataRequest, CancellationToken>((request, _) =>
-            {
-                if (!finalObjectExists || finalObjectMetadata == null || request.Key != finalKey)
-                {
-                    throw new AmazonS3Exception("Not found")
-                    {
-                        StatusCode = HttpStatusCode.NotFound
-                    };
-                }
-
-                return Task.FromResult(CreateMetadataResponse(
-                    finalObjectMetadata["namespace"],
-                    finalObjectMetadata["name"],
-                    finalObjectMetadata["provider"],
-                    finalObjectMetadata["version"],
-                    finalObjectMetadata["description"],
-                    finalObjectMetadata["publishedAt"]));
-            });
-
-        _mockDatabaseService
-            .Setup(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()))
-            .ReturnsAsync(true);
-
-        _mockS3Client
-            .Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
-            .ReturnsAsync(new DeleteObjectResponse());
-
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc");
-
-        Assert.True(result);
-        Assert.NotNull(finalKey);
-        _mockDatabaseService.Verify(x => x.AddModuleAsync(It.Is<ModuleStorage>(module =>
-            module.Description == "desc" &&
-            module.FilePath == finalKey)), Times.Once);
-    }
-
-    [Fact]
-    public async Task UploadModuleAsyncReplacesWithNewUniqueFinalKeyAndDeletesPreviousObject()
-    {
-        var existingModule = CreateExistingModuleStorage();
-        string? tempKey = null;
-        string? finalKey = null;
-        var deleteKeys = new List<string>();
-
-        _mockDatabaseService
-            .Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0"))
-            .ReturnsAsync(existingModule);
-
-        _mockS3Client
-            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-            .Callback<PutObjectRequest, CancellationToken>((request, _) => tempKey = request.Key)
-            .ReturnsAsync(new PutObjectResponse());
-
-        _mockS3Client
-            .Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
-            .Callback<CopyObjectRequest, CancellationToken>((request, _) => finalKey = request.DestinationKey)
-            .ReturnsAsync(new CopyObjectResponse());
-
-        _mockDatabaseService
-            .Setup(x => x.ReplaceModuleExactAsync(
-                existingModule,
-                It.Is<ModuleStorage>(module =>
-                    module.Description == "desc" &&
-                    module.FilePath == finalKey)))
-            .ReturnsAsync(true);
-
-        _mockS3Client
-            .Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
-            .Callback<DeleteObjectRequest, CancellationToken>((request, _) => deleteKeys.Add(request.Key))
-            .ReturnsAsync(new DeleteObjectResponse());
-
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc", replace: true);
-
-        Assert.True(result);
-        Assert.NotNull(tempKey);
-        Assert.NotNull(finalKey);
-        Assert.NotEqual(existingModule.FilePath, finalKey);
-        Assert.StartsWith("ns/name-aws-1.0.0.", finalKey!, StringComparison.Ordinal);
-        Assert.EndsWith(".zip", finalKey, StringComparison.Ordinal);
-        Assert.Contains(tempKey!, deleteKeys);
-        Assert.Contains(existingModule.FilePath, deleteKeys);
-        _mockDatabaseService.Verify(x => x.ReplaceModuleExactAsync(
-            existingModule,
-            It.Is<ModuleStorage>(module =>
-                module.Description == "desc" &&
-                module.FilePath == finalKey)), Times.Once);
-        _mockDatabaseService.Verify(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task UploadModuleAsyncReturnsFalseAndCleansUpWhenReplaceUpdateReturnsFalse()
-    {
-        var existingModule = CreateExistingModuleStorage();
-        string? tempKey = null;
-        string? finalKey = null;
-        var deleteKeys = new List<string>();
-
-        _mockDatabaseService
-            .Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0"))
-            .ReturnsAsync(existingModule);
-
-        _mockS3Client
-            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-            .Callback<PutObjectRequest, CancellationToken>((request, _) => tempKey = request.Key)
-            .ReturnsAsync(new PutObjectResponse());
-
-        _mockS3Client
-            .Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
-            .Callback<CopyObjectRequest, CancellationToken>((request, _) => finalKey = request.DestinationKey)
-            .ReturnsAsync(new CopyObjectResponse());
-
-        _mockDatabaseService
-            .Setup(x => x.ReplaceModuleExactAsync(existingModule, It.IsAny<ModuleStorage>()))
-            .ReturnsAsync(false);
-
-        _mockS3Client
-            .Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
-            .Callback<DeleteObjectRequest, CancellationToken>((request, _) => deleteKeys.Add(request.Key))
-            .ReturnsAsync(new DeleteObjectResponse());
-
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc", replace: true);
-
-        Assert.False(result);
-        Assert.NotNull(tempKey);
-        Assert.NotNull(finalKey);
-        Assert.Contains(tempKey!, deleteKeys);
-        Assert.Contains(finalKey!, deleteKeys);
-        Assert.DoesNotContain(existingModule.FilePath, deleteKeys);
-        _mockDatabaseService.Verify(x => x.ReplaceModuleExactAsync(existingModule, It.IsAny<ModuleStorage>()), Times.Once);
-        _mockDatabaseService.Verify(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task UploadModuleAsyncReturnsFalseAndCleansUpWhenReplaceUpdateThrows()
-    {
-        var existingModule = CreateExistingModuleStorage();
-        string? tempKey = null;
-        string? finalKey = null;
-        var deleteKeys = new List<string>();
-
-        _mockDatabaseService
-            .Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0"))
-            .ReturnsAsync(existingModule);
-
-        _mockS3Client
-            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-            .Callback<PutObjectRequest, CancellationToken>((request, _) => tempKey = request.Key)
-            .ReturnsAsync(new PutObjectResponse());
-
-        _mockS3Client
-            .Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
-            .Callback<CopyObjectRequest, CancellationToken>((request, _) => finalKey = request.DestinationKey)
-            .ReturnsAsync(new CopyObjectResponse());
-
-        _mockDatabaseService
-            .Setup(x => x.ReplaceModuleExactAsync(existingModule, It.IsAny<ModuleStorage>()))
-            .ThrowsAsync(new InvalidOperationException("replace failed"));
-
-        _mockS3Client
-            .Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
-            .Callback<DeleteObjectRequest, CancellationToken>((request, _) => deleteKeys.Add(request.Key))
-            .ReturnsAsync(new DeleteObjectResponse());
-
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc", replace: true);
-
-        Assert.False(result);
-        Assert.NotNull(tempKey);
-        Assert.NotNull(finalKey);
-        Assert.Contains(tempKey!, deleteKeys);
-        Assert.Contains(finalKey!, deleteKeys);
-        Assert.DoesNotContain(existingModule.FilePath, deleteKeys);
-        _mockDatabaseService.Verify(x => x.ReplaceModuleExactAsync(existingModule, It.IsAny<ModuleStorage>()), Times.Once);
-        _mockDatabaseService.Verify(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task UploadModuleAsyncReturnsFalseAndDeletesUniqueFinalObjectWhenReplaceFinalizeCopyFails()
-    {
-        var existingModule = CreateExistingModuleStorage();
-        string? tempKey = null;
-        string? finalKey = null;
-        var deleteKeys = new List<string>();
-
-        _mockDatabaseService
-            .Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0"))
-            .ReturnsAsync(existingModule);
-
-        _mockS3Client
-            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-            .Callback<PutObjectRequest, CancellationToken>((request, _) => tempKey = request.Key)
-            .ReturnsAsync(new PutObjectResponse());
-
-        _mockS3Client
-            .Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
-            .Callback<CopyObjectRequest, CancellationToken>((request, _) => finalKey = request.DestinationKey)
-            .ThrowsAsync(new AmazonS3Exception("copy failed")
-            {
-                StatusCode = HttpStatusCode.InternalServerError
-            });
-
-        _mockS3Client
-            .Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
-            .Callback<DeleteObjectRequest, CancellationToken>((request, _) => deleteKeys.Add(request.Key))
-            .ReturnsAsync(new DeleteObjectResponse());
-
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc", replace: true);
-
-        Assert.False(result);
-        Assert.NotNull(tempKey);
-        Assert.NotNull(finalKey);
-        Assert.Contains(tempKey!, deleteKeys);
-        Assert.Contains(finalKey!, deleteKeys);
-        Assert.DoesNotContain(existingModule.FilePath, deleteKeys);
-        _mockDatabaseService.Verify(x => x.ReplaceModuleExactAsync(existingModule, It.IsAny<ModuleStorage>()), Times.Never);
-        _mockDatabaseService.Verify(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task UploadModuleAsyncReturnsFalseAndDeletesUniqueFinalObjectWhenReplaceUpdateFailsAfterFinalize()
-    {
-        var existingModule = CreateExistingModuleStorage();
-        string? tempKey = null;
-        string? finalKey = null;
-        var deleteKeys = new List<string>();
-
-        _mockDatabaseService
-            .Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0"))
-            .ReturnsAsync(existingModule);
-
-        _mockS3Client
-            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-            .Callback<PutObjectRequest, CancellationToken>((request, _) => tempKey = request.Key)
-            .ReturnsAsync(new PutObjectResponse());
-
-        _mockS3Client
-            .Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
-            .Callback<CopyObjectRequest, CancellationToken>((request, _) => finalKey = request.DestinationKey)
-            .ReturnsAsync(new CopyObjectResponse());
-
-        _mockDatabaseService
-            .Setup(x => x.ReplaceModuleExactAsync(existingModule, It.IsAny<ModuleStorage>()))
-            .ReturnsAsync(false);
-
-        _mockS3Client
-            .Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
-            .Callback<DeleteObjectRequest, CancellationToken>((request, _) => deleteKeys.Add(request.Key))
-            .ReturnsAsync(new DeleteObjectResponse());
-
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc", replace: true);
-
-        Assert.False(result);
-        Assert.NotNull(tempKey);
-        Assert.NotNull(finalKey);
-        Assert.Contains(tempKey!, deleteKeys);
-        Assert.Contains(finalKey!, deleteKeys);
-        Assert.DoesNotContain(existingModule.FilePath, deleteKeys);
-        _mockDatabaseService.Verify(x => x.ReplaceModuleExactAsync(existingModule, It.IsAny<ModuleStorage>()), Times.Once);
-        _mockDatabaseService.Verify(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task UploadModuleAsyncLogsWhenTempKeyCleanupDeleteFails()
-    {
-        _mockS3Client
-            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-            .ReturnsAsync(new PutObjectResponse());
-
-        _mockS3Client
-            .Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), default))
-            .ReturnsAsync(new CopyObjectResponse());
-
-        _mockDatabaseService
-            .Setup(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()))
-            .ReturnsAsync(false);
-
-        _mockS3Client
-            .Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), default))
-            .ThrowsAsync(new AmazonS3Exception("delete failed")
-            {
-                StatusCode = HttpStatusCode.InternalServerError
-            });
-
-        var service = CreateService();
-        using var stream = new MemoryStream([1, 2, 3]);
-
-        var result = await service.UploadModuleAsync("ns", "name", "aws", "1.0.0", stream, "desc");
-
-        Assert.False(result);
-        _mockLogger.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((value, _) => value.ToString()!.Contains("temporary S3 object")),
-                It.IsAny<AmazonS3Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
+        _database.Verify(x => x.TryCommitStagedPublicationAsync(
+            It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), It.IsAny<ModuleStorage?>()), Times.Never);
+        _database.Verify(x => x.TryFailStagedPublicationAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Once);
     }
 }


### PR DESCRIPTION
Summary: stage S3 module attempts before object work; commit catalog updates through the staged-publication CAS contract; clean only attempt-owned objects on conflict or failed promotion.

Verified: full diagnostic suite 686 passed; MinIO/Terraform smoke passed; slopwatch passed.