### PR TITLE
feat: add mirror operator control plane

### DIFF
--- a/TerraformRegistry.API/Interfaces/IMirrorLeaseRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IMirrorLeaseRepository.cs
@@ -4,6 +4,11 @@ namespace TerraformRegistry.API.Interfaces;
 
 public interface IMirrorLeaseRepository
 {
+    Task<IReadOnlyList<MirrorCacheLease>> ListLeasesAsync(
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default);
+
     Task<MirrorCacheLease?> GetLeaseAsync(
         string leaseKey,
         CancellationToken cancellationToken = default);

--- a/TerraformRegistry.Models/MirrorAdminModels.cs
+++ b/TerraformRegistry.Models/MirrorAdminModels.cs
@@ -1,11 +1,66 @@
+using System.Text.Json.Serialization;
+
 namespace TerraformRegistry.Models;
 
 public sealed class MirrorConfigResponse
 {
-    public required MirrorOptions Effective { get; set; }
+    [JsonIgnore]
+    public MirrorOptions Effective { get; set; } = new();
+    [JsonPropertyName("effective")]
+    public MirrorOperatorOptions OperatorEffective { get; set; } = new();
     public bool HasRuntimeOverride { get; set; }
     public DateTime? UpdatedAt { get; set; }
     public string? UpdatedBy { get; set; }
+}
+
+public sealed class MirrorOperatorOptions
+{
+    public bool Enabled { get; init; }
+    public string UpstreamRegistryBaseUrl { get; init; } = string.Empty;
+    public MirrorOperatorProviderOptions Providers { get; init; } = new();
+    public MirrorModuleRuntimeOptions Modules { get; init; } = new();
+    public MirrorLimitRuntimeOptions Limits { get; init; } = new();
+
+    public static MirrorOperatorOptions From(MirrorOptions options) => new()
+    {
+        Enabled = options.Enabled,
+        UpstreamRegistryBaseUrl = options.UpstreamRegistryBaseUrl,
+        Providers = new MirrorOperatorProviderOptions
+        {
+            Enabled = options.Providers.Enabled,
+            RequireAuthentication = options.Providers.RequireAuthentication,
+            AllowedHostnames = [.. options.Providers.AllowedHostnames],
+            UpstreamRegistryUrls = new(options.Providers.UpstreamRegistryUrls, StringComparer.OrdinalIgnoreCase),
+            AllowedArtifactHosts = [.. options.Providers.AllowedArtifactHosts],
+            Allowlist = [.. options.Providers.Allowlist],
+            Denylist = [.. options.Providers.Denylist],
+            Platforms = [.. options.Providers.Platforms],
+            MaxPackageBytes = options.Providers.MaxPackageBytes,
+            MaxChecksumBytes = options.Providers.MaxChecksumBytes,
+            MaxRedirects = options.Providers.MaxRedirects,
+            MetadataTtlMinutes = options.Providers.MetadataTtlMinutes,
+            DownloadTimeoutSeconds = options.Providers.DownloadTimeoutSeconds
+        },
+        Modules = options.Modules,
+        Limits = options.Limits
+    };
+}
+
+public sealed class MirrorOperatorProviderOptions
+{
+    public bool Enabled { get; init; }
+    public bool RequireAuthentication { get; init; }
+    public List<string> AllowedHostnames { get; init; } = [];
+    public Dictionary<string, string> UpstreamRegistryUrls { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    public List<string> AllowedArtifactHosts { get; init; } = [];
+    public List<string> Allowlist { get; init; } = [];
+    public List<string> Denylist { get; init; } = [];
+    public List<string> Platforms { get; init; } = [];
+    public long MaxPackageBytes { get; init; }
+    public long MaxChecksumBytes { get; init; }
+    public int MaxRedirects { get; init; }
+    public int MetadataTtlMinutes { get; init; }
+    public int DownloadTimeoutSeconds { get; init; }
 }
 
 public sealed class MirrorConfigUpdateRequest

--- a/TerraformRegistry.Models/MirrorOptions.cs
+++ b/TerraformRegistry.Models/MirrorOptions.cs
@@ -27,7 +27,6 @@ public sealed class MirrorProviderRuntimeOptions
     /// GPG key IDs that are trusted to sign mirrored provider SHA256SUMS files.
     /// Packages signed by any other key fail closed.
     /// </summary>
-    [JsonIgnore]
     public List<string> TrustedSigningKeyIds { get; set; } = [];
     public List<string> AllowedArtifactHosts { get; set; } = [];
     public List<string> Allowlist { get; set; } = [];

--- a/TerraformRegistry.Models/MirrorOptions.cs
+++ b/TerraformRegistry.Models/MirrorOptions.cs
@@ -1,9 +1,12 @@
+using System.Text.Json.Serialization;
+
 namespace TerraformRegistry.Models;
 
 public sealed class MirrorOptions
 {
     public bool Enabled { get; set; }
     public string UpstreamRegistryBaseUrl { get; set; } = "https://registry.terraform.io";
+    [JsonIgnore]
     public string? PackageUrlSigningKey { get; set; }
     public MirrorProviderRuntimeOptions Providers { get; set; } = new();
     public MirrorModuleRuntimeOptions Modules { get; set; } = new();
@@ -24,6 +27,7 @@ public sealed class MirrorProviderRuntimeOptions
     /// GPG key IDs that are trusted to sign mirrored provider SHA256SUMS files.
     /// Packages signed by any other key fail closed.
     /// </summary>
+    [JsonIgnore]
     public List<string> TrustedSigningKeyIds { get; set; } = [];
     public List<string> AllowedArtifactHosts { get; set; } = [];
     public List<string> Allowlist { get; set; } = [];

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlMirrorLeaseRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlMirrorLeaseRepository.cs
@@ -6,6 +6,32 @@ namespace TerraformRegistry.PostgreSQL.Repositories;
 
 public sealed class PostgreSqlMirrorLeaseRepository(string connectionString) : IMirrorLeaseRepository
 {
+    public async Task<IReadOnlyList<MirrorCacheLease>> ListLeasesAsync(
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = @"
+            SELECT id, lease_key, operation_type, owner_instance_id, expires_at, heartbeat_at, created_at, updated_at
+            FROM mirror_cache_leases
+            ORDER BY expires_at, lease_key
+            LIMIT @limit OFFSET @offset";
+
+        var leases = new List<MirrorCacheLease>();
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@limit", Math.Clamp(limit, 1, 100));
+        command.Parameters.AddWithValue("@offset", Math.Max(0, offset));
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            leases.Add(MapLease(reader));
+        }
+
+        return leases;
+    }
+
     public async Task<MirrorCacheLease?> GetLeaseAsync(
         string leaseKey,
         CancellationToken cancellationToken = default)

--- a/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
@@ -44,6 +44,26 @@ public sealed class MirrorAdminHandlersTests
             null), Times.Once);
     }
 
+    [Fact]
+    public async Task ListLeasesReturnsBoundedPageForMirrorReaders()
+    {
+        var context = CreateContext([Permissions.MirrorRead]);
+        var leases = new Mock<IMirrorLeaseRepository>(MockBehavior.Strict);
+        leases.Setup(x => x.ListLeasesAsync(25, 0, context.RequestAborted))
+            .ReturnsAsync([new MirrorCacheLease
+            {
+                LeaseKey = "provider:registry.terraform.io:hashicorp:aws:5.0.0:linux:amd64",
+                OperationType = "download",
+                OwnerInstanceId = "worker-1",
+                ExpiresAt = DateTime.UtcNow.AddMinutes(1)
+            }]);
+
+        var result = await MirrorAdminHandlers.ListLeases(leases.Object, context, 25, 0);
+
+        Assert.Equal(StatusCodes.Status200OK, ((IStatusCodeHttpResult)result).StatusCode);
+        leases.VerifyAll();
+    }
+
     private static DefaultHttpContext CreateContext(string[] permissions)
     {
         var context = new DefaultHttpContext();

--- a/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
@@ -1,0 +1,57 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using TerraformRegistry.API;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Handlers;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class MirrorAdminHandlersTests
+{
+    [Fact]
+    public async Task GetConfigRequiresMirrorReadPermission()
+    {
+        var context = CreateContext([]);
+
+        var result = await MirrorAdminHandlers.GetConfig(Mock.Of<IMirrorConfigService>(), context);
+
+        var status = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
+        Assert.Equal(StatusCodes.Status403Forbidden, status.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateConfigPersistsActorAndAuditsChange()
+    {
+        var context = CreateContext([Permissions.MirrorConfigure]);
+        var config = new Mock<IMirrorConfigService>(MockBehavior.Strict);
+        var audit = new Mock<IAuditService>();
+        var request = new MirrorConfigUpdateRequest { Enabled = true };
+        config.Setup(x => x.UpdateConfigAsync(request, "operator-1", context.RequestAborted))
+            .ReturnsAsync(new MirrorConfigResponse { Effective = new MirrorOptions { Enabled = true } });
+
+        var result = await MirrorAdminHandlers.UpdateConfig(config.Object, audit.Object, context, request);
+
+        Assert.Equal(StatusCodes.Status200OK, ((IStatusCodeHttpResult)result).StatusCode);
+        config.VerifyAll();
+        audit.Verify(x => x.LogAsync(
+            "operator-1",
+            "mirror.config_updated",
+            "mirror",
+            "config",
+            It.IsAny<object>(),
+            null), Times.Once);
+    }
+
+    private static DefaultHttpContext CreateContext(string[] permissions)
+    {
+        var context = new DefaultHttpContext();
+        context.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, "operator-1"),
+            .. permissions.Select(permission => new Claim("permission", permission))
+        ], "test"));
+        return context;
+    }
+}

--- a/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
@@ -5,6 +5,7 @@ using TerraformRegistry.API;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Handlers;
 using TerraformRegistry.Models;
+using TerraformRegistry.Services.Mirror;
 
 namespace TerraformRegistry.Tests.UnitTests;
 
@@ -90,6 +91,60 @@ public sealed class MirrorAdminHandlersTests
 
         Assert.Equal(StatusCodes.Status200OK, ((IStatusCodeHttpResult)result).StatusCode);
         modules.VerifyAll();
+    }
+
+    [Fact]
+    public async Task PurgeProviderReturnsConflictForAnInUseEntry()
+    {
+        var context = CreateContext([Permissions.MirrorManage]);
+        var providers = new Mock<IProviderMirrorRepository>();
+        providers.Setup(x => x.GetProviderPackageAsync("registry.example.com", "hashicorp", "aws", "1.0.0", "linux", "amd64"))
+            .ReturnsAsync(new MirrorProviderPackage
+            {
+                Hostname = "registry.example.com", Namespace = "hashicorp", Type = "aws", Version = "1.0.0",
+                Os = "linux", Arch = "amd64", DownloadUrl = "https://registry.example.com/package", PackageStoragePath = "cache/aws"
+            });
+        var usage = new MirrorCacheUsage();
+        using var lease = usage.Acquire("provider:registry.example.com:hashicorp:aws:1.0.0:linux:amd64");
+        var budget = new MirrorCacheBudgetService(providers.Object, Mock.Of<IModuleMirrorRepository>(),
+            Mock.Of<IProviderArtifactStorage>(), Mock.Of<IModuleService>(), usage);
+        var audit = new Mock<IAuditService>();
+
+        var result = await MirrorAdminHandlers.PurgeProvider(budget, audit.Object, context,
+            "registry.example.com", "hashicorp", "aws", "1.0.0", "linux", "amd64");
+
+        Assert.Equal(StatusCodes.Status409Conflict, ((IStatusCodeHttpResult)result).StatusCode);
+        audit.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task PurgeProviderAuditsSuccessfulDeletion()
+    {
+        var context = CreateContext([Permissions.MirrorManage]);
+        var package = new MirrorProviderPackage
+        {
+            Hostname = "registry.example.com", Namespace = "hashicorp", Type = "aws", Version = "1.0.0",
+            Os = "linux", Arch = "amd64", DownloadUrl = "https://registry.example.com/package", PackageStoragePath = "cache/aws"
+        };
+        var providers = new Mock<IProviderMirrorRepository>();
+        providers.Setup(x => x.GetProviderPackageAsync(package.Hostname, package.Namespace, package.Type, package.Version,
+                package.Os, package.Arch))
+            .ReturnsAsync(package);
+        providers.Setup(x => x.UpsertProviderPackageAsync(It.Is<MirrorProviderPackage>(item =>
+                item.PackageStoragePath == null && item.State == "evicted")))
+            .Returns(Task.CompletedTask);
+        var storage = new Mock<IProviderArtifactStorage>();
+        storage.Setup(x => x.DeleteAsync("cache/aws", context.RequestAborted)).ReturnsAsync(true);
+        var budget = new MirrorCacheBudgetService(providers.Object, Mock.Of<IModuleMirrorRepository>(), storage.Object,
+            Mock.Of<IModuleService>(), new MirrorCacheUsage());
+        var audit = new Mock<IAuditService>();
+
+        var result = await MirrorAdminHandlers.PurgeProvider(budget, audit.Object, context,
+            package.Hostname, package.Namespace, package.Type, package.Version, package.Os, package.Arch);
+
+        Assert.Equal(StatusCodes.Status204NoContent, ((IStatusCodeHttpResult)result).StatusCode);
+        audit.Verify(x => x.LogAsync("operator-1", "mirror.provider_purged", "mirror_provider",
+            "registry.example.com/hashicorp/aws/1.0.0/linux/amd64", null, null), Times.Once);
     }
 
     private static DefaultHttpContext CreateContext(string[] permissions)

--- a/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
@@ -64,6 +64,34 @@ public sealed class MirrorAdminHandlersTests
         leases.VerifyAll();
     }
 
+    [Fact]
+    public async Task ListProviderCacheRequiresMirrorReadAndClampsPagination()
+    {
+        var context = CreateContext([Permissions.MirrorRead]);
+        var providers = new Mock<IProviderMirrorRepository>(MockBehavior.Strict);
+        providers.Setup(x => x.ListProviderPackagesAsync("aws", "ready", 100, 0))
+            .ReturnsAsync([]);
+
+        var result = await MirrorAdminHandlers.ListProviderCache(providers.Object, context, "aws", "ready", 500, -1);
+
+        Assert.Equal(StatusCodes.Status200OK, ((IStatusCodeHttpResult)result).StatusCode);
+        providers.VerifyAll();
+    }
+
+    [Fact]
+    public async Task ListModuleCacheRequiresMirrorReadAndClampsPagination()
+    {
+        var context = CreateContext([Permissions.MirrorRead]);
+        var modules = new Mock<IModuleMirrorRepository>(MockBehavior.Strict);
+        modules.Setup(x => x.ListModulePackagesAsync("vpc", "ready", 100, 0))
+            .ReturnsAsync([]);
+
+        var result = await MirrorAdminHandlers.ListModuleCache(modules.Object, context, "vpc", "ready", 500, -1);
+
+        Assert.Equal(StatusCodes.Status200OK, ((IStatusCodeHttpResult)result).StatusCode);
+        modules.VerifyAll();
+    }
+
     private static DefaultHttpContext CreateContext(string[] permissions)
     {
         var context = new DefaultHttpContext();

--- a/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
@@ -101,8 +101,14 @@ public sealed class MirrorAdminHandlersTests
         providers.Setup(x => x.GetProviderPackageAsync("registry.example.com", "hashicorp", "aws", "1.0.0", "linux", "amd64"))
             .ReturnsAsync(new MirrorProviderPackage
             {
-                Hostname = "registry.example.com", Namespace = "hashicorp", Type = "aws", Version = "1.0.0",
-                Os = "linux", Arch = "amd64", DownloadUrl = "https://registry.example.com/package", PackageStoragePath = "cache/aws"
+                Hostname = "registry.example.com",
+                Namespace = "hashicorp",
+                Type = "aws",
+                Version = "1.0.0",
+                Os = "linux",
+                Arch = "amd64",
+                DownloadUrl = "https://registry.example.com/package",
+                PackageStoragePath = "cache/aws"
             });
         var usage = new MirrorCacheUsage();
         using var lease = usage.Acquire("provider:registry.example.com:hashicorp:aws:1.0.0:linux:amd64");
@@ -123,8 +129,14 @@ public sealed class MirrorAdminHandlersTests
         var context = CreateContext([Permissions.MirrorManage]);
         var package = new MirrorProviderPackage
         {
-            Hostname = "registry.example.com", Namespace = "hashicorp", Type = "aws", Version = "1.0.0",
-            Os = "linux", Arch = "amd64", DownloadUrl = "https://registry.example.com/package", PackageStoragePath = "cache/aws"
+            Hostname = "registry.example.com",
+            Namespace = "hashicorp",
+            Type = "aws",
+            Version = "1.0.0",
+            Os = "linux",
+            Arch = "amd64",
+            DownloadUrl = "https://registry.example.com/package",
+            PackageStoragePath = "cache/aws"
         };
         var providers = new Mock<IProviderMirrorRepository>();
         providers.Setup(x => x.GetProviderPackageAsync(package.Hostname, package.Namespace, package.Type, package.Version,
@@ -153,8 +165,13 @@ public sealed class MirrorAdminHandlersTests
         var context = CreateContext([Permissions.MirrorManage]);
         var package = new MirrorModulePackage
         {
-            Hostname = "registry.example.com", Namespace = "terraform-aws-modules", Name = "vpc", Provider = "aws",
-            Version = "1.0.0", DownloadUrl = "https://registry.example.com/package", PackageStoragePath = "cache/vpc"
+            Hostname = "registry.example.com",
+            Namespace = "terraform-aws-modules",
+            Name = "vpc",
+            Provider = "aws",
+            Version = "1.0.0",
+            DownloadUrl = "https://registry.example.com/package",
+            PackageStoragePath = "cache/vpc"
         };
         var modules = new Mock<IModuleMirrorRepository>();
         modules.Setup(x => x.GetModulePackageAsync(package.Hostname, package.Namespace, package.Name, package.Provider,

--- a/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
@@ -147,6 +147,32 @@ public sealed class MirrorAdminHandlersTests
             "registry.example.com/hashicorp/aws/1.0.0/linux/amd64", null, null), Times.Once);
     }
 
+    [Fact]
+    public async Task PurgeModuleReturnsConflictForAnInUseEntry()
+    {
+        var context = CreateContext([Permissions.MirrorManage]);
+        var package = new MirrorModulePackage
+        {
+            Hostname = "registry.example.com", Namespace = "terraform-aws-modules", Name = "vpc", Provider = "aws",
+            Version = "1.0.0", DownloadUrl = "https://registry.example.com/package", PackageStoragePath = "cache/vpc"
+        };
+        var modules = new Mock<IModuleMirrorRepository>();
+        modules.Setup(x => x.GetModulePackageAsync(package.Hostname, package.Namespace, package.Name, package.Provider,
+                package.Version))
+            .ReturnsAsync(package);
+        var usage = new MirrorCacheUsage();
+        using var lease = usage.Acquire("module:registry.example.com:terraform-aws-modules:vpc:aws:1.0.0");
+        var budget = new MirrorCacheBudgetService(Mock.Of<IProviderMirrorRepository>(), modules.Object,
+            Mock.Of<IProviderArtifactStorage>(), Mock.Of<IModuleService>(), usage);
+        var audit = new Mock<IAuditService>();
+
+        var result = await MirrorAdminHandlers.PurgeModule(budget, audit.Object, context,
+            package.Hostname, package.Namespace, package.Name, package.Provider, package.Version);
+
+        Assert.Equal(StatusCodes.Status409Conflict, ((IStatusCodeHttpResult)result).StatusCode);
+        audit.VerifyNoOtherCalls();
+    }
+
     private static DefaultHttpContext CreateContext(string[] permissions)
     {
         var context = new DefaultHttpContext();

--- a/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
@@ -83,12 +83,46 @@ public sealed class MirrorCacheBudgetServiceTests
     }
 
     [Fact]
+    public async Task PurgeProviderRefusesAPackageWithAnActiveDistributedLease()
+    {
+        var package = ProviderPackage("active", 6, DateTime.UtcNow);
+        var providers = new Mock<IProviderMirrorRepository>();
+        providers.Setup(x => x.GetProviderPackageAsync(
+                package.Hostname, package.Namespace, package.Type, package.Version, package.Os, package.Arch))
+            .ReturnsAsync(package);
+        var leases = new Mock<IMirrorLeaseRepository>();
+        leases.Setup(x => x.GetLeaseAsync(
+                "provider-package:registry.example.com:hashicorp:aws:1.0.0:linux:amd64", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MirrorCacheLease
+            {
+                LeaseKey = "provider-package:registry.example.com:hashicorp:aws:1.0.0:linux:amd64",
+                OperationType = "provider-package",
+                OwnerInstanceId = "other-instance",
+                ExpiresAt = DateTime.UtcNow.AddMinutes(1)
+            });
+        var storage = new Mock<IProviderArtifactStorage>();
+        var service = new MirrorCacheBudgetService(providers.Object, Mock.Of<IModuleMirrorRepository>(), storage.Object,
+            Mock.Of<IModuleService>(), new MirrorCacheUsage(), leases.Object);
+
+        var result = await service.PurgeProviderAsync(package.Hostname, package.Namespace, package.Type, package.Version,
+            package.Os, package.Arch, CancellationToken.None);
+
+        Assert.Equal(MirrorCachePurgeResult.InUse, result);
+        storage.Verify(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task PurgeModuleRefusesAnActivePackage()
     {
         var package = new MirrorModulePackage
         {
-            Hostname = "registry.example.com", Namespace = "terraform-aws-modules", Name = "vpc", Provider = "aws",
-            Version = "1.0.0", DownloadUrl = "https://registry.example.com/package", PackageStoragePath = "cache/vpc"
+            Hostname = "registry.example.com",
+            Namespace = "terraform-aws-modules",
+            Name = "vpc",
+            Provider = "aws",
+            Version = "1.0.0",
+            DownloadUrl = "https://registry.example.com/package",
+            PackageStoragePath = "cache/vpc"
         };
         var modules = new Mock<IModuleMirrorRepository>();
         modules.Setup(x => x.GetModulePackageAsync(package.Hostname, package.Namespace, package.Name, package.Provider,

--- a/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
@@ -82,6 +82,29 @@ public sealed class MirrorCacheBudgetServiceTests
         storage.Verify(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task PurgeModuleRefusesAnActivePackage()
+    {
+        var package = new MirrorModulePackage
+        {
+            Hostname = "registry.example.com", Namespace = "terraform-aws-modules", Name = "vpc", Provider = "aws",
+            Version = "1.0.0", DownloadUrl = "https://registry.example.com/package", PackageStoragePath = "cache/vpc"
+        };
+        var modules = new Mock<IModuleMirrorRepository>();
+        modules.Setup(x => x.GetModulePackageAsync(package.Hostname, package.Namespace, package.Name, package.Provider,
+                package.Version))
+            .ReturnsAsync(package);
+        var usage = new MirrorCacheUsage();
+        using var lease = usage.Acquire("module:registry.example.com:terraform-aws-modules:vpc:aws:1.0.0");
+        var service = new MirrorCacheBudgetService(Mock.Of<IProviderMirrorRepository>(), modules.Object,
+            Mock.Of<IProviderArtifactStorage>(), Mock.Of<IModuleService>(), usage);
+
+        var result = await service.PurgeModuleAsync(package.Hostname, package.Namespace, package.Name, package.Provider,
+            package.Version, CancellationToken.None);
+
+        Assert.Equal(MirrorCachePurgeResult.InUse, result);
+    }
+
     private static MirrorProviderPackage ProviderPackage(string path, long size, DateTime updatedAt) => new()
     {
         Hostname = "registry.example.com",

--- a/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
@@ -61,6 +61,27 @@ public sealed class MirrorCacheBudgetServiceTests
         storage.Verify(x => x.DeleteAsync("idle", It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task PurgeProviderRefusesAnActivePackage()
+    {
+        var package = ProviderPackage("active", 6, DateTime.UtcNow);
+        var providers = new Mock<IProviderMirrorRepository>();
+        providers.Setup(x => x.GetProviderPackageAsync(
+                package.Hostname, package.Namespace, package.Type, package.Version, package.Os, package.Arch))
+            .ReturnsAsync(package);
+        var storage = new Mock<IProviderArtifactStorage>();
+        var usage = new MirrorCacheUsage();
+        using var lease = usage.Acquire("provider:registry.example.com:hashicorp:aws:1.0.0:linux:amd64");
+        var service = new MirrorCacheBudgetService(providers.Object, Mock.Of<IModuleMirrorRepository>(), storage.Object,
+            Mock.Of<IModuleService>(), usage);
+
+        var result = await service.PurgeProviderAsync(package.Hostname, package.Namespace, package.Type, package.Version,
+            package.Os, package.Arch, CancellationToken.None);
+
+        Assert.Equal(MirrorCachePurgeResult.InUse, result);
+        storage.Verify(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     private static MirrorProviderPackage ProviderPackage(string path, long size, DateTime updatedAt) => new()
     {
         Hostname = "registry.example.com",

--- a/TerraformRegistry.Tests/UnitTests/MirrorConfigServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorConfigServiceTests.cs
@@ -167,6 +167,27 @@ public class MirrorConfigServiceTests
     }
 
     [Fact]
+    public async Task UpdateConfigAsyncPreservesTrustedSigningKeyIdsThatAreNotExposedToOperators()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["Mirror:Providers:TrustedSigningKeyIds:0"] = "trusted-key-id"
+            })
+            .Build();
+        var settings = new Mock<IRuntimeSettingsService>();
+        settings.Setup(x => x.GetAsync("mirror.config", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RuntimeSetting?)null);
+        var service = new MirrorConfigService(configuration, settings.Object);
+
+        await service.UpdateConfigAsync(new MirrorConfigUpdateRequest { Enabled = true }, "operator-1", CancellationToken.None);
+
+        settings.Verify(x => x.SetAsync("mirror.config",
+            It.Is<string>(json => json.Contains("trusted-key-id", StringComparison.Ordinal)),
+            "operator-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public void MirrorPermissionsAreAvailableToAdminsButNotDefaultUsers()
     {
         Assert.Contains("mirror.read", Permissions.All);

--- a/TerraformRegistry.Tests/UnitTests/MirrorConfigServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorConfigServiceTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Moq;
+using System.Text.Json;
 using TerraformRegistry.API;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Models;
@@ -9,6 +10,24 @@ namespace TerraformRegistry.Tests.UnitTests;
 
 public class MirrorConfigServiceTests
 {
+    [Fact]
+    public void MirrorConfigurationResponseDoesNotSerializeSigningSecrets()
+    {
+        var response = new MirrorConfigResponse
+        {
+            Effective = new MirrorOptions
+            {
+                PackageUrlSigningKey = "private-signing-key",
+                Providers = new MirrorProviderRuntimeOptions { TrustedSigningKeyIds = ["trusted-key-id"] }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(response);
+
+        Assert.DoesNotContain("private-signing-key", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("trusted-key-id", json, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task GetConfigAsyncUsesStartupDefaultsWhenRuntimeSettingMissing()
     {

--- a/TerraformRegistry.Tests/UnitTests/MirrorConfigServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorConfigServiceTests.cs
@@ -45,7 +45,7 @@ public class MirrorConfigServiceTests
             .Build();
         var settings = new Mock<IRuntimeSettingsService>();
         settings.Setup(x => x.GetAsync("mirror.config", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((RuntimeSetting?)null);
+            .ReturnsAsync(() => null);
 
         var service = new MirrorConfigService(configuration, settings.Object);
 

--- a/TerraformRegistry/Handlers/MirrorAdminHandlers.cs
+++ b/TerraformRegistry/Handlers/MirrorAdminHandlers.cs
@@ -7,6 +7,18 @@ namespace TerraformRegistry.Handlers;
 
 public static class MirrorAdminHandlers
 {
+    public static async Task<IResult> ListLeases(
+        IMirrorLeaseRepository leaseRepository,
+        HttpContext context,
+        int limit = 50,
+        int offset = 0)
+    {
+        if (!Has(context, Permissions.MirrorRead)) return Forbidden();
+
+        var leases = await leaseRepository.ListLeasesAsync(limit, offset, context.RequestAborted);
+        return Results.Ok(leases);
+    }
+
     public static async Task<IResult> GetConfig(IMirrorConfigService configService, HttpContext context)
     {
         if (!Has(context, Permissions.MirrorRead)) return Forbidden();

--- a/TerraformRegistry/Handlers/MirrorAdminHandlers.cs
+++ b/TerraformRegistry/Handlers/MirrorAdminHandlers.cs
@@ -2,11 +2,45 @@ using System.Security.Claims;
 using TerraformRegistry.API;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Models;
+using TerraformRegistry.Services.Mirror;
 
 namespace TerraformRegistry.Handlers;
 
 public static class MirrorAdminHandlers
 {
+    public static async Task<IResult> PurgeProvider(
+        MirrorCacheBudgetService cacheBudget,
+        IAuditService auditService,
+        HttpContext context,
+        string hostname,
+        string providerNamespace,
+        string type,
+        string version,
+        string os,
+        string arch)
+    {
+        if (!Has(context, Permissions.MirrorManage)) return Forbidden();
+
+        var result = await cacheBudget.PurgeProviderAsync(
+            hostname, providerNamespace, type, version, os, arch, context.RequestAborted);
+        if (result == MirrorCachePurgeResult.InUse)
+        {
+            return Results.Conflict(new { error = "The mirror cache entry is currently in use." });
+        }
+        if (result == MirrorCachePurgeResult.NotFound)
+        {
+            return Results.NotFound(new { error = "Mirror cache entry not found." });
+        }
+        if (result == MirrorCachePurgeResult.Failed)
+        {
+            return Results.Problem("The mirror cache entry could not be purged.", statusCode: StatusCodes.Status502BadGateway);
+        }
+
+        context.FireAuditLog(auditService, "mirror.provider_purged", "mirror_provider",
+            $"{hostname}/{providerNamespace}/{type}/{version}/{os}/{arch}");
+        return Results.NoContent();
+    }
+
     public static async Task<IResult> ListProviderCache(
         IProviderMirrorRepository providerRepository,
         HttpContext context,

--- a/TerraformRegistry/Handlers/MirrorAdminHandlers.cs
+++ b/TerraformRegistry/Handlers/MirrorAdminHandlers.cs
@@ -41,6 +41,38 @@ public static class MirrorAdminHandlers
         return Results.NoContent();
     }
 
+    public static async Task<IResult> PurgeModule(
+        MirrorCacheBudgetService cacheBudget,
+        IAuditService auditService,
+        HttpContext context,
+        string hostname,
+        string moduleNamespace,
+        string name,
+        string provider,
+        string version)
+    {
+        if (!Has(context, Permissions.MirrorManage)) return Forbidden();
+
+        var result = await cacheBudget.PurgeModuleAsync(
+            hostname, moduleNamespace, name, provider, version, context.RequestAborted);
+        if (result == MirrorCachePurgeResult.InUse)
+        {
+            return Results.Conflict(new { error = "The mirror cache entry is currently in use." });
+        }
+        if (result == MirrorCachePurgeResult.NotFound)
+        {
+            return Results.NotFound(new { error = "Mirror cache entry not found." });
+        }
+        if (result == MirrorCachePurgeResult.Failed)
+        {
+            return Results.Problem("The mirror cache entry could not be purged.", statusCode: StatusCodes.Status502BadGateway);
+        }
+
+        context.FireAuditLog(auditService, "mirror.module_purged", "mirror_module",
+            $"{hostname}/{moduleNamespace}/{name}/{provider}/{version}");
+        return Results.NoContent();
+    }
+
     public static async Task<IResult> ListProviderCache(
         IProviderMirrorRepository providerRepository,
         HttpContext context,

--- a/TerraformRegistry/Handlers/MirrorAdminHandlers.cs
+++ b/TerraformRegistry/Handlers/MirrorAdminHandlers.cs
@@ -7,6 +7,36 @@ namespace TerraformRegistry.Handlers;
 
 public static class MirrorAdminHandlers
 {
+    public static async Task<IResult> ListProviderCache(
+        IProviderMirrorRepository providerRepository,
+        HttpContext context,
+        string? q,
+        string? state,
+        int limit = 50,
+        int offset = 0)
+    {
+        if (!Has(context, Permissions.MirrorRead)) return Forbidden();
+
+        var packages = await providerRepository.ListProviderPackagesAsync(
+            q, state, Math.Clamp(limit, 1, 100), Math.Max(0, offset));
+        return Results.Ok(packages);
+    }
+
+    public static async Task<IResult> ListModuleCache(
+        IModuleMirrorRepository moduleRepository,
+        HttpContext context,
+        string? q,
+        string? state,
+        int limit = 50,
+        int offset = 0)
+    {
+        if (!Has(context, Permissions.MirrorRead)) return Forbidden();
+
+        var packages = await moduleRepository.ListModulePackagesAsync(
+            q, state, Math.Clamp(limit, 1, 100), Math.Max(0, offset));
+        return Results.Ok(packages);
+    }
+
     public static async Task<IResult> ListLeases(
         IMirrorLeaseRepository leaseRepository,
         HttpContext context,

--- a/TerraformRegistry/Handlers/MirrorAdminHandlers.cs
+++ b/TerraformRegistry/Handlers/MirrorAdminHandlers.cs
@@ -1,0 +1,45 @@
+using System.Security.Claims;
+using TerraformRegistry.API;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Handlers;
+
+public static class MirrorAdminHandlers
+{
+    public static async Task<IResult> GetConfig(IMirrorConfigService configService, HttpContext context)
+    {
+        if (!Has(context, Permissions.MirrorRead)) return Forbidden();
+
+        return Results.Ok(await configService.GetConfigAsync(context.RequestAborted));
+    }
+
+    public static async Task<IResult> UpdateConfig(
+        IMirrorConfigService configService,
+        IAuditService auditService,
+        HttpContext context,
+        MirrorConfigUpdateRequest request)
+    {
+        if (!Has(context, Permissions.MirrorConfigure)) return Forbidden();
+
+        var actor = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await configService.UpdateConfigAsync(request, actor, context.RequestAborted);
+        context.FireAuditLog(auditService, "mirror.config_updated", "mirror", "config", new
+        {
+            request.Enabled,
+            ProvidersEnabled = request.Providers.Enabled,
+            ModulesEnabled = request.Modules.Enabled,
+            request.Limits.MaxConcurrentDownloads,
+            request.Limits.MaxTotalCachedBytes
+        });
+        return Results.Ok(response);
+    }
+
+    private static bool Has(HttpContext context, string permission) =>
+        context.User.Identity?.IsAuthenticated != true || context.User.HasPermission(permission);
+
+    private static IResult Forbidden() => Results.Content(
+        """{\"error\":\"Insufficient permissions\"}""",
+        "application/json",
+        statusCode: StatusCodes.Status403Forbidden);
+}

--- a/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
@@ -51,6 +51,32 @@ public sealed class MirrorCacheBudgetService(
         return false;
     }
 
+    public async Task<MirrorCachePurgeResult> PurgeProviderAsync(
+        string hostname,
+        string providerNamespace,
+        string type,
+        string version,
+        string os,
+        string arch,
+        CancellationToken cancellationToken)
+    {
+        var package = await providerRepository.GetProviderPackageAsync(
+            hostname, providerNamespace, type, version, os, arch);
+        if (package is null || string.IsNullOrWhiteSpace(package.PackageStoragePath))
+        {
+            return MirrorCachePurgeResult.NotFound;
+        }
+
+        if (cacheUsage.IsInUse(ProviderKey(package)))
+        {
+            return MirrorCachePurgeResult.InUse;
+        }
+
+        return await EvictAsync(new EvictionCandidate(package, null), cancellationToken)
+            ? MirrorCachePurgeResult.Purged
+            : MirrorCachePurgeResult.Failed;
+    }
+
     private async Task<bool> EvictAsync(EvictionCandidate candidate, CancellationToken cancellationToken)
     {
         if (candidate.Provider is { } provider)
@@ -140,4 +166,12 @@ public sealed class MirrorCacheBudgetService(
             ? $"provider:{Provider.Hostname}:{Provider.Namespace}:{Provider.Type}:{Provider.Version}:{Provider.Os}:{Provider.Arch}"
             : $"module:{Module!.Hostname}:{Module.Namespace}:{Module.Name}:{Module.Provider}:{Module.Version}";
     }
+}
+
+public enum MirrorCachePurgeResult
+{
+    Purged,
+    NotFound,
+    InUse,
+    Failed
 }

--- a/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
@@ -9,7 +9,8 @@ public sealed class MirrorCacheBudgetService(
     IModuleMirrorRepository moduleRepository,
     IProviderArtifactStorage providerStorage,
     IModuleService moduleService,
-    MirrorCacheUsage cacheUsage)
+    MirrorCacheUsage cacheUsage,
+    IMirrorLeaseRepository? leaseRepository = null)
 {
     private const int PageSize = 1000;
 
@@ -67,7 +68,7 @@ public sealed class MirrorCacheBudgetService(
             return MirrorCachePurgeResult.NotFound;
         }
 
-        if (cacheUsage.IsInUse(ProviderKey(package)))
+        if (await IsInUseAsync(package, cancellationToken))
         {
             return MirrorCachePurgeResult.InUse;
         }
@@ -92,7 +93,7 @@ public sealed class MirrorCacheBudgetService(
             return MirrorCachePurgeResult.NotFound;
         }
 
-        if (cacheUsage.IsInUse(ModuleKey(package)))
+        if (await IsInUseAsync(package, cancellationToken))
         {
             return MirrorCachePurgeResult.InUse;
         }
@@ -106,7 +107,7 @@ public sealed class MirrorCacheBudgetService(
     {
         if (candidate.Provider is { } provider)
         {
-            if (cacheUsage.IsInUse(ProviderKey(provider)))
+            if (await IsInUseAsync(provider, cancellationToken))
             {
                 return false;
             }
@@ -129,7 +130,7 @@ public sealed class MirrorCacheBudgetService(
         }
 
         var module = candidate.Module!;
-        if (cacheUsage.IsInUse(ModuleKey(module)))
+        if (await IsInUseAsync(module, cancellationToken))
         {
             return false;
         }
@@ -176,10 +177,23 @@ public sealed class MirrorCacheBudgetService(
 
     private static long CacheBytes(MirrorProviderPackage package) => package.CacheSizeBytes ?? package.SizeBytes ?? 0;
     private static long CacheBytes(MirrorModulePackage package) => package.CacheSizeBytes ?? package.SizeBytes ?? 0;
+    private async Task<bool> IsInUseAsync(MirrorProviderPackage package, CancellationToken cancellationToken) =>
+        cacheUsage.IsInUse(ProviderKey(package)) || await HasActiveLeaseAsync(ProviderLeaseKey(package), cancellationToken);
+    private async Task<bool> IsInUseAsync(MirrorModulePackage package, CancellationToken cancellationToken) =>
+        cacheUsage.IsInUse(ModuleKey(package)) || await HasActiveLeaseAsync(ModuleLeaseKey(package), cancellationToken);
+    private async Task<bool> HasActiveLeaseAsync(string leaseKey, CancellationToken cancellationToken)
+    {
+        var lease = leaseRepository is null ? null : await leaseRepository.GetLeaseAsync(leaseKey, cancellationToken);
+        return lease?.ExpiresAt > DateTime.UtcNow;
+    }
     internal static string ProviderKey(MirrorProviderPackage package) =>
         $"provider:{package.Hostname}:{package.Namespace}:{package.Type}:{package.Version}:{package.Os}:{package.Arch}";
     internal static string ModuleKey(MirrorModulePackage package) =>
         $"module:{package.Hostname}:{package.Namespace}:{package.Name}:{package.Provider}:{package.Version}";
+    private static string ProviderLeaseKey(MirrorProviderPackage package) =>
+        $"provider-package:{package.Hostname}:{package.Namespace}:{package.Type}:{package.Version}:{package.Os}:{package.Arch}";
+    private static string ModuleLeaseKey(MirrorModulePackage package) =>
+        $"module-package:{package.Hostname}:{package.Namespace}:{package.Name}:{package.Provider}:{package.Version}";
 
     private sealed class EvictionCandidate(MirrorProviderPackage? provider, MirrorModulePackage? module)
     {

--- a/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
@@ -77,6 +77,31 @@ public sealed class MirrorCacheBudgetService(
             : MirrorCachePurgeResult.Failed;
     }
 
+    public async Task<MirrorCachePurgeResult> PurgeModuleAsync(
+        string hostname,
+        string moduleNamespace,
+        string name,
+        string provider,
+        string version,
+        CancellationToken cancellationToken)
+    {
+        var package = await moduleRepository.GetModulePackageAsync(
+            hostname, moduleNamespace, name, provider, version);
+        if (package is null || string.IsNullOrWhiteSpace(package.PackageStoragePath))
+        {
+            return MirrorCachePurgeResult.NotFound;
+        }
+
+        if (cacheUsage.IsInUse(ModuleKey(package)))
+        {
+            return MirrorCachePurgeResult.InUse;
+        }
+
+        return await EvictAsync(new EvictionCandidate(null, package), cancellationToken)
+            ? MirrorCachePurgeResult.Purged
+            : MirrorCachePurgeResult.Failed;
+    }
+
     private async Task<bool> EvictAsync(EvictionCandidate candidate, CancellationToken cancellationToken)
     {
         if (candidate.Provider is { } provider)

--- a/TerraformRegistry/Services/Mirror/MirrorConfigService.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorConfigService.cs
@@ -19,7 +19,7 @@ public sealed class MirrorConfigService(IConfiguration configuration, IRuntimeSe
         if (stored == null)
         {
             MirrorConfigurationValidator.Validate(startup);
-            return new MirrorConfigResponse { Effective = startup };
+            return ToResponse(startup);
         }
 
         var runtime = JsonSerializer.Deserialize<MirrorConfigUpdateRequest>(stored.ValueJson, JsonOptions) ?? new();
@@ -28,6 +28,7 @@ public sealed class MirrorConfigService(IConfiguration configuration, IRuntimeSe
         return new MirrorConfigResponse
         {
             Effective = effective,
+            OperatorEffective = MirrorOperatorOptions.From(effective),
             HasRuntimeOverride = true,
             UpdatedAt = stored.UpdatedAt,
             UpdatedBy = stored.UpdatedBy
@@ -41,6 +42,8 @@ public sealed class MirrorConfigService(IConfiguration configuration, IRuntimeSe
     {
         var startup = new MirrorOptions();
         configuration.GetSection("Mirror").Bind(startup);
+        var existing = await GetConfigAsync(cancellationToken);
+        request.Providers.TrustedSigningKeyIds = [.. existing.Effective.Providers.TrustedSigningKeyIds];
         MirrorConfigurationValidator.Validate(Merge(startup, request));
         var json = JsonSerializer.Serialize(request, JsonOptions);
         await runtimeSettings.SetAsync(SettingsKey, json, updatedBy, cancellationToken);
@@ -55,4 +58,10 @@ public sealed class MirrorConfigService(IConfiguration configuration, IRuntimeSe
         startup.Limits = runtime.Limits;
         return startup;
     }
+
+    private static MirrorConfigResponse ToResponse(MirrorOptions effective) => new()
+    {
+        Effective = effective,
+        OperatorEffective = MirrorOperatorOptions.From(effective)
+    };
 }

--- a/TerraformRegistry/Services/Sqlite/SqliteMirrorLeaseRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteMirrorLeaseRepository.cs
@@ -7,6 +7,32 @@ namespace TerraformRegistry.Services.Sqlite;
 
 public sealed class SqliteMirrorLeaseRepository(string connectionString) : IMirrorLeaseRepository
 {
+    public async Task<IReadOnlyList<MirrorCacheLease>> ListLeasesAsync(
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default)
+    {
+        var leases = new List<MirrorCacheLease>();
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+            SELECT id, lease_key, operation_type, owner_instance_id, expires_at, heartbeat_at, created_at, updated_at
+            FROM mirror_cache_leases
+            ORDER BY expires_at, lease_key
+            LIMIT $limit OFFSET $offset";
+        command.Parameters.AddWithValue("$limit", Math.Clamp(limit, 1, 100));
+        command.Parameters.AddWithValue("$offset", Math.Max(0, offset));
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            leases.Add(MapLease(reader));
+        }
+
+        return leases;
+    }
+
     public async Task<MirrorCacheLease?> GetLeaseAsync(
         string leaseKey,
         CancellationToken cancellationToken = default)

--- a/TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs
@@ -212,6 +212,13 @@ internal static class AdminEndpointMappingExtensions
                     MirrorAdminHandlers.ListModuleCache(moduleRepository, context, q, state, limit, offset))
             .WithTags("Mirror");
 
+        app.MapDelete("/api/admin/mirror/modules/{hostname}/{namespace}/{name}/{provider}/{version}",
+                (string hostname, string @namespace, string name, string provider, string version,
+                        MirrorCacheBudgetService cacheBudget, IAuditService auditService, HttpContext context) =>
+                    MirrorAdminHandlers.PurgeModule(cacheBudget, auditService, context, hostname, @namespace, name,
+                        provider, version))
+            .WithTags("Mirror");
+
         app.MapGet("/api/admin/mirror/leases",
                 (IMirrorLeaseRepository leaseRepository, HttpContext context, int limit = 50, int offset = 0) =>
                     MirrorAdminHandlers.ListLeases(leaseRepository, context, limit, offset))

--- a/TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs
@@ -3,6 +3,7 @@ using TerraformRegistry.Handlers;
 using TerraformRegistry.Models;
 using TerraformRegistry.Services;
 using TerraformRegistry.Services.ModuleExtraction;
+using TerraformRegistry.Services.Mirror;
 
 namespace TerraformRegistry.Startup;
 
@@ -196,6 +197,13 @@ internal static class AdminEndpointMappingExtensions
                 (IProviderMirrorRepository providerRepository, HttpContext context, string? q, string? state,
                         int limit = 50, int offset = 0) =>
                     MirrorAdminHandlers.ListProviderCache(providerRepository, context, q, state, limit, offset))
+            .WithTags("Mirror");
+
+        app.MapDelete("/api/admin/mirror/providers/{hostname}/{namespace}/{type}/{version}/{os}/{arch}",
+                (string hostname, string @namespace, string type, string version, string os, string arch,
+                        MirrorCacheBudgetService cacheBudget, IAuditService auditService, HttpContext context) =>
+                    MirrorAdminHandlers.PurgeProvider(cacheBudget, auditService, context, hostname, @namespace, type,
+                        version, os, arch))
             .WithTags("Mirror");
 
         app.MapGet("/api/admin/mirror/modules",

--- a/TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs
@@ -192,6 +192,18 @@ internal static class AdminEndpointMappingExtensions
 
     private static WebApplication MapMirrorAdminEndpoints(this WebApplication app)
     {
+        app.MapGet("/api/admin/mirror/providers",
+                (IProviderMirrorRepository providerRepository, HttpContext context, string? q, string? state,
+                        int limit = 50, int offset = 0) =>
+                    MirrorAdminHandlers.ListProviderCache(providerRepository, context, q, state, limit, offset))
+            .WithTags("Mirror");
+
+        app.MapGet("/api/admin/mirror/modules",
+                (IModuleMirrorRepository moduleRepository, HttpContext context, string? q, string? state,
+                        int limit = 50, int offset = 0) =>
+                    MirrorAdminHandlers.ListModuleCache(moduleRepository, context, q, state, limit, offset))
+            .WithTags("Mirror");
+
         app.MapGet("/api/admin/mirror/leases",
                 (IMirrorLeaseRepository leaseRepository, HttpContext context, int limit = 50, int offset = 0) =>
                     MirrorAdminHandlers.ListLeases(leaseRepository, context, limit, offset))

--- a/TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs
@@ -192,6 +192,11 @@ internal static class AdminEndpointMappingExtensions
 
     private static WebApplication MapMirrorAdminEndpoints(this WebApplication app)
     {
+        app.MapGet("/api/admin/mirror/leases",
+                (IMirrorLeaseRepository leaseRepository, HttpContext context, int limit = 50, int offset = 0) =>
+                    MirrorAdminHandlers.ListLeases(leaseRepository, context, limit, offset))
+            .WithTags("Mirror");
+
         app.MapGet("/api/admin/mirror/config",
                 (IMirrorConfigService configService, HttpContext context) =>
                     MirrorAdminHandlers.GetConfig(configService, context))

--- a/TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs
@@ -1,5 +1,6 @@
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Handlers;
+using TerraformRegistry.Models;
 using TerraformRegistry.Services;
 using TerraformRegistry.Services.ModuleExtraction;
 
@@ -15,6 +16,7 @@ internal static class AdminEndpointMappingExtensions
         app.MapUserEndpoints();
         app.MapNamespaceEndpoints();
         app.MapModuleDocsEndpoints();
+        app.MapMirrorAdminEndpoints();
 
         return app;
     }
@@ -184,6 +186,22 @@ internal static class AdminEndpointMappingExtensions
                         HttpRequest request) =>
                     ModuleDocsHandlers.UpdateConfig(configService, auditService, context, request))
             .WithTags("Module Docs");
+
+        return app;
+    }
+
+    private static WebApplication MapMirrorAdminEndpoints(this WebApplication app)
+    {
+        app.MapGet("/api/admin/mirror/config",
+                (IMirrorConfigService configService, HttpContext context) =>
+                    MirrorAdminHandlers.GetConfig(configService, context))
+            .WithTags("Mirror");
+
+        app.MapPut("/api/admin/mirror/config",
+                (IMirrorConfigService configService, IAuditService auditService, HttpContext context,
+                        MirrorConfigUpdateRequest request) =>
+                    MirrorAdminHandlers.UpdateConfig(configService, auditService, context, request))
+            .WithTags("Mirror");
 
         return app;
     }

--- a/TerraformRegistry/web-src/composables/useMirrorAdmin.ts
+++ b/TerraformRegistry/web-src/composables/useMirrorAdmin.ts
@@ -1,0 +1,84 @@
+import { useAuth } from './useAuth'
+
+export interface MirrorConfig {
+  enabled: boolean
+  providers: { enabled: boolean, requireAuthentication: boolean }
+  modules: { enabled: boolean, requireAuthentication: boolean }
+  limits: { maxConcurrentDownloads: number, maxConcurrentDownloadsPerCoordinate: number, maxTotalCachedBytes: number, negativeCacheTtlSeconds: number }
+}
+
+export interface MirrorConfigResponse {
+  effective: MirrorConfig
+  hasRuntimeOverride: boolean
+  updatedAt: string | null
+  updatedBy: string | null
+}
+
+export interface MirrorProviderCacheEntry {
+  hostname: string
+  namespace: string
+  type: string
+  version: string
+  os: string
+  arch: string
+  state: string
+  packageStoragePath: string | null
+  cacheSizeBytes: number | null
+  lastError: string | null
+  lastSyncAt: string | null
+}
+
+export interface MirrorModuleCacheEntry {
+  hostname: string
+  namespace: string
+  name: string
+  provider: string
+  version: string
+  state: string
+  packageStoragePath: string | null
+  cacheSizeBytes: number | null
+  lastError: string | null
+  lastSyncAt: string | null
+}
+
+export interface MirrorLease {
+  leaseKey: string
+  operationType: string
+  ownerInstanceId: string
+  expiresAt: string
+  heartbeatAt: string | null
+}
+
+export function useMirrorAdmin() {
+  const { getAuthHeaders } = useAuth()
+
+  const query = (params: Record<string, string | number | undefined>) => {
+    const values = new URLSearchParams()
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== '') values.set(key, String(value))
+    }
+    const result = values.toString()
+    return result ? `?${result}` : ''
+  }
+
+  const getConfig = () => $fetch<MirrorConfigResponse>('/api/admin/mirror/config', { headers: getAuthHeaders() })
+  const updateConfig = (config: MirrorConfig) => $fetch<MirrorConfigResponse>('/api/admin/mirror/config', {
+    method: 'PUT', headers: getAuthHeaders(), body: config,
+  })
+  const listProviders = (params: { q?: string, state?: string, limit?: number, offset?: number } = {}) =>
+    $fetch<MirrorProviderCacheEntry[]>(`/api/admin/mirror/providers${query(params)}`, { headers: getAuthHeaders() })
+  const listModules = (params: { q?: string, state?: string, limit?: number, offset?: number } = {}) =>
+    $fetch<MirrorModuleCacheEntry[]>(`/api/admin/mirror/modules${query(params)}`, { headers: getAuthHeaders() })
+  const listLeases = (params: { limit?: number, offset?: number } = {}) =>
+    $fetch<MirrorLease[]>(`/api/admin/mirror/leases${query(params)}`, { headers: getAuthHeaders() })
+  const purgeProvider = (entry: MirrorProviderCacheEntry) => $fetch(
+    `/api/admin/mirror/providers/${[entry.hostname, entry.namespace, entry.type, entry.version, entry.os, entry.arch].map(encodeURIComponent).join('/')}`,
+    { method: 'DELETE', headers: getAuthHeaders() },
+  )
+  const purgeModule = (entry: MirrorModuleCacheEntry) => $fetch(
+    `/api/admin/mirror/modules/${[entry.hostname, entry.namespace, entry.name, entry.provider, entry.version].map(encodeURIComponent).join('/')}`,
+    { method: 'DELETE', headers: getAuthHeaders() },
+  )
+
+  return { getConfig, updateConfig, listProviders, listModules, listLeases, purgeProvider, purgeModule }
+}

--- a/TerraformRegistry/web-src/layouts/default.vue
+++ b/TerraformRegistry/web-src/layouts/default.vue
@@ -52,6 +52,7 @@ const adminLinks = [
   { label: 'Webhooks', icon: 'i-lucide-webhook', to: '/admin/webhooks', permission: 'webhooks.manage' },
   { label: 'VCS Connections', icon: 'i-lucide-git-branch', to: '/admin/vcs-connections', permission: 'vcs.manage' },
   { label: 'Documentation', icon: 'i-lucide-file-search', to: '/admin/module-docs', permission: 'module_docs.read' },
+  { label: 'Mirror', icon: 'i-lucide-boxes', to: '/admin/mirror', permission: 'mirror.read' },
   { label: 'Audit Log', icon: 'i-lucide-scroll-text', to: '/admin/audit', permission: 'admin.audit' },
 ];
 

--- a/TerraformRegistry/web-src/pages/admin/mirror.vue
+++ b/TerraformRegistry/web-src/pages/admin/mirror.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { extractErrorMessage } from '~/composables/useErrorMessage'
+import { useMirrorAdmin } from '~/composables/useMirrorAdmin'
+import type { MirrorConfigResponse, MirrorLease, MirrorModuleCacheEntry, MirrorProviderCacheEntry } from '~/composables/useMirrorAdmin'
+
+definePageMeta({ middleware: 'auth' })
+
+const { hasPermission } = usePermissions()
+const { getConfig, updateConfig, listProviders, listModules, listLeases, purgeProvider, purgeModule } = useMirrorAdmin()
+const canRead = computed(() => hasPermission('mirror.read'))
+const canManage = computed(() => hasPermission('mirror.manage'))
+const canConfigure = computed(() => hasPermission('mirror.configure'))
+const config = ref<MirrorConfigResponse | null>(null)
+const providers = ref<MirrorProviderCacheEntry[]>([])
+const modules = ref<MirrorModuleCacheEntry[]>([])
+const leases = ref<MirrorLease[]>([])
+const loading = ref(false)
+const purging = ref<string | null>(null)
+const errorMessage = ref<string | null>(null)
+const successMessage = ref<string | null>(null)
+const query = ref('')
+const state = ref('')
+const updatingConfig = ref(false)
+
+const bytes = (value: number | null) => value === null ? 'Unknown' : new Intl.NumberFormat().format(value)
+const date = (value: string | null) => value ? new Date(value).toLocaleString() : 'Never'
+const providerKey = (item: MirrorProviderCacheEntry) => `${item.hostname}/${item.namespace}/${item.type}/${item.version}/${item.os}/${item.arch}`
+const moduleKey = (item: MirrorModuleCacheEntry) => `${item.hostname}/${item.namespace}/${item.name}/${item.provider}/${item.version}`
+
+async function refresh() {
+  if (!canRead.value) return
+  loading.value = true
+  errorMessage.value = null
+  try {
+    const params = { q: query.value || undefined, state: state.value || undefined, limit: 100 }
+    const results = await Promise.all([getConfig(), listProviders(params), listModules(params), listLeases({ limit: 100 })])
+    config.value = results[0]
+    providers.value = results[1]
+    modules.value = results[2]
+    leases.value = results[3]
+  } catch (error) {
+    errorMessage.value = extractErrorMessage(error, 'Failed to load mirror administration data')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function removeProvider(entry: MirrorProviderCacheEntry) {
+  const key = providerKey(entry)
+  if (!canManage.value || !confirm(`Purge cached provider ${key}?`)) return
+  purging.value = key
+  try {
+    await purgeProvider(entry)
+    successMessage.value = `Purged ${key}`
+    await refresh()
+  } catch (error) { errorMessage.value = extractErrorMessage(error, 'Failed to purge provider cache entry') }
+  finally { purging.value = null }
+}
+
+async function setMirrorEnabled(enabled: boolean) {
+  if (!canConfigure.value || !config.value || updatingConfig.value) return
+  updatingConfig.value = true
+  errorMessage.value = null
+  try {
+    const effective = { ...config.value.effective, enabled }
+    config.value = await updateConfig(effective)
+    successMessage.value = enabled ? 'Mirror enabled' : 'Mirror disabled'
+  } catch (error) { errorMessage.value = extractErrorMessage(error, 'Failed to update mirror configuration') }
+  finally { updatingConfig.value = false }
+}
+
+async function removeModule(entry: MirrorModuleCacheEntry) {
+  const key = moduleKey(entry)
+  if (!canManage.value || !confirm(`Purge cached module ${key}?`)) return
+  purging.value = key
+  try {
+    await purgeModule(entry)
+    successMessage.value = `Purged ${key}`
+    await refresh()
+  } catch (error) { errorMessage.value = extractErrorMessage(error, 'Failed to purge module cache entry') }
+  finally { purging.value = null }
+}
+
+watch([query, state], refresh)
+onMounted(refresh)
+</script>
+
+<template>
+  <main class="mx-auto max-w-7xl space-y-6 p-6 text-neutral-100">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <div><h1 class="text-2xl font-semibold">Mirror operations</h1><p class="text-sm text-neutral-400">Inspect effective configuration, cache state, and active work.</p></div>
+      <button class="rounded bg-neutral-700 px-4 py-2 text-sm hover:bg-neutral-600" :disabled="loading" @click="refresh">Refresh</button>
+    </div>
+    <div v-if="!canRead" class="rounded border border-amber-500/40 bg-amber-500/10 p-4 text-amber-200">Mirror read permission is required.</div>
+    <div v-if="errorMessage" class="rounded border border-red-500/40 bg-red-500/10 p-4 text-red-200">{{ errorMessage }}</div>
+    <div v-if="successMessage" class="rounded border border-green-500/40 bg-green-500/10 p-4 text-green-200">{{ successMessage }}</div>
+    <section v-if="config" class="rounded border border-neutral-800 bg-neutral-900 p-4"><div class="flex items-center justify-between gap-3"><h2 class="font-medium">Effective configuration</h2><button v-if="canConfigure" class="rounded bg-neutral-700 px-3 py-2 text-sm hover:bg-neutral-600" :disabled="updatingConfig" @click="setMirrorEnabled(!config.effective.enabled)">{{ config.effective.enabled ? 'Disable mirror' : 'Enable mirror' }}</button></div><dl class="mt-3 grid gap-3 sm:grid-cols-4 text-sm"><div><dt class="text-neutral-500">Mirror</dt><dd>{{ config.effective.enabled ? 'Enabled' : 'Disabled' }}</dd></div><div><dt class="text-neutral-500">Provider mirror</dt><dd>{{ config.effective.providers.enabled ? 'Enabled' : 'Disabled' }}</dd></div><div><dt class="text-neutral-500">Module mirror</dt><dd>{{ config.effective.modules.enabled ? 'Enabled' : 'Disabled' }}</dd></div><div><dt class="text-neutral-500">Concurrent downloads</dt><dd>{{ config.effective.limits.maxConcurrentDownloads }}</dd></div></dl><p v-if="canConfigure" class="mt-3 text-xs text-neutral-500">Runtime override: {{ config.hasRuntimeOverride ? 'active' : 'not set' }}.</p></section>
+    <section class="rounded border border-neutral-800 bg-neutral-900 p-4"><div class="flex flex-wrap gap-3"><input v-model="query" class="rounded bg-neutral-800 px-3 py-2 text-sm" placeholder="Search cache" /><select v-model="state" class="rounded bg-neutral-800 px-3 py-2 text-sm"><option value="">All states</option><option value="ready">Ready</option><option value="failed">Failed</option><option value="evicted">Evicted</option></select></div></section>
+    <section class="rounded border border-neutral-800 bg-neutral-900 p-4"><h2 class="font-medium">Provider cache</h2><div class="mt-3 overflow-x-auto"><table class="w-full text-left text-sm"><thead class="text-neutral-500"><tr><th>Coordinate</th><th>State</th><th>Bytes</th><th>Synced</th><th></th></tr></thead><tbody><tr v-for="item in providers" :key="providerKey(item)" class="border-t border-neutral-800"><td class="py-2">{{ providerKey(item) }}</td><td>{{ item.state }}</td><td>{{ bytes(item.cacheSizeBytes) }}</td><td>{{ date(item.lastSyncAt) }}</td><td><button v-if="canManage && item.packageStoragePath" class="text-red-300 hover:text-red-200" :disabled="purging === providerKey(item)" @click="removeProvider(item)">Purge</button></td></tr></tbody></table></div></section>
+    <section class="rounded border border-neutral-800 bg-neutral-900 p-4"><h2 class="font-medium">Module cache</h2><div class="mt-3 overflow-x-auto"><table class="w-full text-left text-sm"><thead class="text-neutral-500"><tr><th>Coordinate</th><th>State</th><th>Bytes</th><th>Synced</th><th></th></tr></thead><tbody><tr v-for="item in modules" :key="moduleKey(item)" class="border-t border-neutral-800"><td class="py-2">{{ moduleKey(item) }}</td><td>{{ item.state }}</td><td>{{ bytes(item.cacheSizeBytes) }}</td><td>{{ date(item.lastSyncAt) }}</td><td><button v-if="canManage && item.packageStoragePath" class="text-red-300 hover:text-red-200" :disabled="purging === moduleKey(item)" @click="removeModule(item)">Purge</button></td></tr></tbody></table></div></section>
+    <section class="rounded border border-neutral-800 bg-neutral-900 p-4"><h2 class="font-medium">Active leases</h2><ul class="mt-3 space-y-2 text-sm"><li v-for="lease in leases" :key="lease.leaseKey" class="rounded bg-neutral-800 p-2"><span class="font-mono text-xs">{{ lease.leaseKey }}</span><span class="ml-3 text-neutral-400">{{ lease.operationType }} · {{ lease.ownerInstanceId }} · expires {{ date(lease.expiresAt) }}</span></li><li v-if="leases.length === 0" class="text-neutral-500">No active leases.</li></ul></section>
+  </main>
+</template>

--- a/TerraformRegistry/web-src/pages/admin/roles.vue
+++ b/TerraformRegistry/web-src/pages/admin/roles.vue
@@ -144,6 +144,9 @@ const permissionCategories = [
       { value: 'admin.roles', label: 'Roles' },
       { value: 'admin.users', label: 'Users' },
       { value: 'admin.audit', label: 'Audit' },
+      { value: 'mirror.read', label: 'Mirror read' },
+      { value: 'mirror.manage', label: 'Mirror manage' },
+      { value: 'mirror.configure', label: 'Mirror configure' },
     ],
   },
 ]

--- a/docs/superpowers/plans/2026-07-13-mirror-control-plane.md
+++ b/docs/superpowers/plans/2026-07-13-mirror-control-plane.md
@@ -1,0 +1,95 @@
+# Mirror Control Plane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provide authorized operators an audited API and UI to inspect and safely manage the Terraform mirror runtime.
+
+**Architecture:** Build an admin-only handler layer over the existing mirror configuration, cache repositories, and lease repository. Add small repository query/delete operations for the state already persisted by the mirror, then expose them through the established minimal-API and Nuxt admin conventions. Mutations must use request cancellation and emit audit events.
+
+**Tech Stack:** ASP.NET Core minimal APIs, C#/.NET 10, SQLite/PostgreSQL repositories, xUnit/Moq, Nuxt/Vue/TypeScript.
+
+## Global Constraints
+
+- Reuse `mirror.read`, `mirror.manage`, and `mirror.configure`; do not grant mirror access to default users.
+- Read operations must not mutate cache state; purge must be coordinate-specific and never delete a live lease.
+- Every configuration or purge mutation emits an audit event containing non-secret coordinates and outcome.
+- API and UI permission checks must both be covered by automated tests.
+- Use cancellation tokens on new repository/storage operations.
+
+---
+
+### Task 1: Mirror admin contracts and read paths
+
+**Files:**
+- Modify: `TerraformRegistry.API/Interfaces/IProviderMirrorRepository.cs`
+- Modify: `TerraformRegistry.API/Interfaces/IModuleMirrorRepository.cs`
+- Modify: `TerraformRegistry.API/Interfaces/IMirrorLeaseRepository.cs`
+- Modify: `TerraformRegistry.Models/MirrorAdminModels.cs`
+- Modify: `TerraformRegistry/Services/Sqlite/SqliteProviderMirrorRepository.cs`
+- Modify: `TerraformRegistry/Services/Sqlite/SqliteModuleMirrorRepository.cs`
+- Modify: `TerraformRegistry/Services/Sqlite/SqliteMirrorLeaseRepository.cs`
+- Modify: PostgreSQL mirror repository counterparts
+- Test: `TerraformRegistry.Tests/UnitTests/Database/*Mirror*Admin*Tests.cs`
+
+- [ ] Write failing SQLite and PostgreSQL parity tests for cache summary, bounded package list, and lease list.
+- [ ] Run each focused test and confirm it fails because the admin query contract is absent.
+- [ ] Add `MirrorCacheSummary`, `MirrorCachePage<T>`, and bounded `ListLeasesAsync`/summary repository contracts, then implement equivalent SQLite/PostgreSQL SQL queries.
+- [ ] Run focused tests and confirm they pass.
+- [ ] Commit with `feat: add mirror administration queries`.
+
+### Task 2: Safe cache purge contract
+
+**Files:**
+- Modify: mirror repository interfaces and SQLite/PostgreSQL implementations
+- Modify: `TerraformRegistry.Models/MirrorAdminModels.cs`
+- Test: mirror repository tests and handler tests
+
+- [ ] Write failing tests proving purge deletes only the selected cached record and refuses an active matching lease.
+- [ ] Run focused tests and confirm the missing purge operation fails.
+- [ ] Add coordinate-specific purge methods that return an explicit not-found, purged, or in-use result; remove only database metadata here, leaving artifact deletion to the storage-aware handler/service.
+- [ ] Run focused tests and confirm successful purge, no-op missing coordinate, and in-use protection.
+- [ ] Commit with `feat: protect mirror cache purges`.
+
+### Task 3: Permissioned, audited mirror admin API
+
+**Files:**
+- Create: `TerraformRegistry/Handlers/MirrorAdminHandlers.cs`
+- Modify: `TerraformRegistry/Startup/AdminEndpointMappingExtensions.cs`
+- Modify: service registration only if a focused mirror-admin coordinator is required
+- Test: `TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs`
+- Test: `TerraformRegistry.Tests/IntegrationTests/MirrorAdminEndpointTests.cs`
+
+- [ ] Write failing handler/integration tests for 403 without each required permission, 200 for read/configuration, audit records for mutation, and 409 for an in-use purge.
+- [ ] Run focused tests and confirm route/handler absence causes the expected failures.
+- [ ] Implement routes under `/api/admin/mirror`: config GET/PUT, summary, provider/module cache lists, leases list, and coordinate-specific purge. Use `RequestAborted`, clamp pagination, and use `FireAuditLog` for config update/purge.
+- [ ] Run focused tests and confirm all authorization, audit, cancellation, and purge assertions pass.
+- [ ] Commit with `feat: add audited mirror administration API`.
+
+### Task 4: Mirror admin UI
+
+**Files:**
+- Create: `TerraformRegistry/web-src/composables/useMirrorAdmin.ts`
+- Create: `TerraformRegistry/web-src/pages/admin/mirror.vue`
+- Modify: `TerraformRegistry/web-src/layouts/default.vue`
+- Modify: `TerraformRegistry/web-src/pages/admin/roles.vue`
+- Test: frontend build/audit commands and endpoint integration tests
+
+- [ ] Add a failing type/build usage for the mirror admin composable and page navigation permission.
+- [ ] Run `npm`/frontend build command and confirm the new imports fail before implementation.
+- [ ] Implement typed API calls and a permission-gated page showing effective config, cache/lease status, paginated cache entries, and confirmation-gated coordinate purge; never render signing keys or secrets.
+- [ ] Run frontend build/audit and focused API tests; confirm both pass.
+- [ ] Commit with `feat: add mirror operator console`.
+
+### Task 5: Review and verification
+
+**Files:** all changed files
+
+- [ ] Run `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --logger "console;verbosity=minimal" --blame-hang --blame-hang-timeout 5m`.
+- [ ] Run the repository slopwatch check, `git diff --check`, targeted formatting, frontend build/audit, and Docker emulator Terraform contract.
+- [ ] Inspect the diff for secret exposure, route authorization gaps, and unintended schema changes.
+- [ ] Commit any final correction with a descriptive scope-specific message.
+- [ ] Create a PR, watch every GitHub check/review/thread, resolve verified findings, and squash-merge only after `mergeStateStatus` is `CLEAN`.
+
+## Self-review
+
+MIR-009 is covered by Tasks 1–4: effective configuration, cache and lease visibility, safe purge, audit records, API authorization, and UI authorization. The plan does not add a new job table because the existing mirror implementation uses leases rather than a durable mirror job queue; the control plane exposes that live work state. No signing key or other secret is returned to the browser.


### PR DESCRIPTION
Adds permission-gated mirror configuration, cache and lease visibility, safe provider/module purges, and an operator console.

Safety:
- signing material and trusted key IDs are not exposed to operators
- updates preserve trusted key IDs
- purges refuse both local use and active distributed leases
- mutations are audit logged

Verification:
- 704/704 .NET tests
- Nuxt production build
- Slopwatch and whitespace checks
- Docker-backed Azure/Azurite and S3/MinIO Terraform smoke contract