### PR TITLE
perf: reconcile storage after startup

### DIFF
--- a/TerraformRegistry.API/Interfaces/IModuleService.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleService.cs
@@ -13,6 +13,11 @@ public interface IModuleService
     Task InitializeStorageAsync(CancellationToken cancellationToken);
 
     /// <summary>
+    ///     Reconciles persisted storage state after startup readiness has been established.
+    /// </summary>
+    Task ReconcileStorageAsync(CancellationToken cancellationToken);
+
+    /// <summary>
     ///     Lists all modules
     /// </summary>
     Task<ModuleList> ListModulesAsync(ModuleSearchRequest request);

--- a/TerraformRegistry.API/ModuleService.cs
+++ b/TerraformRegistry.API/ModuleService.cs
@@ -16,6 +16,11 @@ public abstract class ModuleService : IModuleService
     public virtual Task InitializeStorageAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     /// <summary>
+    ///     Reconciles storage-backed records after initialization without delaying readiness.
+    /// </summary>
+    public virtual Task ReconcileStorageAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
     ///     Lists all modules
     /// </summary>
     public abstract Task<ModuleList> ListModulesAsync(ModuleSearchRequest request);

--- a/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
+++ b/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
@@ -99,9 +99,11 @@ public class AzureBlobModuleService : ModuleService
     {
         RegistryLog.Information(_logger, "Ensuring blob container '{ContainerName}' exists...", _containerName);
         await _containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
-        await LoadExistingModulesAsync(cancellationToken);
         RegistryLog.Information(_logger, "Blob container '{ContainerName}' is ready.", _containerName);
     }
+
+    public override Task ReconcileStorageAsync(CancellationToken cancellationToken) =>
+        LoadExistingModulesAsync(cancellationToken);
 
     /// <summary>
     ///     Lists all modules based on search criteria

--- a/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceConstructorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceConstructorTests.cs
@@ -195,7 +195,7 @@ public class AzureBlobModuleServiceConstructorTests
     }
 
     [Fact]
-    public async Task InitializationSynchronizesExistingBlobsIntoDatabase()
+    public async Task ReconciliationSynchronizesExistingBlobsIntoDatabase()
     {
         var settings = new Dictionary<string, string?>
 (StringComparer.Ordinal)
@@ -231,6 +231,7 @@ public class AzureBlobModuleServiceConstructorTests
 
         _mockDatabaseService.Verify(db => db.AddModuleAsync(It.IsAny<TerraformRegistry.Models.ModuleStorage>()), Times.Never);
         await service.InitializeStorageAsync(CancellationToken.None);
+        await service.ReconcileStorageAsync(CancellationToken.None);
 
         Assert.NotNull(service);
         _mockDatabaseService.Verify(db => db.AddModuleAsync(It.Is<TerraformRegistry.Models.ModuleStorage>(m =>
@@ -243,7 +244,7 @@ public class AzureBlobModuleServiceConstructorTests
     }
 
     [Fact]
-    public async Task InitializationDoesNotImportStagedPublicationBlobs()
+    public async Task ReconciliationDoesNotImportStagedPublicationBlobs()
     {
         var settings = new Dictionary<string, string?>(StringComparer.Ordinal)
         {
@@ -261,8 +262,26 @@ public class AzureBlobModuleServiceConstructorTests
             _mockBlobServiceClient.Object);
 
         await service.InitializeStorageAsync(CancellationToken.None);
+        await service.ReconcileStorageAsync(CancellationToken.None);
 
         _mockBlobContainerClient.Verify(c => c.GetBlobClient(stagedBlobName), Times.Never);
         _mockDatabaseService.Verify(db => db.AddModuleAsync(It.IsAny<TerraformRegistry.Models.ModuleStorage>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InitializationDoesNotScanExistingBlobsBeforeReadiness()
+    {
+        var settings = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            { "ContainerName", _containerName },
+            { "SasTokenExpiryMinutes", "5" }
+        };
+        var service = new AzureBlobModuleService(CreateConfiguration(settings), _mockDatabaseService.Object,
+            _mockLogger.Object, _mockBlobServiceClient.Object);
+
+        await service.InitializeStorageAsync(CancellationToken.None);
+
+        _mockBlobContainerClient.Verify(c => c.GetBlobsAsync(
+            BlobTraits.None, BlobStates.None, null, CancellationToken.None), Times.Never);
     }
 }

--- a/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -43,6 +44,27 @@ public class LocalModuleServiceTests
 
         // Assert
         Assert.True(Directory.Exists(_testModulePath));
+    }
+
+    [Fact]
+    public async Task InitializationDefersLocalArtifactRecoveryUntilReconciliation()
+    {
+        var namespaceDirectory = Path.Join(_testModulePath, "acme");
+        Directory.CreateDirectory(namespaceDirectory);
+        var archivePath = Path.Join(namespaceDirectory, "network-aws-1.0.0.zip");
+        using (ZipFile.Open(archivePath, ZipArchiveMode.Create))
+        {
+        }
+        _mockDbService.Setup(service => service.AddModuleAsync(It.IsAny<ModuleStorage>())).ReturnsAsync(true);
+        var service = new LocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);
+
+        await service.InitializeStorageAsync(CancellationToken.None);
+
+        _mockDbService.Verify(database => database.AddModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
+        await service.ReconcileStorageAsync(CancellationToken.None);
+        _mockDbService.Verify(database => database.AddModuleAsync(It.Is<ModuleStorage>(module =>
+            module.Namespace == "acme" && module.Name == "network" && module.Provider == "aws" &&
+            module.Version == "1.0.0")), Times.Once);
     }
 
     // Verifies that the constructor logs the storage path being used

--- a/TerraformRegistry.Tests/UnitTests/StorageInitializationHostedServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/StorageInitializationHostedServiceTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using TerraformRegistry.API.Interfaces;
@@ -64,5 +65,38 @@ public class StorageInitializationHostedServiceTests
         await hostedService.StopAsync(CancellationToken.None);
 
         moduleService.Verify(service => service.ReconcileStorageAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReconciliationDoesNotRetryOrLogCancellationExceptions()
+    {
+        var moduleService = new Mock<IModuleService>();
+        var reconciliationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var throwCancellation = new TaskCompletionSource();
+        moduleService
+            .Setup(service => service.ReconcileStorageAsync(It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                reconciliationStarted.SetResult();
+                await throwCancellation.Task;
+            });
+        var logger = new Mock<ILogger<StorageReconciliationHostedService>>();
+        logger.Setup(entry => entry.IsEnabled(LogLevel.Error)).Returns(true);
+        var hostedService = new StorageReconciliationHostedService(moduleService.Object, logger.Object);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await reconciliationStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        throwCancellation.SetException(new OperationCanceledException());
+        await hostedService.StopAsync(CancellationToken.None);
+
+        moduleService.Verify(service => service.ReconcileStorageAsync(It.IsAny<CancellationToken>()), Times.Once);
+        logger.Verify(
+            entry => entry.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
     }
 }

--- a/TerraformRegistry.Tests/UnitTests/StorageInitializationHostedServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/StorageInitializationHostedServiceTests.cs
@@ -40,4 +40,29 @@ public class StorageInitializationHostedServiceTests
         Assert.True(readiness.IsStorageInitialized);
         moduleService.Verify(service => service.InitializeStorageAsync(CancellationToken.None), Times.Once);
     }
+
+    [Fact]
+    public async Task ReconciliationRunsInBackgroundWithoutBlockingStartup()
+    {
+        var moduleService = new Mock<IModuleService>();
+        var reconciliationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowReconciliationToComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        moduleService
+            .Setup(service => service.ReconcileStorageAsync(It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                reconciliationStarted.SetResult();
+                await allowReconciliationToComplete.Task;
+            });
+
+        var hostedService = new StorageReconciliationHostedService(moduleService.Object,
+            NullLogger<StorageReconciliationHostedService>.Instance);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await reconciliationStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        allowReconciliationToComplete.SetResult();
+        await hostedService.StopAsync(CancellationToken.None);
+
+        moduleService.Verify(service => service.ReconcileStorageAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
 }

--- a/TerraformRegistry/Services/LocalModuleService.cs
+++ b/TerraformRegistry/Services/LocalModuleService.cs
@@ -41,6 +41,12 @@ public class LocalModuleService : ModuleService
     {
         cancellationToken.ThrowIfCancellationRequested();
         Directory.CreateDirectory(_moduleStorageRoot);
+        return Task.CompletedTask;
+    }
+
+    public override Task ReconcileStorageAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
         LoadExistingModules();
         return Task.CompletedTask;
     }

--- a/TerraformRegistry/Services/StorageReconciliationHostedService.cs
+++ b/TerraformRegistry/Services/StorageReconciliationHostedService.cs
@@ -34,7 +34,7 @@ public sealed class StorageReconciliationHostedService : BackgroundService
             {
                 return;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 RegistryLog.Error(_logger, ex, "Storage reconciliation failed; retrying after {RetryDelay}.", RetryDelay);
                 await Task.Delay(RetryDelay, stoppingToken);

--- a/TerraformRegistry/Services/StorageReconciliationHostedService.cs
+++ b/TerraformRegistry/Services/StorageReconciliationHostedService.cs
@@ -1,0 +1,36 @@
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.API.Logging;
+
+namespace TerraformRegistry.Services;
+
+/// <summary>
+///     Runs storage reconciliation after readiness without delaying application startup.
+/// </summary>
+public sealed class StorageReconciliationHostedService(
+    IModuleService moduleService,
+    ILogger<StorageReconciliationHostedService> logger) : BackgroundService
+{
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(5);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await moduleService.ReconcileStorageAsync(stoppingToken);
+                RegistryLog.Information(logger, "Storage reconciliation completed successfully.");
+                return;
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                RegistryLog.Error(logger, ex, "Storage reconciliation failed; retrying after {RetryDelay}.", RetryDelay);
+                await Task.Delay(RetryDelay, stoppingToken);
+            }
+        }
+    }
+}

--- a/TerraformRegistry/Services/StorageReconciliationHostedService.cs
+++ b/TerraformRegistry/Services/StorageReconciliationHostedService.cs
@@ -6,11 +6,19 @@ namespace TerraformRegistry.Services;
 /// <summary>
 ///     Runs storage reconciliation after readiness without delaying application startup.
 /// </summary>
-public sealed class StorageReconciliationHostedService(
-    IModuleService moduleService,
-    ILogger<StorageReconciliationHostedService> logger) : BackgroundService
+public sealed class StorageReconciliationHostedService : BackgroundService
 {
     private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(5);
+    private readonly IModuleService _moduleService;
+    private readonly ILogger<StorageReconciliationHostedService> _logger;
+
+    public StorageReconciliationHostedService(
+        IModuleService moduleService,
+        ILogger<StorageReconciliationHostedService> logger)
+    {
+        _moduleService = moduleService;
+        _logger = logger;
+    }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -18,17 +26,17 @@ public sealed class StorageReconciliationHostedService(
         {
             try
             {
-                await moduleService.ReconcileStorageAsync(stoppingToken);
-                RegistryLog.Information(logger, "Storage reconciliation completed successfully.");
+                await _moduleService.ReconcileStorageAsync(stoppingToken);
+                RegistryLog.Information(_logger, "Storage reconciliation completed successfully.");
                 return;
             }
-            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            catch (OperationCanceledException)
             {
                 return;
             }
             catch (Exception ex)
             {
-                RegistryLog.Error(logger, ex, "Storage reconciliation failed; retrying after {RetryDelay}.", RetryDelay);
+                RegistryLog.Error(_logger, ex, "Storage reconciliation failed; retrying after {RetryDelay}.", RetryDelay);
                 await Task.Delay(RetryDelay, stoppingToken);
             }
         }

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -98,6 +98,7 @@ internal static class ServiceRegistrationExtensions
 
         services.AddHostedService<DatabaseInitializerHostedService>();
         services.AddHostedService<StorageInitializationHostedService>();
+        services.AddHostedService<StorageReconciliationHostedService>();
         services.AddHttpClient();
         services.AddHttpClient("TerraformRegistryMirrorDiscovery", client =>
             {

--- a/scripts/remediation/storage-emulators/storage-emulators.sh
+++ b/scripts/remediation/storage-emulators/storage-emulators.sh
@@ -55,8 +55,9 @@ require_initialized() {
 case "$COMMAND" in
   start)
     initialize
-    compose up -d --build --force-recreate azurite minio postgres app caddy
+    compose up -d --build --force-recreate azurite minio postgres
     compose run --rm minio-init
+    compose up -d --build --force-recreate app caddy
     ;;
   status)
     require_initialized

--- a/scripts/remediation/storage-emulators/test-lifecycle.sh
+++ b/scripts/remediation/storage-emulators/test-lifecycle.sh
@@ -3,7 +3,12 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 HARNESS="$(mktemp -d)"
-trap 'rm -rf "$HARNESS"' EXIT
+cleanup() {
+  local status=$?
+  rm -rf "$HARNESS"
+  exit "$status"
+}
+trap cleanup EXIT
 
 if "$ROOT/scripts/remediation/storage-emulators/storage-emulators.sh" status --home "$HARNESS" >/tmp/storage-emulator-status.out 2>&1; then
   echo "Expected status to fail before the harness is initialized." >&2
@@ -11,3 +16,8 @@ if "$ROOT/scripts/remediation/storage-emulators/storage-emulators.sh" status --h
 fi
 
 grep -Fq 'not initialized' /tmp/storage-emulator-status.out
+
+LIFECYCLE="$ROOT/scripts/remediation/storage-emulators/storage-emulators.sh"
+grep -Fq 'compose up -d --build --force-recreate azurite minio postgres' "$LIFECYCLE"
+grep -Fq 'compose run --rm minio-init' "$LIFECYCLE"
+grep -Fq 'compose up -d --build --force-recreate app caddy' "$LIFECYCLE"


### PR DESCRIPTION
Moves Local and Azure Blob recovery scans out of storage initialization into a cancellable, retrying hosted reconciliation worker. Startup readiness now verifies storage availability without waiting for large artifact scans; recovery tests explicitly exercise the deferred reconciliation path.