### PR TITLE
perf: reduce provider package query round trips

### DIFF
--- a/TerraformRegistry.API/Interfaces/IProviderRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IProviderRepository.cs
@@ -14,8 +14,7 @@ public interface IProviderRepository
     Task<IReadOnlyList<ProviderVersionEntry>> GetProviderVersionsAsync(string providerNamespace, string type);
     Task<IReadOnlyList<ProviderManagementVersionEntry>> GetProviderManagementVersionsAsync(string providerNamespace, string type);
     Task<ProviderVersion?> GetProviderVersionAsync(string providerNamespace, string type, string version);
-    Task<ProviderPackageDetails?> GetProviderPackageDetailsAsync(string providerNamespace, string type, string version, string os, string arch) =>
-        Task.FromResult<ProviderPackageDetails?>(null);
+    Task<ProviderPackageDetails?> GetProviderPackageDetailsAsync(string providerNamespace, string type, string version, string os, string arch);
     Task<ProviderVersion> CreateProviderVersionAsync(Guid providerId, string version, string[] protocols, string keyId);
     Task<bool> SetVersionShasumsPathAsync(Guid versionId, string storagePath);
     Task<bool> SetVersionShasumsSignaturePathAsync(Guid versionId, string storagePath);

--- a/TerraformRegistry.API/Interfaces/IProviderRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IProviderRepository.cs
@@ -14,6 +14,8 @@ public interface IProviderRepository
     Task<IReadOnlyList<ProviderVersionEntry>> GetProviderVersionsAsync(string providerNamespace, string type);
     Task<IReadOnlyList<ProviderManagementVersionEntry>> GetProviderManagementVersionsAsync(string providerNamespace, string type);
     Task<ProviderVersion?> GetProviderVersionAsync(string providerNamespace, string type, string version);
+    Task<ProviderPackageDetails?> GetProviderPackageDetailsAsync(string providerNamespace, string type, string version, string os, string arch) =>
+        Task.FromResult<ProviderPackageDetails?>(null);
     Task<ProviderVersion> CreateProviderVersionAsync(Guid providerId, string version, string[] protocols, string keyId);
     Task<bool> SetVersionShasumsPathAsync(Guid versionId, string storagePath);
     Task<bool> SetVersionShasumsSignaturePathAsync(Guid versionId, string storagePath);

--- a/TerraformRegistry.Models/ProviderPackageDetails.cs
+++ b/TerraformRegistry.Models/ProviderPackageDetails.cs
@@ -1,0 +1,17 @@
+namespace TerraformRegistry.Models;
+
+public sealed record ProviderPackageDetails(
+    Guid ProviderId,
+    string[] Protocols,
+    string KeyId,
+    string ShasumsStoragePath,
+    string ShasumsSignatureStoragePath,
+    string Os,
+    string Arch,
+    string Filename,
+    string Shasum,
+    string PackageStoragePath,
+    string AsciiArmor,
+    string? TrustSignature,
+    string? Source,
+    string? SourceUrl);

--- a/TerraformRegistry.PostgreSQL/PostgreSqlProviderRepository.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSqlProviderRepository.cs
@@ -251,6 +251,33 @@ public sealed class PostgreSqlProviderRepository : IProviderRepository
         return await reader.ReadAsync() ? MapVersion(reader) : null;
     }
 
+    public async Task<ProviderPackageDetails?> GetProviderPackageDetailsAsync(string providerNamespace, string type, string version, string os, string arch)
+    {
+        await using var connection = await OpenConnectionAsync();
+        await using var command = new NpgsqlCommand(@"
+            SELECT p.id, pv.protocols::text, pv.key_id, pv.shasums_storage_path, pv.shasums_signature_storage_path,
+                   pp.os, pp.arch, pp.filename, pp.shasum, pp.package_storage_path,
+                   g.ascii_armor, g.trust_signature, g.source, g.source_url
+            FROM providers p
+            INNER JOIN provider_versions pv ON pv.provider_id = p.id AND pv.deleted_at IS NULL
+            INNER JOIN provider_platforms pp ON pp.provider_version_id = pv.id
+            INNER JOIN provider_gpg_keys g ON g.namespace = p.namespace AND g.key_id = pv.key_id AND g.revoked_at IS NULL
+            WHERE p.namespace = @providerNamespace AND p.type = @type AND pv.version = @version
+              AND pp.os = @os AND pp.arch = @arch AND p.deleted_at IS NULL", connection);
+        command.Parameters.AddWithValue("providerNamespace", providerNamespace);
+        command.Parameters.AddWithValue("@type", type);
+        command.Parameters.AddWithValue("@version", version);
+        command.Parameters.AddWithValue("@os", os);
+        command.Parameters.AddWithValue("@arch", arch);
+
+        await using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync()) return null;
+        if (reader.IsDBNull(3) || reader.IsDBNull(4) || reader.IsDBNull(9)) return null;
+        return new ProviderPackageDetails(reader.GetGuid(0), DeserializeProtocols(reader.GetString(1)), reader.GetString(2),
+            reader.GetString(3), reader.GetString(4), reader.GetString(5), reader.GetString(6), reader.GetString(7), reader.GetString(8),
+            reader.GetString(9), reader.GetString(10), ReadNullableString(reader, 11), ReadNullableString(reader, 12), ReadNullableString(reader, 13));
+    }
+
     public async Task<ProviderVersion> CreateProviderVersionAsync(Guid providerId, string version, string[] protocols, string keyId)
     {
         var providerVersion = new ProviderVersion

--- a/TerraformRegistry.Tests/UnitTests/ProviderRegistryServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ProviderRegistryServiceTests.cs
@@ -72,6 +72,22 @@ public class ProviderRegistryServiceTests
                 AsciiArmor = "key",
                 CreatedAt = DateTime.UtcNow
             });
+        repository.Setup(x => x.GetProviderPackageDetailsAsync("acme", "example", "1.0.0", "linux", "amd64"))
+            .ReturnsAsync(new ProviderPackageDetails(
+                providerId,
+                ["5.0"],
+                "ABCDEF",
+                "shasums",
+                "sig",
+                "linux",
+                "amd64",
+                "terraform-provider-example_1.0.0_linux_amd64.zip",
+                new string('a', 64),
+                "package.zip",
+                "key",
+                null,
+                null,
+                null));
         storage.Setup(x => x.CreateDownloadUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string path, CancellationToken _) => $"/provider/download?token={path}");
 

--- a/TerraformRegistry.Tests/UnitTests/ProviderRegistryServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ProviderRegistryServiceTests.cs
@@ -96,6 +96,55 @@ public class ProviderRegistryServiceTests
     }
 
     [Fact]
+    public async Task GetPackageAsyncUsesOneRepositoryReadAndCreatesArtifactUrlsConcurrently()
+    {
+        var repository = new Mock<IProviderRepository>(MockBehavior.Strict);
+        var storage = new Mock<IProviderArtifactStorage>(MockBehavior.Strict);
+        var packageDetails = new ProviderPackageDetails(
+            Guid.NewGuid(),
+            ["5.0"],
+            "ABCDEF",
+            "shasums",
+            "signature",
+            "linux",
+            "amd64",
+            "terraform-provider-example_1.0.0_linux_amd64.zip",
+            new string('a', 64),
+            "package.zip",
+            "key",
+            null,
+            null,
+            null);
+        repository
+            .Setup(x => x.GetProviderPackageDetailsAsync("acme", "example", "1.0.0", "linux", "amd64"))
+            .ReturnsAsync(packageDetails);
+        repository
+            .Setup(x => x.RecordProviderDownloadAsync(packageDetails.ProviderId, "acme", "example", "1.0.0", "linux", "amd64", null, null))
+            .Returns(Task.CompletedTask);
+
+        var urlsStarted = 0;
+        var releaseUrls = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        storage
+            .Setup(x => x.CreateDownloadUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string path, CancellationToken cancellationToken) =>
+            {
+                if (Interlocked.Increment(ref urlsStarted) == 3)
+                    releaseUrls.SetResult();
+
+                await releaseUrls.Task.WaitAsync(cancellationToken);
+                return $"/provider/download?token={path}";
+            });
+        var service = CreateService(repository, storage);
+
+        var response = await service.GetPackageAsync("acme", "example", "1.0.0", "linux", "amd64", null, null, CancellationToken.None);
+
+        Assert.NotNull(response);
+        Assert.Equal(3, urlsStarted);
+        repository.Verify(x => x.GetProviderPackageDetailsAsync("acme", "example", "1.0.0", "linux", "amd64"), Times.Once);
+        repository.Verify(x => x.RecordProviderDownloadAsync(packageDetails.ProviderId, "acme", "example", "1.0.0", "linux", "amd64", null, null), Times.Once);
+    }
+
+    [Fact]
     public async Task CreateProviderAsyncRejectsInvalidProviderNamespace()
     {
         var service = CreateService();

--- a/TerraformRegistry/Services/ProviderRegistryService.cs
+++ b/TerraformRegistry/Services/ProviderRegistryService.cs
@@ -77,61 +77,40 @@ public sealed class ProviderRegistryService : IProviderRegistryService
     {
         ValidateCoordinate(providerNamespace, type);
 
-        var provider = await _repository.GetProviderAsync(providerNamespace, type);
-        if (provider == null)
-        {
+        var details = await _repository.GetProviderPackageDetailsAsync(providerNamespace, type, version, os, arch);
+        if (details is null)
             return null;
-        }
-
-        var providerVersion = await _repository.GetProviderVersionAsync(providerNamespace, type, version);
-        if (providerVersion == null ||
-            string.IsNullOrWhiteSpace(providerVersion.ShasumsStoragePath) ||
-            string.IsNullOrWhiteSpace(providerVersion.ShasumsSignatureStoragePath))
-        {
-            return null;
-        }
-
-        var platform = await _repository.GetProviderPlatformAsync(providerNamespace, type, version, os, arch);
-        if (platform == null || string.IsNullOrWhiteSpace(platform.PackageStoragePath))
-        {
-            return null;
-        }
-
-        var gpgKey = await _repository.GetGpgKeyAsync(providerNamespace, providerVersion.KeyId);
-        if (gpgKey == null)
-        {
-            return null;
-        }
 
         try
         {
-            var packageUrl = await _storage.CreateDownloadUrlAsync(platform.PackageStoragePath, cancellationToken);
-            var shasumsUrl = await _storage.CreateDownloadUrlAsync(providerVersion.ShasumsStoragePath, cancellationToken);
-            var signatureUrl = await _storage.CreateDownloadUrlAsync(providerVersion.ShasumsSignatureStoragePath, cancellationToken);
+            var packageUrlTask = _storage.CreateDownloadUrlAsync(details.PackageStoragePath, cancellationToken);
+            var shasumsUrlTask = _storage.CreateDownloadUrlAsync(details.ShasumsStoragePath, cancellationToken);
+            var signatureUrlTask = _storage.CreateDownloadUrlAsync(details.ShasumsSignatureStoragePath, cancellationToken);
+            await Task.WhenAll(packageUrlTask, shasumsUrlTask, signatureUrlTask);
 
-            await _repository.RecordProviderDownloadAsync(provider.Id, providerNamespace, type, version, os, arch, clientIp, userAgent);
+            await _repository.RecordProviderDownloadAsync(details.ProviderId, providerNamespace, type, version, os, arch, clientIp, userAgent);
 
             return new ProviderPackageResponse
             {
-                Protocols = providerVersion.Protocols,
-                Os = platform.Os,
-                Arch = platform.Arch,
-                Filename = platform.Filename,
-                DownloadUrl = packageUrl,
-                ShasumsUrl = shasumsUrl,
-                ShasumsSignatureUrl = signatureUrl,
-                Shasum = platform.Shasum,
+                Protocols = details.Protocols,
+                Os = details.Os,
+                Arch = details.Arch,
+                Filename = details.Filename,
+                DownloadUrl = await packageUrlTask,
+                ShasumsUrl = await shasumsUrlTask,
+                ShasumsSignatureUrl = await signatureUrlTask,
+                Shasum = details.Shasum,
                 SigningKeys = new ProviderSigningKeys
                 {
                     GpgPublicKeys =
                     [
                         new ProviderGpgPublicKey
                         {
-                            KeyId = gpgKey.KeyId,
-                            AsciiArmor = gpgKey.AsciiArmor,
-                            TrustSignature = gpgKey.TrustSignature,
-                            Source = gpgKey.Source,
-                            SourceUrl = gpgKey.SourceUrl
+                            KeyId = details.KeyId,
+                            AsciiArmor = details.AsciiArmor,
+                            TrustSignature = details.TrustSignature,
+                            Source = details.Source,
+                            SourceUrl = details.SourceUrl
                         }
                     ]
                 }

--- a/TerraformRegistry/Services/SqliteProviderRepository.cs
+++ b/TerraformRegistry/Services/SqliteProviderRepository.cs
@@ -255,6 +255,34 @@ public sealed class SqliteProviderRepository : IProviderRepository
         return await reader.ReadAsync() ? MapVersion(reader) : null;
     }
 
+    public async Task<ProviderPackageDetails?> GetProviderPackageDetailsAsync(string providerNamespace, string type, string version, string os, string arch)
+    {
+        await using var connection = await OpenConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+            SELECT p.id, pv.protocols, pv.key_id, pv.shasums_storage_path, pv.shasums_signature_storage_path,
+                   pp.os, pp.arch, pp.filename, pp.shasum, pp.package_storage_path,
+                   g.ascii_armor, g.trust_signature, g.source, g.source_url
+            FROM providers p
+            INNER JOIN provider_versions pv ON pv.provider_id = p.id AND pv.deleted_at IS NULL
+            INNER JOIN provider_platforms pp ON pp.provider_version_id = pv.id
+            INNER JOIN provider_gpg_keys g ON g.namespace = p.namespace AND g.key_id = pv.key_id AND g.revoked_at IS NULL
+            WHERE p.namespace = $namespace AND p.type = $type AND pv.version = $version
+              AND pp.os = $os AND pp.arch = $arch AND p.deleted_at IS NULL";
+        command.Parameters.AddWithValue("$namespace", providerNamespace);
+        command.Parameters.AddWithValue("$type", type);
+        command.Parameters.AddWithValue("$version", version);
+        command.Parameters.AddWithValue("$os", os);
+        command.Parameters.AddWithValue("$arch", arch);
+
+        await using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync()) return null;
+        if (reader.IsDBNull(3) || reader.IsDBNull(4) || reader.IsDBNull(9)) return null;
+        return new ProviderPackageDetails(Guid.Parse(reader.GetString(0)), DeserializeProtocols(reader.GetString(1)), reader.GetString(2),
+            reader.GetString(3), reader.GetString(4), reader.GetString(5), reader.GetString(6), reader.GetString(7), reader.GetString(8),
+            reader.GetString(9), reader.GetString(10), ReadNullableString(reader, 11), ReadNullableString(reader, 12), ReadNullableString(reader, 13));
+    }
+
     public async Task<ProviderVersion> CreateProviderVersionAsync(Guid providerId, string version, string[] protocols, string keyId)
     {
         var providerVersion = new ProviderVersion


### PR DESCRIPTION
Implements PERF-003 with a single provider-package details query, concurrent artifact URL creation, and focused round-trip coverage.\n\nVerification:\n- dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --filter FullyQualifiedName~ProviderRegistryServiceTests.GetPackageAsyncUsesOneRepositoryReadAndCreatesArtifactUrlsConcurrently\n- slopwatch analyze -d . --hook --no-baseline --fail-on warning\n- git diff --check