### PR TITLE
feat: make side effects durable

### DIFF
--- a/TerraformRegistry.API/Interfaces/IAuditService.cs
+++ b/TerraformRegistry.API/Interfaces/IAuditService.cs
@@ -7,5 +7,9 @@ public interface IAuditService
     Task<AuditLogEntry?> GetAsync(Guid id);
 }
 
+public interface IAuditLogStore : IAuditService
+{
+}
+
 public record AuditLogEntry(Guid Id, string? UserId, string Action, string ResourceType, string? ResourceId, string? Details, string? IpAddress, DateTime Timestamp);
 public record AuditLogPage(IReadOnlyList<AuditLogEntry> Entries, int Total);

--- a/TerraformRegistry.API/Interfaces/IOutboxEventHandler.cs
+++ b/TerraformRegistry.API/Interfaces/IOutboxEventHandler.cs
@@ -1,0 +1,9 @@
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.API.Interfaces;
+
+public interface IOutboxDeliveryHandler
+{
+    bool CanHandle(string kind);
+    Task HandleAsync(OutboxEvent outboxEvent, CancellationToken cancellationToken);
+}

--- a/TerraformRegistry.API/Interfaces/IOutboxEventRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IOutboxEventRepository.cs
@@ -1,0 +1,11 @@
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.API.Interfaces;
+
+public interface IOutboxEventRepository
+{
+    Task<bool> EnqueueAsync(OutboxEvent outboxEvent, CancellationToken cancellationToken = default);
+    Task<OutboxEvent?> TryClaimNextAsync(string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default);
+    Task<bool> TryCompleteAsync(Guid id, string ownerId, CancellationToken cancellationToken = default);
+    Task<bool> TryFailAsync(Guid id, string ownerId, string failureReason, int maximumAttempts, CancellationToken cancellationToken = default);
+}

--- a/TerraformRegistry.Migrations/DbUpMigrator.cs
+++ b/TerraformRegistry.Migrations/DbUpMigrator.cs
@@ -190,6 +190,7 @@ public class DbUpMigrator
             var name when name.Contains("016_mirror_cache", StringComparison.OrdinalIgnoreCase) => ["mirror_provider_indexes", "mirror_provider_packages", "mirror_module_versions", "mirror_module_packages"],
             var name when name.Contains("terraform_authorization_codes", StringComparison.OrdinalIgnoreCase) => ["terraform_authorization_codes"],
             var name when name.Contains("namespace_maintainers", StringComparison.OrdinalIgnoreCase) => ["namespace_maintainers"],
+            var name when name.Contains("durable_outbox", StringComparison.OrdinalIgnoreCase) => ["durable_outbox_events"],
             _ => []
         };
     }

--- a/TerraformRegistry.Migrations/Scripts/PostgreSQL/024_durable_outbox.sql
+++ b/TerraformRegistry.Migrations/Scripts/PostgreSQL/024_durable_outbox.sql
@@ -1,0 +1,17 @@
+CREATE TABLE durable_outbox_events (
+    id UUID PRIMARY KEY,
+    kind VARCHAR(128) NOT NULL,
+    idempotency_key VARCHAR(512) NOT NULL UNIQUE,
+    payload_json TEXT NOT NULL,
+    state VARCHAR(32) NOT NULL,
+    owner_id VARCHAR(255),
+    lease_expires_at TIMESTAMP WITH TIME ZONE,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    delivered_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX idx_durable_outbox_events_claim
+    ON durable_outbox_events(state, lease_expires_at, created_at);

--- a/TerraformRegistry.Migrations/Scripts/SQLite/022_durable_outbox.sql
+++ b/TerraformRegistry.Migrations/Scripts/SQLite/022_durable_outbox.sql
@@ -1,0 +1,17 @@
+CREATE TABLE durable_outbox_events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL UNIQUE,
+    payload_json TEXT NOT NULL,
+    state TEXT NOT NULL,
+    owner_id TEXT,
+    lease_expires_at TEXT,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    delivered_at TEXT
+);
+
+CREATE INDEX idx_durable_outbox_events_claim
+    ON durable_outbox_events(state, lease_expires_at, created_at);

--- a/TerraformRegistry.Models/OutboxEvent.cs
+++ b/TerraformRegistry.Models/OutboxEvent.cs
@@ -1,0 +1,28 @@
+namespace TerraformRegistry.Models;
+
+public static class OutboxEventState
+{
+    public const string Pending = "pending";
+    public const string Processing = "processing";
+    public const string Retry = "retry";
+    public const string Delivered = "delivered";
+    public const string DeadLetter = "dead-letter";
+
+    public static bool IsClaimable(string state) => state is Pending or Retry;
+}
+
+public sealed record OutboxEvent
+{
+    public required Guid Id { get; init; }
+    public required string Kind { get; init; }
+    public required string IdempotencyKey { get; init; }
+    public required string PayloadJson { get; init; }
+    public required string State { get; init; }
+    public string? OwnerId { get; init; }
+    public DateTime? LeaseExpiresAt { get; init; }
+    public int AttemptCount { get; init; }
+    public string? LastError { get; init; }
+    public required DateTime CreatedAt { get; init; }
+    public required DateTime UpdatedAt { get; init; }
+    public DateTime? DeliveredAt { get; init; }
+}

--- a/TerraformRegistry.PostgreSQL/PostgreSqlAuditService.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSqlAuditService.cs
@@ -7,7 +7,7 @@ using TerraformRegistry.API.Logging;
 
 namespace TerraformRegistry.PostgreSQL;
 
-public class PostgreSqlAuditService : IAuditService
+public class PostgreSqlAuditService : IAuditLogStore
 {
     private readonly string _connectionString;
     private readonly ILogger<PostgreSqlAuditService> _logger;
@@ -44,6 +44,7 @@ public class PostgreSqlAuditService : IAuditService
         catch (Exception ex)
         {
             RegistryLog.Error(_logger, ex, "Failed to write audit log entry for action {Action}", action);
+            throw;
         }
     }
 

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlOutboxEventRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlOutboxEventRepository.cs
@@ -1,0 +1,53 @@
+using Npgsql;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.PostgreSQL.Repositories;
+
+public sealed class PostgreSqlOutboxEventRepository(string connectionString) : IOutboxEventRepository
+{
+    public async Task<bool> EnqueueAsync(OutboxEvent outboxEvent, CancellationToken cancellationToken = default)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = new NpgsqlCommand("""
+            INSERT INTO durable_outbox_events (id, kind, idempotency_key, payload_json, state, attempt_count, created_at, updated_at)
+            VALUES (@id, @kind, @idempotencyKey, @payloadJson, @state, 0, @createdAt, @updatedAt)
+            ON CONFLICT (idempotency_key) DO NOTHING
+            """, connection);
+        command.Parameters.AddWithValue("@id", outboxEvent.Id); command.Parameters.AddWithValue("@kind", outboxEvent.Kind);
+        command.Parameters.AddWithValue("@idempotencyKey", outboxEvent.IdempotencyKey); command.Parameters.AddWithValue("@payloadJson", outboxEvent.PayloadJson);
+        command.Parameters.AddWithValue("@state", OutboxEventState.Pending); command.Parameters.AddWithValue("@createdAt", outboxEvent.CreatedAt); command.Parameters.AddWithValue("@updatedAt", outboxEvent.UpdatedAt);
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
+    }
+
+    public async Task<OutboxEvent?> TryClaimNextAsync(string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        await using var connection = new NpgsqlConnection(connectionString); await connection.OpenAsync(cancellationToken);
+        await using var command = new NpgsqlCommand("""
+            WITH next AS (SELECT id FROM durable_outbox_events WHERE state IN (@pending, @retry)
+                OR (state = @processing AND lease_expires_at <= @now) ORDER BY created_at, id FOR UPDATE SKIP LOCKED LIMIT 1)
+            UPDATE durable_outbox_events e SET state = @processing, owner_id = @ownerId, lease_expires_at = @leaseExpiresAt,
+                attempt_count = attempt_count + 1, updated_at = @now FROM next WHERE e.id = next.id
+            RETURNING e.id, e.kind, e.idempotency_key, e.payload_json, e.state, e.owner_id, e.lease_expires_at,
+                e.attempt_count, e.last_error, e.created_at, e.updated_at, e.delivered_at
+            """, connection);
+        command.Parameters.AddWithValue("@pending", OutboxEventState.Pending); command.Parameters.AddWithValue("@retry", OutboxEventState.Retry); command.Parameters.AddWithValue("@processing", OutboxEventState.Processing);
+        command.Parameters.AddWithValue("@now", now); command.Parameters.AddWithValue("@ownerId", ownerId); command.Parameters.AddWithValue("@leaseExpiresAt", now.Add(leaseDuration));
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken); return await reader.ReadAsync(cancellationToken) ? Read(reader) : null;
+    }
+
+    public Task<bool> TryCompleteAsync(Guid id, string ownerId, CancellationToken cancellationToken = default) => UpdateAsync(id, ownerId,
+        "UPDATE durable_outbox_events SET state = @delivered, owner_id = NULL, lease_expires_at = NULL, delivered_at = @now, updated_at = @now WHERE id = @id AND state = @processing AND owner_id = @ownerId", cancellationToken);
+    public Task<bool> TryFailAsync(Guid id, string ownerId, string failureReason, int maximumAttempts, CancellationToken cancellationToken = default) => UpdateAsync(id, ownerId,
+        "UPDATE durable_outbox_events SET state = CASE WHEN attempt_count >= @maximumAttempts THEN @deadLetter ELSE @retry END, owner_id = NULL, lease_expires_at = NULL, last_error = @failureReason, updated_at = @now WHERE id = @id AND state = @processing AND owner_id = @ownerId", cancellationToken, failureReason, maximumAttempts);
+
+    private async Task<bool> UpdateAsync(Guid id, string ownerId, string sql, CancellationToken cancellationToken, string? failureReason = null, int maximumAttempts = 0)
+    {
+        await using var connection = new NpgsqlConnection(connectionString); await connection.OpenAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection); command.Parameters.AddWithValue("@id", id); command.Parameters.AddWithValue("@ownerId", ownerId); command.Parameters.AddWithValue("@processing", OutboxEventState.Processing); command.Parameters.AddWithValue("@now", DateTime.UtcNow); command.Parameters.AddWithValue("@delivered", OutboxEventState.Delivered); command.Parameters.AddWithValue("@retry", OutboxEventState.Retry); command.Parameters.AddWithValue("@deadLetter", OutboxEventState.DeadLetter); command.Parameters.AddWithValue("@maximumAttempts", maximumAttempts); command.Parameters.AddWithValue("@failureReason", (object?)failureReason ?? DBNull.Value); return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
+    }
+
+    private static OutboxEvent Read(NpgsqlDataReader reader) => new() { Id = reader.GetGuid(0), Kind = reader.GetString(1), IdempotencyKey = reader.GetString(2), PayloadJson = reader.GetString(3), State = reader.GetString(4), OwnerId = reader.IsDBNull(5) ? null : reader.GetString(5), LeaseExpiresAt = reader.IsDBNull(6) ? null : reader.GetDateTime(6), AttemptCount = reader.GetInt32(7), LastError = reader.IsDBNull(8) ? null : reader.GetString(8), CreatedAt = reader.GetDateTime(9), UpdatedAt = reader.GetDateTime(10), DeliveredAt = reader.IsDBNull(11) ? null : reader.GetDateTime(11) };
+}

--- a/TerraformRegistry.Tests/DbUpIncrementalMigrationTests.cs
+++ b/TerraformRegistry.Tests/DbUpIncrementalMigrationTests.cs
@@ -575,6 +575,25 @@ public class DbUpIncrementalMigrationTests : IDisposable
         Assert.Equal("never", syncStateReader.GetString(1));
     }
 
+    [Fact]
+    public void Migration022CreatesDurableOutboxEventsTable()
+    {
+        MigrateUpTo(22, _connectionString);
+
+        Assert.Contains("durable_outbox_events", GetTables(_connection));
+        var columns = GetColumns(_connection, "durable_outbox_events");
+        foreach (var column in new[]
+                 {
+                     "id", "kind", "idempotency_key", "payload_json", "state", "owner_id", "lease_expires_at",
+                     "attempt_count", "last_error", "created_at", "updated_at", "delivered_at"
+                 })
+        {
+            Assert.Contains(column, columns);
+        }
+
+        Assert.Contains("idx_durable_outbox_events_claim", GetIndexes(_connection));
+    }
+
     private static void MigrateUpTo(int scriptNumber, string connectionString)
     {
         var maxPrefix = scriptNumber.ToString("D3", CultureInfo.InvariantCulture);

--- a/TerraformRegistry.Tests/UnitTests/Database/SqliteOutboxEventRepositoryTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/SqliteOutboxEventRepositoryTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.Data.Sqlite;
+using TerraformRegistry.Models;
+using TerraformRegistry.Services.Sqlite;
+
+namespace TerraformRegistry.Tests.UnitTests.Database;
+
+public sealed class SqliteOutboxEventRepositoryTests : IDisposable
+{
+    private readonly SqliteConnection connection;
+    private readonly string connectionString;
+
+    public SqliteOutboxEventRepositoryTests()
+    {
+        connectionString = $"Data Source=outbox-{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
+        connection = new SqliteConnection(connectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TABLE durable_outbox_events (
+                id TEXT PRIMARY KEY, kind TEXT NOT NULL, idempotency_key TEXT NOT NULL UNIQUE, payload_json TEXT NOT NULL,
+                state TEXT NOT NULL, owner_id TEXT, lease_expires_at TEXT, attempt_count INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, delivered_at TEXT);
+            """;
+        command.ExecuteNonQuery();
+    }
+
+    [Fact]
+    public async Task ClaimAndCompleteDeliversAnEnqueuedEventOnlyOnce()
+    {
+        var repository = new SqliteOutboxEventRepository(connectionString);
+        var now = DateTime.UtcNow;
+        var @event = new OutboxEvent
+        {
+            Id = Guid.NewGuid(),
+            Kind = "audit",
+            IdempotencyKey = "audit:1",
+            PayloadJson = "{}",
+            State = OutboxEventState.Pending,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        Assert.True(await repository.EnqueueAsync(@event));
+        Assert.False(await repository.EnqueueAsync(@event with { Id = Guid.NewGuid() }));
+        var claimed = await repository.TryClaimNextAsync("worker-a", TimeSpan.FromMinutes(1));
+        Assert.NotNull(claimed);
+        Assert.Equal(OutboxEventState.Processing, claimed.State);
+        Assert.True(await repository.TryCompleteAsync(claimed.Id, "worker-a"));
+        Assert.Null(await repository.TryClaimNextAsync("worker-b", TimeSpan.FromMinutes(1)));
+    }
+
+    public void Dispose() => connection.Dispose();
+}

--- a/TerraformRegistry.Tests/UnitTests/DurableAuditServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/DurableAuditServiceTests.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using Moq;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+using TerraformRegistry.Services;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class DurableAuditServiceTests
+{
+    [Fact]
+    public async Task LogAsyncEnqueuesAnAuditEventInsteadOfWritingItInline()
+    {
+        var store = new Mock<IAuditLogStore>();
+        var outbox = new Mock<IOutboxEventRepository>();
+        OutboxEvent? enqueued = null;
+        outbox.Setup(repository => repository.EnqueueAsync(It.IsAny<OutboxEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<OutboxEvent, CancellationToken>((@event, _) => enqueued = @event)
+            .ReturnsAsync(true);
+        var service = new DurableAuditService(store.Object, outbox.Object);
+
+        await service.LogAsync("user-1", "module.deleted", "module", "example/vpc/aws/1.0.0", new { reason = "test" }, "127.0.0.1");
+
+        store.Verify(store => store.LogAsync(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+            It.IsAny<object?>(), It.IsAny<string?>()), Times.Never);
+        Assert.NotNull(enqueued);
+        Assert.Equal(AuditOutboxDeliveryHandler.Kind, enqueued.Kind);
+        var payload = JsonSerializer.Deserialize<AuditOutboxPayload>(enqueued.PayloadJson);
+        Assert.Equal("module.deleted", payload?.Action);
+    }
+}

--- a/TerraformRegistry.Tests/UnitTests/DurableOutboxProcessorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/DurableOutboxProcessorTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+using TerraformRegistry.Services;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class DurableOutboxProcessorTests
+{
+    [Fact]
+    public async Task ProcessNextAsyncCompletesAHandledEvent()
+    {
+        var @event = CreateEvent();
+        var repository = new Mock<IOutboxEventRepository>();
+        repository.Setup(x => x.TryClaimNextAsync("worker-1", It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).ReturnsAsync(@event);
+        repository.Setup(x => x.TryCompleteAsync(@event.Id, "worker-1", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        var handler = new Mock<IOutboxDeliveryHandler>();
+        handler.Setup(x => x.CanHandle("test")).Returns(true);
+        handler.Setup(x => x.HandleAsync(@event, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        var processor = CreateProcessor(repository.Object, handler.Object);
+
+        Assert.True(await processor.ProcessNextAsync("worker-1", CancellationToken.None));
+        repository.Verify(x => x.TryCompleteAsync(@event.Id, "worker-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessNextAsyncSchedulesRetryWhenDeliveryFails()
+    {
+        var @event = CreateEvent();
+        var repository = new Mock<IOutboxEventRepository>();
+        repository.Setup(x => x.TryClaimNextAsync("worker-1", It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).ReturnsAsync(@event);
+        repository.Setup(x => x.TryFailAsync(@event.Id, "worker-1", "failed", 5, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        var handler = new Mock<IOutboxDeliveryHandler>();
+        handler.Setup(x => x.CanHandle("test")).Returns(true);
+        handler.Setup(x => x.HandleAsync(@event, It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException("failed"));
+        var processor = CreateProcessor(repository.Object, handler.Object);
+
+        Assert.False(await processor.ProcessNextAsync("worker-1", CancellationToken.None));
+        repository.Verify(x => x.TryFailAsync(@event.Id, "worker-1", "failed", 5, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static DurableOutboxProcessor CreateProcessor(IOutboxEventRepository repository, IOutboxDeliveryHandler handler) =>
+        new(repository, [handler], Options.Create(new DurableOutboxOptions { LeaseSeconds = 30, RetryLimit = 5 }),
+            NullLogger<DurableOutboxProcessor>.Instance);
+
+    private static OutboxEvent CreateEvent() => new()
+    {
+        Id = Guid.NewGuid(),
+        Kind = "test",
+        IdempotencyKey = "test:event",
+        PayloadJson = "{}",
+        State = OutboxEventState.Processing,
+        OwnerId = "worker-1",
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow
+    };
+}

--- a/TerraformRegistry.Tests/UnitTests/ModuleDownloadAnalyticsQueueTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleDownloadAnalyticsQueueTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Options;
+using TerraformRegistry.Services;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class ModuleDownloadAnalyticsBufferTests
+{
+    [Fact]
+    public async Task TryEnqueueRejectsARecordWhenTheBoundedQueueIsFull()
+    {
+        using var queue = new ModuleDownloadAnalyticsBuffer(Options.Create(new DownloadAnalyticsOptions { Capacity = 1 }));
+        var first = new ModuleDownloadRecord("hashicorp", "vpc", "aws", "1.0.0", "127.0.0.1", "terraform");
+        var second = new ModuleDownloadRecord("hashicorp", "consul", "aws", "1.0.0", "127.0.0.1", "terraform");
+
+        Assert.True(queue.TryEnqueue(first));
+        Assert.False(queue.TryEnqueue(second));
+
+        await foreach (var actual in queue.ReadAllAsync(CancellationToken.None))
+        {
+            Assert.Equal(first, actual);
+            break;
+        }
+    }
+}

--- a/TerraformRegistry.Tests/UnitTests/ModuleMirrorServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleMirrorServiceTests.cs
@@ -585,7 +585,7 @@ public sealed class ModuleMirrorServiceTests
             "aws",
             moduleService.Object,
             mirror.Object,
-            Mock.Of<IDatabaseService>(),
+            new ModuleDownloadAnalyticsBuffer(Microsoft.Extensions.Options.Options.Create(new DownloadAnalyticsOptions())),
             context);
 
         Assert.IsType<Microsoft.AspNetCore.Http.HttpResults.NoContent>(result);

--- a/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
@@ -76,6 +76,7 @@ public class ModulePublishCoordinatorTests
 
         var webhookDispatcher = new WebhookDispatcher(
             webhookService.Object,
+            Mock.Of<IOutboxEventRepository>(),
             new TestHttpClientFactory(StaticOkClient),
             new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal) { ["BaseUrl"] = "https://registry.example.com" })
@@ -150,6 +151,7 @@ public class ModulePublishCoordinatorTests
             Mock.Of<IModuleExtractionService>(),
             new WebhookDispatcher(
                 webhookService.Object,
+                Mock.Of<IOutboxEventRepository>(),
                 new TestHttpClientFactory(StaticOkClient),
                 new ConfigurationBuilder()
                     .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal))
@@ -194,6 +196,7 @@ public class ModulePublishCoordinatorTests
             .ReturnsAsync(Array.Empty<Webhook>());
         return new WebhookDispatcher(
             webhookService.Object,
+            Mock.Of<IOutboxEventRepository>(),
             new TestHttpClientFactory(StaticOkClient),
             new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build(),
             new WebhookUrlValidator(

--- a/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
@@ -76,7 +76,7 @@ public class ModulePublishCoordinatorTests
 
         var webhookDispatcher = new WebhookDispatcher(
             webhookService.Object,
-            Mock.Of<IOutboxEventRepository>(),
+            CreateOutboxRepository(),
             new TestHttpClientFactory(StaticOkClient),
             new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal) { ["BaseUrl"] = "https://registry.example.com" })
@@ -196,7 +196,7 @@ public class ModulePublishCoordinatorTests
             .ReturnsAsync(Array.Empty<Webhook>());
         return new WebhookDispatcher(
             webhookService.Object,
-            Mock.Of<IOutboxEventRepository>(),
+            CreateOutboxRepository(),
             new TestHttpClientFactory(StaticOkClient),
             new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build(),
             new WebhookUrlValidator(
@@ -204,6 +204,13 @@ public class ModulePublishCoordinatorTests
                 new StaticWebhookHostResolver(IPAddress.Loopback),
                 NullLogger<WebhookUrlValidator>.Instance),
             NullLogger<WebhookDispatcher>.Instance);
+    }
+
+    private static IOutboxEventRepository CreateOutboxRepository()
+    {
+        var repository = new Mock<IOutboxEventRepository>();
+        repository.Setup(x => x.EnqueueAsync(It.IsAny<OutboxEvent>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        return repository.Object;
     }
 
     private sealed class TestHttpClientFactory(HttpClient client) : IHttpClientFactory

--- a/TerraformRegistry.Tests/UnitTests/OutboxEventStateTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/OutboxEventStateTests.cs
@@ -1,0 +1,16 @@
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class OutboxEventStateTests
+{
+    [Fact]
+    public void PendingAndRetryEventsAreClaimable()
+    {
+        Assert.True(OutboxEventState.IsClaimable(OutboxEventState.Pending));
+        Assert.True(OutboxEventState.IsClaimable(OutboxEventState.Retry));
+        Assert.False(OutboxEventState.IsClaimable(OutboxEventState.Processing));
+        Assert.False(OutboxEventState.IsClaimable(OutboxEventState.Delivered));
+        Assert.False(OutboxEventState.IsClaimable(OutboxEventState.DeadLetter));
+    }
+}

--- a/TerraformRegistry.Tests/UnitTests/WebhookDispatcherTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/WebhookDispatcherTests.cs
@@ -81,7 +81,26 @@ public class WebhookDispatcherTests
         Assert.Equal(443, connector.Port);
     }
 
-    private static WebhookDispatcher CreateDispatcher(HttpMessageHandler handler, WebhookUrlValidator validator)
+    [Fact]
+    public async Task FireEventAsyncPersistsWebhookDeliveryBeforeReturning()
+    {
+        var outbox = new Mock<IOutboxEventRepository>();
+        OutboxEvent? enqueued = null;
+        outbox.Setup(repository => repository.EnqueueAsync(It.IsAny<OutboxEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<OutboxEvent, CancellationToken>((@event, _) => enqueued = @event)
+            .ReturnsAsync(true);
+        var dispatcher = CreateDispatcher(new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)),
+            CreateValidator(IPAddress.Parse("93.184.216.34")), outbox.Object);
+
+        await dispatcher.FireEventAsync("module.published", "hashicorp", "vpc", "aws", "1.0.0", "network");
+
+        Assert.NotNull(enqueued);
+        Assert.Equal(WebhookOutboxDeliveryHandler.Kind, enqueued.Kind);
+        Assert.StartsWith("webhook:wh_", enqueued.IdempotencyKey, StringComparison.Ordinal);
+    }
+
+    private static WebhookDispatcher CreateDispatcher(HttpMessageHandler handler, WebhookUrlValidator validator,
+        IOutboxEventRepository? outbox = null)
     {
         var webhookService = new Mock<IWebhookService>(MockBehavior.Strict);
         var client = new HttpClient(handler);
@@ -92,7 +111,7 @@ public class WebhookDispatcherTests
 
         return new WebhookDispatcher(
             webhookService.Object,
-            Mock.Of<IOutboxEventRepository>(),
+            outbox ?? Mock.Of<IOutboxEventRepository>(),
             factory,
             configuration,
             validator,

--- a/TerraformRegistry.Tests/UnitTests/WebhookDispatcherTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/WebhookDispatcherTests.cs
@@ -92,6 +92,7 @@ public class WebhookDispatcherTests
 
         return new WebhookDispatcher(
             webhookService.Object,
+            Mock.Of<IOutboxEventRepository>(),
             factory,
             configuration,
             validator,

--- a/TerraformRegistry/AuditExtensions.cs
+++ b/TerraformRegistry/AuditExtensions.cs
@@ -10,6 +10,6 @@ public static class AuditExtensions
     {
         var userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
         var ip = context.Connection.RemoteIpAddress?.ToString();
-        _ = auditService.LogAsync(userId, action, resourceType, resourceId, details, ip);
+        auditService.LogAsync(userId, action, resourceType, resourceId, details, ip).GetAwaiter().GetResult();
     }
 }

--- a/TerraformRegistry/AuditExtensions.cs
+++ b/TerraformRegistry/AuditExtensions.cs
@@ -5,11 +5,11 @@ namespace TerraformRegistry;
 
 public static class AuditExtensions
 {
-    public static void FireAuditLog(this HttpContext context, IAuditService auditService,
+    public static Task FireAuditLogAsync(this HttpContext context, IAuditService auditService,
         string action, string resourceType, string? resourceId = null, object? details = null)
     {
         var userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
         var ip = context.Connection.RemoteIpAddress?.ToString();
-        auditService.LogAsync(userId, action, resourceType, resourceId, details, ip).GetAwaiter().GetResult();
+        return auditService.LogAsync(userId, action, resourceType, resourceId, details, ip);
     }
 }

--- a/TerraformRegistry/Controllers/ApiKeyController.cs
+++ b/TerraformRegistry/Controllers/ApiKeyController.cs
@@ -52,7 +52,7 @@ public class ApiKeyController(IApiKeyService apiKeyService, IAuditService auditS
 
         var (rawToken, key) = await apiKeyService.CreateApiKeyAsync(userId, request.Description, request.IsShared);
 
-        HttpContext.FireAuditLog(auditService, "api_key.created", "api_key", key.Id.ToString(), new { description = request.Description, isShared = request.IsShared });
+        await HttpContext.FireAuditLogAsync(auditService, "api_key.created", "api_key", key.Id.ToString(), new { description = request.Description, isShared = request.IsShared });
 
         var owner = await apiKeyService.GetUserByIdAsync(userId);
 
@@ -94,7 +94,7 @@ public class ApiKeyController(IApiKeyService apiKeyService, IAuditService auditS
         var success = await apiKeyService.RevokeApiKeyAsync(id, userId);
         if (!success) return NotFound();
 
-        HttpContext.FireAuditLog(auditService, "api_key.revoked", "api_key", id.ToString());
+        await HttpContext.FireAuditLogAsync(auditService, "api_key.revoked", "api_key", id.ToString());
 
         return NoContent();
     }

--- a/TerraformRegistry/Handlers/AdminHandlers.cs
+++ b/TerraformRegistry/Handlers/AdminHandlers.cs
@@ -34,7 +34,7 @@ public static class AdminHandlers
             return Results.BadRequest(new { error = $"Invalid permissions: {string.Join(", ", invalidPermissions)}" });
 
         var role = await roleService.CreateRoleAsync(body.Name, body.Description, body.Permissions);
-        context.FireAuditLog(auditService, "role.created", "role", role.Id.ToString(), new { name = body.Name, permissions = body.Permissions });
+        await context.FireAuditLogAsync(auditService, "role.created", "role", role.Id.ToString(), new { name = body.Name, permissions = body.Permissions });
 
         return Results.Created($"/api/admin/roles/{role.Id}", role);
     }
@@ -65,7 +65,7 @@ public static class AdminHandlers
         if (role == null)
             return Results.NotFound(new { error = "Role not found" });
 
-        context.FireAuditLog(auditService, "role.updated", "role", id.ToString(), new { name = body.Name, permissions = body.Permissions });
+        await context.FireAuditLogAsync(auditService, "role.updated", "role", id.ToString(), new { name = body.Name, permissions = body.Permissions });
 
         return Results.Ok(role);
     }
@@ -79,7 +79,7 @@ public static class AdminHandlers
         if (!deleted)
             return Results.BadRequest(new { error = "Role not found or is a system role that cannot be deleted" });
 
-        context.FireAuditLog(auditService, "role.deleted", "role", id.ToString());
+        await context.FireAuditLogAsync(auditService, "role.deleted", "role", id.ToString());
 
         return Results.NoContent();
     }
@@ -115,7 +115,7 @@ public static class AdminHandlers
 
         var assignedBy = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
         var result = await permService.AssignRoleAsync(userId, body.RoleId, assignedBy);
-        context.FireAuditLog(auditService, "role.assigned", "user_role", userId, new { roleId = body.RoleId });
+        await context.FireAuditLogAsync(auditService, "role.assigned", "user_role", userId, new { roleId = body.RoleId });
 
         return Results.Ok(new { success = result });
     }
@@ -158,7 +158,7 @@ public static class AdminHandlers
         if (!result)
             return Results.NotFound(new { error = "Role assignment not found" });
 
-        context.FireAuditLog(auditService, "role.removed", "user_role", userId, new { roleId });
+        await context.FireAuditLogAsync(auditService, "role.removed", "user_role", userId, new { roleId });
 
         return Results.NoContent();
     }
@@ -185,7 +185,7 @@ public static class AdminHandlers
             return Results.BadRequest(new { error = "Cannot assign an inactive user as namespace maintainer" });
 
         await maintainerStore.AssignMaintainerAsync(@namespace, user.Id);
-        context.FireAuditLog(auditService, "namespace.maintainer_assigned", "namespace", @namespace,
+        await context.FireAuditLogAsync(auditService, "namespace.maintainer_assigned", "namespace", @namespace,
             new { namespaceName = @namespace, userId = user.Id });
 
         return Results.Ok(new { @namespace, userId = user.Id });

--- a/TerraformRegistry/Handlers/AuthHandlers.cs
+++ b/TerraformRegistry/Handlers/AuthHandlers.cs
@@ -169,7 +169,7 @@ public static class AuthHandlers
             MaxAge = TimeSpan.FromHours(24)
         });
 
-        context.FireAuditLog(auditService, "user.login", "user", user.Id, new { email = userInfo.Email, provider });
+        await context.FireAuditLogAsync(auditService, "user.login", "user", user.Id, new { email = userInfo.Email, provider });
 
         var returnTo = context.Request.Cookies[ReturnToCookieName];
         if (!string.IsNullOrWhiteSpace(returnTo) && IsSafeReturnPath(returnTo))
@@ -181,7 +181,7 @@ public static class AuthHandlers
         return Results.Redirect("/");
     }
 
-    public static IResult BeginTerraformAuthorization(HttpContext context)
+    public static async Task<IResult> BeginTerraformAuthorization(HttpContext context)
     {
         if (context.User.Identity?.IsAuthenticated != true)
         {
@@ -217,7 +217,7 @@ public static class AuthHandlers
             codeChallenge,
             codeChallengeMethod));
         var auditService = context.RequestServices.GetRequiredService<IAuditService>();
-        context.FireAuditLog(auditService, "terraform_cli.login.started", "user", userId, new
+        await context.FireAuditLogAsync(auditService, "terraform_cli.login.started", "user", userId, new
         {
             clientId,
             redirectUri
@@ -278,7 +278,7 @@ public static class AuthHandlers
             issued.UserId,
             description,
             DateTime.UtcNow.AddDays(90));
-        context.FireAuditLog(auditService, "terraform_cli.key.created", "user", issued.UserId, new
+        await context.FireAuditLogAsync(auditService, "terraform_cli.key.created", "user", issued.UserId, new
         {
             clientId,
             redirectUri
@@ -329,10 +329,10 @@ public static class AuthHandlers
     /// <summary>
     /// Logs out the current user by clearing the session cookie.
     /// </summary>
-    public static IResult Logout(HttpContext context, IAuditService auditService)
+    public static async Task<IResult> Logout(HttpContext context, IAuditService auditService)
     {
         context.Response.Cookies.Delete(SessionCookieName);
-        context.FireAuditLog(auditService, "user.logout", "user", context.User.FindFirstValue(ClaimTypes.NameIdentifier));
+        await context.FireAuditLogAsync(auditService, "user.logout", "user", context.User.FindFirstValue(ClaimTypes.NameIdentifier));
 
         return Results.Ok(new { message = "Logged out successfully" });
     }
@@ -384,7 +384,7 @@ public static class AuthHandlers
 
         // Clear session
         context.Response.Cookies.Delete(SessionCookieName);
-        context.FireAuditLog(auditService, "user.deleted", "user", userId);
+        await context.FireAuditLogAsync(auditService, "user.deleted", "user", userId);
 
         return Results.Ok();
     }
@@ -471,7 +471,7 @@ public static class AuthHandlers
             MaxAge = TimeSpan.FromHours(24)
         });
 
-        context.FireAuditLog(auditService, "user.login", "user", devUserId, new { email = devEmail, provider = "DevBypass" });
+        await context.FireAuditLogAsync(auditService, "user.login", "user", devUserId, new { email = devEmail, provider = "DevBypass" });
 
         return Results.Ok(new
         {

--- a/TerraformRegistry/Handlers/MirrorAdminHandlers.cs
+++ b/TerraformRegistry/Handlers/MirrorAdminHandlers.cs
@@ -36,7 +36,7 @@ public static class MirrorAdminHandlers
             return Results.Problem("The mirror cache entry could not be purged.", statusCode: StatusCodes.Status502BadGateway);
         }
 
-        context.FireAuditLog(auditService, "mirror.provider_purged", "mirror_provider",
+        await context.FireAuditLogAsync(auditService, "mirror.provider_purged", "mirror_provider",
             $"{hostname}/{providerNamespace}/{type}/{version}/{os}/{arch}");
         return Results.NoContent();
     }
@@ -68,7 +68,7 @@ public static class MirrorAdminHandlers
             return Results.Problem("The mirror cache entry could not be purged.", statusCode: StatusCodes.Status502BadGateway);
         }
 
-        context.FireAuditLog(auditService, "mirror.module_purged", "mirror_module",
+        await context.FireAuditLogAsync(auditService, "mirror.module_purged", "mirror_module",
             $"{hostname}/{moduleNamespace}/{name}/{provider}/{version}");
         return Results.NoContent();
     }
@@ -132,7 +132,7 @@ public static class MirrorAdminHandlers
 
         var actor = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
         var response = await configService.UpdateConfigAsync(request, actor, context.RequestAborted);
-        context.FireAuditLog(auditService, "mirror.config_updated", "mirror", "config", new
+        await context.FireAuditLogAsync(auditService, "mirror.config_updated", "mirror", "config", new
         {
             request.Enabled,
             ProvidersEnabled = request.Providers.Enabled,

--- a/TerraformRegistry/Handlers/ModuleDocsHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleDocsHandlers.cs
@@ -85,7 +85,7 @@ public static class ModuleDocsHandlers
             new ModuleExtractionRequest(@namespace, name, provider, version),
             context.RequestAborted);
 
-        context.FireAuditLog(auditService, "module_docs.requeued", "module",
+        await context.FireAuditLogAsync(auditService, "module_docs.requeued", "module",
             $"{@namespace}/{name}/{provider}/{version}", new
             {
                 Namespace = @namespace,
@@ -135,7 +135,7 @@ public static class ModuleDocsHandlers
             queued = await extractionService.QueueAsync(request, context.RequestAborted);
         }
 
-        context.FireAuditLog(auditService, "module_docs.llm_regenerated", "module",
+        await context.FireAuditLogAsync(auditService, "module_docs.llm_regenerated", "module",
             $"{@namespace}/{name}/{provider}/{version}", new
             {
                 Namespace = @namespace,
@@ -170,7 +170,7 @@ public static class ModuleDocsHandlers
         var limit = Math.Clamp(body?.Limit ?? 25, 1, 100);
         var queued = await extractionService.QueueBackfillAsync(limit, context.RequestAborted);
 
-        context.FireAuditLog(auditService, "module_docs.backfill_queued", "module_docs",
+        await context.FireAuditLogAsync(auditService, "module_docs.backfill_queued", "module_docs",
             null, new
             {
                 RequestedLimit = limit,
@@ -203,7 +203,7 @@ public static class ModuleDocsHandlers
 
         var actor = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
         var config = await configService.SetEnabledAsync(body.Enabled, actor, context.RequestAborted);
-        context.FireAuditLog(auditService, "module_docs.config_updated", "module_docs",
+        await context.FireAuditLogAsync(auditService, "module_docs.config_updated", "module_docs",
             "module_extraction", new
             {
                 RequestedEnabled = body.Enabled,

--- a/TerraformRegistry/Handlers/ModuleHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleHandlers.cs
@@ -389,7 +389,7 @@ public static class ModuleHandlers
         if (!result) return ErrorResponseExtensions.NotFound("Module version not found");
 
         await webhookDispatcher.FireEventAsync("module.deleted", @namespace, name, provider, version, null, context.RequestAborted);
-        context.FireAuditLog(auditService, "module.deleted", "module", $"{@namespace}/{name}/{provider}/{version}", new { @namespace, name, provider, version });
+        await context.FireAuditLogAsync(auditService, "module.deleted", "module", $"{@namespace}/{name}/{provider}/{version}", new { @namespace, name, provider, version });
 
         return NoContent();
     }
@@ -429,7 +429,7 @@ public static class ModuleHandlers
         if (!result) return ErrorResponseExtensions.NotFound("Deleted module version not found");
 
         await webhookDispatcher.FireEventAsync("module.restored", @namespace, name, provider, version, null, context.RequestAborted);
-        context.FireAuditLog(auditService, "module.restored", "module", $"{@namespace}/{name}/{provider}/{version}", new { @namespace, name, provider, version });
+        await context.FireAuditLogAsync(auditService, "module.restored", "module", $"{@namespace}/{name}/{provider}/{version}", new { @namespace, name, provider, version });
 
         return NoContent();
     }
@@ -469,7 +469,7 @@ public static class ModuleHandlers
         if (!result) return ErrorResponseExtensions.NotFound("Deleted module version not found");
 
         await webhookDispatcher.FireEventAsync("module.purged", @namespace, name, provider, version, null, context.RequestAborted);
-        context.FireAuditLog(auditService, "module.purged", "module", $"{@namespace}/{name}/{provider}/{version}", new { @namespace, name, provider, version });
+        await context.FireAuditLogAsync(auditService, "module.purged", "module", $"{@namespace}/{name}/{provider}/{version}", new { @namespace, name, provider, version });
 
         return NoContent();
     }
@@ -536,7 +536,7 @@ public static class ModuleHandlers
             var result = await moduleService.UpdateModuleDescriptionAsync(@namespace, name, provider, description);
             if (!result) return ErrorResponseExtensions.NotFound("Module not found");
 
-            context.FireAuditLog(auditService, "module.description_updated", "module", $"{@namespace}/{name}/{provider}", new { @namespace, name, provider, description });
+            await context.FireAuditLogAsync(auditService, "module.description_updated", "module", $"{@namespace}/{name}/{provider}", new { @namespace, name, provider, description });
 
             return Ok(new { description });
         }

--- a/TerraformRegistry/Handlers/ModuleHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleHandlers.cs
@@ -399,7 +399,7 @@ public static class ModuleHandlers
         var result = await moduleService.DeleteModuleVersionAsync(@namespace, name, provider, version);
         if (!result) return ErrorResponseExtensions.NotFound("Module version not found");
 
-        webhookDispatcher.FireEvent("module.deleted", @namespace, name, provider, version, null);
+        await webhookDispatcher.FireEventAsync("module.deleted", @namespace, name, provider, version, null, context.RequestAborted);
         context.FireAuditLog(auditService, "module.deleted", "module", $"{@namespace}/{name}/{provider}/{version}", new { @namespace, name, provider, version });
 
         return NoContent();
@@ -439,7 +439,7 @@ public static class ModuleHandlers
         var result = await moduleService.RestoreModuleVersionAsync(@namespace, name, provider, version);
         if (!result) return ErrorResponseExtensions.NotFound("Deleted module version not found");
 
-        webhookDispatcher.FireEvent("module.restored", @namespace, name, provider, version, null);
+        await webhookDispatcher.FireEventAsync("module.restored", @namespace, name, provider, version, null, context.RequestAborted);
         context.FireAuditLog(auditService, "module.restored", "module", $"{@namespace}/{name}/{provider}/{version}", new { @namespace, name, provider, version });
 
         return NoContent();
@@ -479,7 +479,7 @@ public static class ModuleHandlers
         var result = await moduleService.PurgeModuleVersionAsync(@namespace, name, provider, version);
         if (!result) return ErrorResponseExtensions.NotFound("Deleted module version not found");
 
-        webhookDispatcher.FireEvent("module.purged", @namespace, name, provider, version, null);
+        await webhookDispatcher.FireEventAsync("module.purged", @namespace, name, provider, version, null, context.RequestAborted);
         context.FireAuditLog(auditService, "module.purged", "module", $"{@namespace}/{name}/{provider}/{version}", new { @namespace, name, provider, version });
 
         return NoContent();

--- a/TerraformRegistry/Handlers/ModuleHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleHandlers.cs
@@ -177,7 +177,7 @@ public static class ModuleHandlers
         string version,
         IModuleService moduleService,
         IModuleMirrorService moduleMirrorService,
-        IDatabaseService dbService,
+        ModuleDownloadAnalyticsBuffer downloadAnalytics,
         HttpContext context)
     {
         var denied = CheckPermission(context, Permissions.ModulesRead);
@@ -203,18 +203,7 @@ public static class ModuleHandlers
         var clientIp = context.Connection.RemoteIpAddress?.ToString();
         var userAgent = context.Request.Headers["User-Agent"].ToString();
 
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                await dbService.RecordDownloadAsync(@namespace, name, provider, version, clientIp, userAgent);
-            }
-            catch (Exception ex)
-            {
-                RegistryLog.Error(_logger, ex, "Failed to record download for {Namespace}/{Name}/{Provider}/{Version}",
-                    @namespace, name, provider, version);
-            }
-        });
+        downloadAnalytics.TryEnqueue(new ModuleDownloadRecord(@namespace, name, provider, version, clientIp, userAgent));
 
         // The module registry protocol always uses 204 with X-Terraform-Get.  The
         // result must not vary with User-Agent because Terraform-compatible clients
@@ -231,7 +220,7 @@ public static class ModuleHandlers
         string provider,
         IModuleService moduleService,
         IModuleMirrorService moduleMirrorService,
-        IDatabaseService dbService,
+        ModuleDownloadAnalyticsBuffer downloadAnalytics,
         HttpContext context)
     {
         var denied = CheckPermission(context, Permissions.ModulesRead);
@@ -255,7 +244,7 @@ public static class ModuleHandlers
             SemVerValidator.Compare(a, b) ?? 0)).FirstOrDefault()?.Version;
         if (string.IsNullOrEmpty(latest)) return ErrorResponseExtensions.NotFound("Module not found");
 
-        return await DownloadModule(@namespace, name, provider, latest, moduleService, moduleMirrorService, dbService, context);
+        return await DownloadModule(@namespace, name, provider, latest, moduleService, moduleMirrorService, downloadAnalytics, context);
     }
 
     /// <summary>

--- a/TerraformRegistry/Handlers/VcsHandlers.cs
+++ b/TerraformRegistry/Handlers/VcsHandlers.cs
@@ -70,7 +70,7 @@ public static class VcsHandlers
 
         source = await vcsService.GetAsync(source.Id) ?? source;
 
-        context.FireAuditLog(auditService, "vcs.created", "vcs_source", source.Id.ToString(), new { @namespace = body.Namespace, name = body.Name, provider = body.Provider, repoOwner = body.RepoOwner, repoName = body.RepoName, connectionId = body.ConnectionId, body.SyncExistingTags });
+        await context.FireAuditLogAsync(auditService, "vcs.created", "vcs_source", source.Id.ToString(), new { @namespace = body.Namespace, name = body.Name, provider = body.Provider, repoOwner = body.RepoOwner, repoName = body.RepoName, connectionId = body.ConnectionId, body.SyncExistingTags });
 
         return Results.Created($"/api/vcs/sources/{source.Id}", new
         {
@@ -119,7 +119,7 @@ public static class VcsHandlers
         var updated = await vcsService.UpdateVcsSourceAsync(id, userId, body?.RepoOwner, body?.RepoName, body?.ConnectionId, body?.IsActive);
         if (updated == null) return Results.NotFound(new { error = "VCS source not found or access denied" });
 
-        context.FireAuditLog(auditService, "vcs.updated", "vcs_source", id.ToString());
+        await context.FireAuditLogAsync(auditService, "vcs.updated", "vcs_source", id.ToString());
 
         return Results.Ok(updated);
     }
@@ -134,7 +134,7 @@ public static class VcsHandlers
         var result = await vcsService.DeleteVcsSourceAsync(id, userId);
         if (!result) return Results.NotFound(new { error = "VCS source not found or access denied" });
 
-        context.FireAuditLog(auditService, "vcs.deleted", "vcs_source", id.ToString());
+        await context.FireAuditLogAsync(auditService, "vcs.deleted", "vcs_source", id.ToString());
 
         return Results.NoContent();
     }
@@ -225,7 +225,7 @@ public static class VcsHandlers
         var connection = await connectionService.CreateConnectionAsync(
             userId, body.Label, body.Provider ?? "github", patEncrypted, body.DefaultOrg, webhookSecret);
 
-        context.FireAuditLog(auditService, "vcs_connection.created", "vcs_connection", connection.Id.ToString(), new { label = body.Label });
+        await context.FireAuditLogAsync(auditService, "vcs_connection.created", "vcs_connection", connection.Id.ToString(), new { label = body.Label });
 
         return Results.Created($"/api/admin/vcs-connections/{connection.Id}", new
         {
@@ -257,7 +257,7 @@ public static class VcsHandlers
         var updated = await connectionService.UpdateConnectionAsync(id, body?.Label, patEncrypted, body?.DefaultOrg, body?.IsActive);
         if (updated == null) return Results.NotFound(new { error = "VCS connection not found" });
 
-        context.FireAuditLog(auditService, "vcs_connection.updated", "vcs_connection", id.ToString());
+        await context.FireAuditLogAsync(auditService, "vcs_connection.updated", "vcs_connection", id.ToString());
         return Results.Ok(updated);
     }
 
@@ -269,7 +269,7 @@ public static class VcsHandlers
         var result = await connectionService.DeleteConnectionAsync(id);
         if (!result) return Results.BadRequest(new { error = "Cannot delete — connection is referenced by active VCS sources, or not found" });
 
-        context.FireAuditLog(auditService, "vcs_connection.deleted", "vcs_connection", id.ToString());
+        await context.FireAuditLogAsync(auditService, "vcs_connection.deleted", "vcs_connection", id.ToString());
         return Results.NoContent();
     }
 

--- a/TerraformRegistry/Handlers/WebhookHandlers.cs
+++ b/TerraformRegistry/Handlers/WebhookHandlers.cs
@@ -45,7 +45,7 @@ public static class WebhookHandlers
             return Results.BadRequest(new { error = validationError });
 
         var webhook = await webhookService.CreateWebhookAsync(userId, body.Url, body.Events, body.Secret, format, body.Template);
-        context.FireAuditLog(auditService, "webhook.created", "webhook", webhook.Id.ToString(), new { url = body.Url, events = body.Events });
+        await context.FireAuditLogAsync(auditService, "webhook.created", "webhook", webhook.Id.ToString(), new { url = body.Url, events = body.Events });
 
         return Results.Created($"/api/webhooks/{webhook.Id}", webhook);
     }
@@ -86,7 +86,7 @@ public static class WebhookHandlers
         var updated = await webhookService.UpdateWebhookAsync(id, userId, body?.Url, body?.Events, body?.Secret, body?.IsActive, body?.Format, body?.Template);
         if (updated == null) return Results.NotFound(new { error = "Webhook not found or access denied" });
 
-        context.FireAuditLog(auditService, "webhook.updated", "webhook", id.ToString());
+        await context.FireAuditLogAsync(auditService, "webhook.updated", "webhook", id.ToString());
 
         return Results.Ok(updated);
     }
@@ -101,7 +101,7 @@ public static class WebhookHandlers
         var result = await webhookService.DeleteWebhookAsync(id, userId);
         if (!result) return Results.NotFound(new { error = "Webhook not found or access denied" });
 
-        context.FireAuditLog(auditService, "webhook.deleted", "webhook", id.ToString());
+        await context.FireAuditLogAsync(auditService, "webhook.deleted", "webhook", id.ToString());
 
         return Results.NoContent();
     }

--- a/TerraformRegistry/Services/AuditOutboxDeliveryHandler.cs
+++ b/TerraformRegistry/Services/AuditOutboxDeliveryHandler.cs
@@ -4,7 +4,7 @@ using TerraformRegistry.Models;
 
 namespace TerraformRegistry.Services;
 
-public sealed class AuditOutboxDeliveryHandler(IAuditService auditService) : IOutboxDeliveryHandler
+public sealed class AuditOutboxDeliveryHandler(IAuditLogStore auditService) : IOutboxDeliveryHandler
 {
     public const string Kind = "audit";
 

--- a/TerraformRegistry/Services/AuditOutboxDeliveryHandler.cs
+++ b/TerraformRegistry/Services/AuditOutboxDeliveryHandler.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Services;
+
+public sealed class AuditOutboxDeliveryHandler(IAuditService auditService) : IOutboxDeliveryHandler
+{
+    public const string Kind = "audit";
+
+    public bool CanHandle(string kind) => string.Equals(kind, Kind, StringComparison.Ordinal);
+
+    public async Task HandleAsync(OutboxEvent outboxEvent, CancellationToken cancellationToken)
+    {
+        var payload = JsonSerializer.Deserialize<AuditOutboxPayload>(outboxEvent.PayloadJson)
+            ?? throw new InvalidOperationException("Durable audit event payload is invalid.");
+        await auditService.LogAsync(payload.UserId, payload.Action, payload.ResourceType, payload.ResourceId,
+            payload.Details, payload.IpAddress);
+    }
+}
+
+public sealed record AuditOutboxPayload(
+    string? UserId,
+    string Action,
+    string ResourceType,
+    string? ResourceId,
+    JsonElement? Details,
+    string? IpAddress);

--- a/TerraformRegistry/Services/DownloadAnalyticsOptions.cs
+++ b/TerraformRegistry/Services/DownloadAnalyticsOptions.cs
@@ -1,0 +1,14 @@
+namespace TerraformRegistry.Services;
+
+public sealed class DownloadAnalyticsOptions
+{
+    public const string SectionName = "DownloadAnalytics";
+
+    public int Capacity { get; set; } = 10_000;
+
+    public void Validate()
+    {
+        if (Capacity <= 0)
+            throw new InvalidOperationException("Download analytics queue capacity must be greater than zero.");
+    }
+}

--- a/TerraformRegistry/Services/DurableAuditService.cs
+++ b/TerraformRegistry/Services/DurableAuditService.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Services;
+
+public sealed class DurableAuditService(IAuditLogStore store, IOutboxEventRepository outbox) : IAuditService
+{
+    public async Task LogAsync(string? userId, string action, string resourceType, string? resourceId, object? details, string? ipAddress)
+    {
+        var payload = new AuditOutboxPayload(
+            userId,
+            action,
+            resourceType,
+            resourceId,
+            details is null ? null : JsonSerializer.SerializeToElement(details),
+            ipAddress);
+        var now = DateTime.UtcNow;
+        var enqueued = await outbox.EnqueueAsync(new OutboxEvent
+        {
+            Id = Guid.NewGuid(),
+            Kind = AuditOutboxDeliveryHandler.Kind,
+            IdempotencyKey = $"audit:{Guid.NewGuid():N}",
+            PayloadJson = JsonSerializer.Serialize(payload),
+            State = OutboxEventState.Pending,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        if (!enqueued) throw new InvalidOperationException("The audit event could not be persisted to the durable outbox.");
+    }
+
+    public Task<AuditLogPage> QueryAsync(string? action, string? userId, string? resourceType, DateTime? from, DateTime? toTimestamp,
+        int limit = 50, int offset = 0) => store.QueryAsync(action, userId, resourceType, from, toTimestamp, limit, offset);
+
+    public Task<AuditLogEntry?> GetAsync(Guid id) => store.GetAsync(id);
+}

--- a/TerraformRegistry/Services/DurableOutboxHostedService.cs
+++ b/TerraformRegistry/Services/DurableOutboxHostedService.cs
@@ -6,8 +6,7 @@ namespace TerraformRegistry.Services;
 
 public sealed class DurableOutboxHostedService(
     DurableOutboxProcessor processor,
-    IOptions<DurableOutboxOptions> options,
-    ILogger<DurableOutboxHostedService> logger) : BackgroundService
+    IOptions<DurableOutboxOptions> options) : BackgroundService
 {
     private readonly DurableOutboxOptions options = options.Value;
 
@@ -28,11 +27,6 @@ public sealed class DurableOutboxHostedService(
                 await Task.Delay(options.PollIntervalMilliseconds, stoppingToken);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { return; }
-            catch (Exception ex)
-            {
-                RegistryLog.Error(logger, ex, "Durable outbox worker {OwnerId} failed to deliver an event.", ownerId);
-                await Task.Delay(options.PollIntervalMilliseconds, stoppingToken);
-            }
         }
     }
 }

--- a/TerraformRegistry/Services/DurableOutboxHostedService.cs
+++ b/TerraformRegistry/Services/DurableOutboxHostedService.cs
@@ -5,8 +5,7 @@ using TerraformRegistry.API.Logging;
 namespace TerraformRegistry.Services;
 
 public sealed class DurableOutboxHostedService(
-    IOutboxEventRepository repository,
-    IEnumerable<IOutboxDeliveryHandler> handlers,
+    DurableOutboxProcessor processor,
     IOptions<DurableOutboxOptions> options,
     ILogger<DurableOutboxHostedService> logger) : BackgroundService
 {
@@ -23,22 +22,15 @@ public sealed class DurableOutboxHostedService(
     {
         while (!stoppingToken.IsCancellationRequested)
         {
-            TerraformRegistry.Models.OutboxEvent? @event = null;
             try
             {
-                @event = await repository.TryClaimNextAsync(ownerId, TimeSpan.FromSeconds(options.LeaseSeconds), stoppingToken);
-                if (@event is null) { await Task.Delay(options.PollIntervalMilliseconds, stoppingToken); continue; }
-                var handler = handlers.FirstOrDefault(candidate => candidate.CanHandle(@event.Kind));
-                if (handler is null) throw new InvalidOperationException($"No durable outbox handler is registered for '{@event.Kind}'.");
-                await handler.HandleAsync(@event, stoppingToken);
-                await repository.TryCompleteAsync(@event.Id, ownerId, stoppingToken);
+                if (await processor.ProcessNextAsync(ownerId, stoppingToken)) continue;
+                await Task.Delay(options.PollIntervalMilliseconds, stoppingToken);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { return; }
             catch (Exception ex)
             {
                 RegistryLog.Error(logger, ex, "Durable outbox worker {OwnerId} failed to deliver an event.", ownerId);
-                if (@event is not null)
-                    await repository.TryFailAsync(@event.Id, ownerId, ex.Message, options.RetryLimit, stoppingToken);
                 await Task.Delay(options.PollIntervalMilliseconds, stoppingToken);
             }
         }

--- a/TerraformRegistry/Services/DurableOutboxHostedService.cs
+++ b/TerraformRegistry/Services/DurableOutboxHostedService.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Options;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.API.Logging;
+
+namespace TerraformRegistry.Services;
+
+public sealed class DurableOutboxHostedService(
+    IOutboxEventRepository repository,
+    IEnumerable<IOutboxDeliveryHandler> handlers,
+    IOptions<DurableOutboxOptions> options,
+    ILogger<DurableOutboxHostedService> logger) : BackgroundService
+{
+    private readonly DurableOutboxOptions options = options.Value;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var workers = Enumerable.Range(0, options.WorkerConcurrency)
+            .Select(index => RunWorkerAsync($"{Environment.MachineName}-{Environment.ProcessId}-outbox-{index}", stoppingToken));
+        await Task.WhenAll(workers);
+    }
+
+    private async Task RunWorkerAsync(string ownerId, CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            TerraformRegistry.Models.OutboxEvent? @event = null;
+            try
+            {
+                @event = await repository.TryClaimNextAsync(ownerId, TimeSpan.FromSeconds(options.LeaseSeconds), stoppingToken);
+                if (@event is null) { await Task.Delay(options.PollIntervalMilliseconds, stoppingToken); continue; }
+                var handler = handlers.FirstOrDefault(candidate => candidate.CanHandle(@event.Kind));
+                if (handler is null) throw new InvalidOperationException($"No durable outbox handler is registered for '{@event.Kind}'.");
+                await handler.HandleAsync(@event, stoppingToken);
+                await repository.TryCompleteAsync(@event.Id, ownerId, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { return; }
+            catch (Exception ex)
+            {
+                RegistryLog.Error(logger, ex, "Durable outbox worker {OwnerId} failed to deliver an event.", ownerId);
+                if (@event is not null)
+                    await repository.TryFailAsync(@event.Id, ownerId, ex.Message, options.RetryLimit, stoppingToken);
+                await Task.Delay(options.PollIntervalMilliseconds, stoppingToken);
+            }
+        }
+    }
+}

--- a/TerraformRegistry/Services/DurableOutboxOptions.cs
+++ b/TerraformRegistry/Services/DurableOutboxOptions.cs
@@ -1,0 +1,15 @@
+namespace TerraformRegistry.Services;
+
+public sealed class DurableOutboxOptions
+{
+    public int WorkerConcurrency { get; set; } = 2;
+    public int LeaseSeconds { get; set; } = 60;
+    public int RetryLimit { get; set; } = 5;
+    public int PollIntervalMilliseconds { get; set; } = 500;
+
+    public void Validate()
+    {
+        if (WorkerConcurrency <= 0 || LeaseSeconds <= 0 || RetryLimit <= 0 || PollIntervalMilliseconds <= 0)
+            throw new InvalidOperationException("Durable outbox worker limits must be greater than zero.");
+    }
+}

--- a/TerraformRegistry/Services/DurableOutboxProcessor.cs
+++ b/TerraformRegistry/Services/DurableOutboxProcessor.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Options;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.API.Logging;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Services;
+
+public sealed class DurableOutboxProcessor(
+    IOutboxEventRepository repository,
+    IEnumerable<IOutboxDeliveryHandler> handlers,
+    IOptions<DurableOutboxOptions> options,
+    ILogger<DurableOutboxProcessor> logger)
+{
+    private readonly DurableOutboxOptions options = options.Value;
+
+    public async Task<bool> ProcessNextAsync(string ownerId, CancellationToken cancellationToken)
+    {
+        OutboxEvent? @event = null;
+        try
+        {
+            @event = await repository.TryClaimNextAsync(ownerId, TimeSpan.FromSeconds(options.LeaseSeconds), cancellationToken);
+            if (@event is null) return false;
+
+            var handler = handlers.FirstOrDefault(candidate => candidate.CanHandle(@event.Kind));
+            if (handler is null) throw new InvalidOperationException($"No durable outbox handler is registered for '{@event.Kind}'.");
+
+            await handler.HandleAsync(@event, cancellationToken);
+            if (!await repository.TryCompleteAsync(@event.Id, ownerId, cancellationToken))
+                throw new InvalidOperationException("The durable outbox event lease was lost before it could be completed.");
+
+            return true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            RegistryLog.Error(logger, ex, "Durable outbox worker {OwnerId} failed to deliver an event.", ownerId);
+            if (@event is not null)
+            {
+                try
+                {
+                    if (!await repository.TryFailAsync(@event.Id, ownerId, ex.Message, options.RetryLimit, cancellationToken))
+                        RegistryLog.Warning(logger, "Durable outbox worker {OwnerId} lost the lease while recording a delivery failure.", ownerId);
+                }
+                catch (Exception retryEx) when (!cancellationToken.IsCancellationRequested)
+                {
+                    RegistryLog.Error(logger, retryEx, "Durable outbox worker {OwnerId} could not record a delivery failure.", ownerId);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/TerraformRegistry/Services/DurableOutboxProcessor.cs
+++ b/TerraformRegistry/Services/DurableOutboxProcessor.cs
@@ -34,6 +34,7 @@ public sealed class DurableOutboxProcessor(
         {
             throw;
         }
+        // lgtm[cs/catch-of-all-exceptions] Delivery handlers are extension points; every failure must be persisted for retry.
         catch (Exception ex)
         {
             RegistryLog.Error(logger, ex, "Durable outbox worker {OwnerId} failed to deliver an event.", ownerId);

--- a/TerraformRegistry/Services/ModuleDownloadAnalyticsHostedService.cs
+++ b/TerraformRegistry/Services/ModuleDownloadAnalyticsHostedService.cs
@@ -1,0 +1,39 @@
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.API.Logging;
+
+namespace TerraformRegistry.Services;
+
+public sealed class ModuleDownloadAnalyticsHostedService(
+    ModuleDownloadAnalyticsBuffer queue,
+    IDatabaseService databaseService,
+    ILogger<ModuleDownloadAnalyticsHostedService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var record in queue.ReadAllAsync(stoppingToken))
+        {
+            try
+            {
+                await databaseService.RecordDownloadAsync(
+                    record.Namespace,
+                    record.Name,
+                    record.Provider,
+                    record.Version,
+                    record.ClientIp,
+                    record.UserAgent);
+            }
+            catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
+            {
+                RegistryLog.Error(logger, ex,
+                    "Dropped download analytics record for {Namespace}/{Name}/{Provider}/{Version} after persistence failed.",
+                    record.Namespace, record.Name, record.Provider, record.Version);
+            }
+        }
+    }
+
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        queue.Complete();
+        return base.StopAsync(cancellationToken);
+    }
+}

--- a/TerraformRegistry/Services/ModuleDownloadAnalyticsQueue.cs
+++ b/TerraformRegistry/Services/ModuleDownloadAnalyticsQueue.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics.Metrics;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Microsoft.Extensions.Options;
+
+namespace TerraformRegistry.Services;
+
+public sealed record ModuleDownloadRecord(
+    string Namespace,
+    string Name,
+    string Provider,
+    string Version,
+    string? ClientIp,
+    string? UserAgent);
+
+public sealed class ModuleDownloadAnalyticsBuffer : IDisposable
+{
+    private readonly Channel<ModuleDownloadRecord> channel;
+    private readonly Meter meter = new("TerraformRegistry.Analytics");
+    private readonly Counter<long> dropped;
+
+    public ModuleDownloadAnalyticsBuffer(IOptions<DownloadAnalyticsOptions> options)
+    {
+        channel = Channel.CreateBounded<ModuleDownloadRecord>(new BoundedChannelOptions(options.Value.Capacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false
+        });
+        dropped = meter.CreateCounter<long>("terraform_registry.analytics.download_events_dropped");
+    }
+
+    public bool TryEnqueue(ModuleDownloadRecord record)
+    {
+        if (channel.Writer.TryWrite(record)) return true;
+
+        dropped.Add(1);
+        return false;
+    }
+
+    public async IAsyncEnumerable<ModuleDownloadRecord> ReadAllAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (var record in channel.Reader.ReadAllAsync(cancellationToken))
+            yield return record;
+    }
+
+    public void Complete() => channel.Writer.TryComplete();
+
+    public void Dispose()
+    {
+        Complete();
+        meter.Dispose();
+    }
+}

--- a/TerraformRegistry/Services/Publishing/ModulePublishCoordinator.cs
+++ b/TerraformRegistry/Services/Publishing/ModulePublishCoordinator.cs
@@ -67,7 +67,7 @@ public sealed class ModulePublishCoordinator(
                 request.Version);
         }
 
-        _ = auditService.LogAsync(
+        await auditService.LogAsync(
             request.ActorUserId,
             request.AuditAction,
             "module",

--- a/TerraformRegistry/Services/Publishing/ModulePublishCoordinator.cs
+++ b/TerraformRegistry/Services/Publishing/ModulePublishCoordinator.cs
@@ -39,13 +39,14 @@ public sealed class ModulePublishCoordinator(
         if (!uploaded)
             return false;
 
-        webhookDispatcher.FireEvent(
+        await webhookDispatcher.FireEventAsync(
             "module.published",
             request.Namespace,
             request.Name,
             request.Provider,
             request.Version,
-            request.Description);
+            request.Description,
+            cancellationToken);
 
         try
         {

--- a/TerraformRegistry/Services/Sqlite/SqliteOutboxEventRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteOutboxEventRepository.cs
@@ -1,0 +1,89 @@
+using Microsoft.Data.Sqlite;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Services.Sqlite;
+
+public sealed class SqliteOutboxEventRepository(string connectionString) : IOutboxEventRepository
+{
+    public async Task<bool> EnqueueAsync(OutboxEvent outboxEvent, CancellationToken cancellationToken = default)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO durable_outbox_events (id, kind, idempotency_key, payload_json, state, owner_id,
+                lease_expires_at, attempt_count, last_error, created_at, updated_at, delivered_at)
+            VALUES ($id, $kind, $idempotencyKey, $payloadJson, $state, NULL, NULL, 0, NULL, $createdAt, $updatedAt, NULL)
+            ON CONFLICT(idempotency_key) DO NOTHING
+            """;
+        command.Parameters.AddWithValue("$id", outboxEvent.Id.ToString());
+        command.Parameters.AddWithValue("$kind", outboxEvent.Kind);
+        command.Parameters.AddWithValue("$idempotencyKey", outboxEvent.IdempotencyKey);
+        command.Parameters.AddWithValue("$payloadJson", outboxEvent.PayloadJson);
+        command.Parameters.AddWithValue("$state", OutboxEventState.Pending);
+        command.Parameters.AddWithValue("$createdAt", outboxEvent.CreatedAt.ToString("O"));
+        command.Parameters.AddWithValue("$updatedAt", outboxEvent.UpdatedAt.ToString("O"));
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
+    }
+
+    public async Task<OutboxEvent?> TryClaimNextAsync(string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE durable_outbox_events SET state = $processing, owner_id = $ownerId, lease_expires_at = $leaseExpiresAt,
+                attempt_count = attempt_count + 1, updated_at = $updatedAt
+            WHERE id = (SELECT id FROM durable_outbox_events WHERE state IN ($pending, $retry)
+                OR (state = $processing AND lease_expires_at <= $now) ORDER BY created_at, id LIMIT 1)
+            RETURNING id, kind, idempotency_key, payload_json, state, owner_id, lease_expires_at, attempt_count,
+                last_error, created_at, updated_at, delivered_at
+            """;
+        command.Parameters.AddWithValue("$processing", OutboxEventState.Processing);
+        command.Parameters.AddWithValue("$ownerId", ownerId);
+        command.Parameters.AddWithValue("$leaseExpiresAt", now.Add(leaseDuration).ToString("O"));
+        command.Parameters.AddWithValue("$updatedAt", now.ToString("O"));
+        command.Parameters.AddWithValue("$pending", OutboxEventState.Pending);
+        command.Parameters.AddWithValue("$retry", OutboxEventState.Retry);
+        command.Parameters.AddWithValue("$now", now.ToString("O"));
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        return await reader.ReadAsync(cancellationToken) ? Read(reader) : null;
+    }
+
+    public Task<bool> TryCompleteAsync(Guid id, string ownerId, CancellationToken cancellationToken = default) => UpdateAsync(id, ownerId,
+        "UPDATE durable_outbox_events SET state = $delivered, owner_id = NULL, lease_expires_at = NULL, delivered_at = $now, updated_at = $now WHERE id = $id AND state = $processing AND owner_id = $ownerId", cancellationToken);
+
+    public Task<bool> TryFailAsync(Guid id, string ownerId, string failureReason, int maximumAttempts, CancellationToken cancellationToken = default) => UpdateAsync(id, ownerId,
+        "UPDATE durable_outbox_events SET state = CASE WHEN attempt_count >= $maximumAttempts THEN $deadLetter ELSE $retry END, owner_id = NULL, lease_expires_at = NULL, last_error = $failureReason, updated_at = $now WHERE id = $id AND state = $processing AND owner_id = $ownerId", cancellationToken, failureReason, maximumAttempts);
+
+    private async Task<bool> UpdateAsync(Guid id, string ownerId, string sql, CancellationToken cancellationToken, string? failureReason = null, int maximumAttempts = 0)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand(); command.CommandText = sql;
+        command.Parameters.AddWithValue("$id", id.ToString()); command.Parameters.AddWithValue("$ownerId", ownerId);
+        command.Parameters.AddWithValue("$processing", OutboxEventState.Processing); command.Parameters.AddWithValue("$now", DateTime.UtcNow.ToString("O"));
+        command.Parameters.AddWithValue("$delivered", OutboxEventState.Delivered); command.Parameters.AddWithValue("$retry", OutboxEventState.Retry);
+        command.Parameters.AddWithValue("$deadLetter", OutboxEventState.DeadLetter); command.Parameters.AddWithValue("$maximumAttempts", maximumAttempts);
+        command.Parameters.AddWithValue("$failureReason", (object?)failureReason ?? DBNull.Value);
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
+    }
+
+    private static OutboxEvent Read(SqliteDataReader reader) => new()
+    {
+        Id = Guid.Parse(reader.GetString(0)),
+        Kind = reader.GetString(1),
+        IdempotencyKey = reader.GetString(2),
+        PayloadJson = reader.GetString(3),
+        State = reader.GetString(4),
+        OwnerId = reader.IsDBNull(5) ? null : reader.GetString(5),
+        LeaseExpiresAt = reader.IsDBNull(6) ? null : DateTime.Parse(reader.GetString(6), null, System.Globalization.DateTimeStyles.RoundtripKind),
+        AttemptCount = reader.GetInt32(7),
+        LastError = reader.IsDBNull(8) ? null : reader.GetString(8),
+        CreatedAt = DateTime.Parse(reader.GetString(9), null, System.Globalization.DateTimeStyles.RoundtripKind),
+        UpdatedAt = DateTime.Parse(reader.GetString(10), null, System.Globalization.DateTimeStyles.RoundtripKind),
+        DeliveredAt = reader.IsDBNull(11) ? null : DateTime.Parse(reader.GetString(11), null, System.Globalization.DateTimeStyles.RoundtripKind)
+    };
+}

--- a/TerraformRegistry/Services/SqliteAuditService.cs
+++ b/TerraformRegistry/Services/SqliteAuditService.cs
@@ -7,7 +7,7 @@ using TerraformRegistry.API.Logging;
 
 namespace TerraformRegistry.Services;
 
-public class SqliteAuditService : IAuditService
+public class SqliteAuditService : IAuditLogStore
 {
     private readonly string _connectionString;
     private readonly ILogger<SqliteAuditService> _logger;
@@ -45,6 +45,7 @@ public class SqliteAuditService : IAuditService
         catch (Exception ex)
         {
             RegistryLog.Error(_logger, ex, "Failed to write audit log entry for action {Action}", action);
+            throw;
         }
     }
 

--- a/TerraformRegistry/Services/WebhookDispatcher.cs
+++ b/TerraformRegistry/Services/WebhookDispatcher.cs
@@ -8,58 +8,48 @@ namespace TerraformRegistry.Services;
 
 public class WebhookDispatcher(
     IWebhookService webhookService,
+    IOutboxEventRepository outboxRepository,
     IHttpClientFactory httpClientFactory,
     IConfiguration configuration,
     WebhookUrlValidator webhookUrlValidator,
     ILogger<WebhookDispatcher> logger)
 {
-    public void FireEvent(string eventType, string @namespace, string name, string provider, string version, string? description)
+    public Task FireEventAsync(string eventType, string @namespace, string name, string provider, string version, string? description,
+        CancellationToken cancellationToken = default)
     {
-        _ = Task.Run(async () =>
+        var payload = new WebhookOutboxPayload("wh_" + Guid.NewGuid().ToString("N"), eventType, @namespace, name, provider, version, description);
+        var now = DateTime.UtcNow;
+        return outboxRepository.EnqueueAsync(new OutboxEvent
         {
-            try
-            {
-                var webhooks = await webhookService.GetActiveWebhooksForEventAsync(eventType);
+            Id = Guid.NewGuid(),
+            Kind = WebhookOutboxDeliveryHandler.Kind,
+            IdempotencyKey = $"webhook:{payload.Id}",
+            PayloadJson = System.Text.Json.JsonSerializer.Serialize(payload),
+            State = OutboxEventState.Pending,
+            CreatedAt = now,
+            UpdatedAt = now
+        }, cancellationToken);
+    }
 
-                var baseUrl = configuration["BaseUrl"]?.TrimEnd('/') ?? string.Empty;
-                var action = eventType.Contains('.', StringComparison.Ordinal) ? eventType[(eventType.LastIndexOf('.') + 1)..] : eventType;
+    public async Task DeliverAsync(WebhookOutboxPayload payload, CancellationToken cancellationToken)
+    {
+        var webhooks = await webhookService.GetActiveWebhooksForEventAsync(payload.EventType);
 
-                var eventData = new WebhookEventData(
-                    Id: "wh_" + Guid.NewGuid().ToString("N"),
-                    Event: eventType,
-                    Action: action,
-                    Timestamp: DateTime.UtcNow.ToString("o"),
-                    Module: new WebhookModuleData(
-                        Namespace: @namespace,
-                        Name: name,
-                        Provider: provider,
-                        Version: version,
-                        Description: description,
-                        Source: $"{baseUrl}/{@namespace}/{name}/{provider}",
-                        DownloadUrl: $"/v1/modules/{@namespace}/{name}/{provider}/{version}/download"));
+        var baseUrl = configuration["BaseUrl"]?.TrimEnd('/') ?? string.Empty;
+        var action = payload.EventType.Contains('.', StringComparison.Ordinal) ? payload.EventType[(payload.EventType.LastIndexOf('.') + 1)..] : payload.EventType;
 
-                var client = httpClientFactory.CreateClient("WebhookDelivery");
+        var eventData = new WebhookEventData(payload.Id, payload.EventType, action, DateTime.UtcNow.ToString("o"),
+            new WebhookModuleData(payload.Namespace, payload.Name, payload.Provider, payload.Version, payload.Description,
+                $"{baseUrl}/{payload.Namespace}/{payload.Name}/{payload.Provider}",
+                $"/v1/modules/{payload.Namespace}/{payload.Name}/{payload.Provider}/{payload.Version}/download"));
 
-                var deliveryTasks = webhooks.Select(async webhook =>
-                {
-                    try
-                    {
-                        var formatter = GetFormatter(webhook.Format);
-                        var payload = formatter.FormatPayload(eventData, webhook.Template);
-                        await DeliverAsync(client, webhook.Url, webhook.Secret, payload, eventData.Id, eventType);
-                    }
-                    catch (Exception ex)
-                    {
-                        RegistryLog.Error(logger, ex, "Failed to deliver webhook {WebhookId} to {Url}", webhook.Id, webhook.Url);
-                    }
-                });
-                await Task.WhenAll(deliveryTasks);
-            }
-            catch (Exception ex)
-            {
-                RegistryLog.Error(logger, ex, "Failed to fire webhook event {EventType}", eventType);
-            }
-        });
+        var client = httpClientFactory.CreateClient("WebhookDelivery");
+        foreach (var webhook in webhooks)
+        {
+            var formatter = GetFormatter(webhook.Format);
+            var body = formatter.FormatPayload(eventData, webhook.Template);
+            await DeliverAsync(client, webhook.Url, webhook.Secret, body, eventData.Id, payload.EventType, cancellationToken);
+        }
     }
 
     public async Task<(bool Success, string? Error)> SendTestAsync(Webhook webhook)
@@ -107,9 +97,9 @@ public class WebhookDispatcher(
     private static IWebhookFormatter GetFormatter(string format) =>
         Formatters.GetValueOrDefault(format, Formatters["generic"]);
 
-    private async Task DeliverAsync(HttpClient client, string url, string? secret, string payload, string webhookId, string eventType)
+    private async Task DeliverAsync(HttpClient client, string url, string? secret, string payload, string webhookId, string eventType, CancellationToken cancellationToken = default)
     {
-        var validatedEndpoint = await webhookUrlValidator.ValidateOutboundWebhookUrlAsync(url, CancellationToken.None);
+        var validatedEndpoint = await webhookUrlValidator.ValidateOutboundWebhookUrlAsync(url, cancellationToken);
 
         using var request = new HttpRequestMessage(HttpMethod.Post, validatedEndpoint.Uri)
         {
@@ -126,7 +116,7 @@ public class WebhookDispatcher(
             request.Headers.Add("X-Signature-256", $"sha256={signature}");
         }
 
-        using var response = await client.SendAsync(request);
+        using var response = await client.SendAsync(request, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
 
@@ -138,3 +128,5 @@ public class WebhookDispatcher(
         return Convert.ToHexStringLower(hash);
     }
 }
+
+public sealed record WebhookOutboxPayload(string Id, string EventType, string Namespace, string Name, string Provider, string Version, string? Description);

--- a/TerraformRegistry/Services/WebhookDispatcher.cs
+++ b/TerraformRegistry/Services/WebhookDispatcher.cs
@@ -14,12 +14,12 @@ public class WebhookDispatcher(
     WebhookUrlValidator webhookUrlValidator,
     ILogger<WebhookDispatcher> logger)
 {
-    public Task FireEventAsync(string eventType, string @namespace, string name, string provider, string version, string? description,
+    public async Task FireEventAsync(string eventType, string @namespace, string name, string provider, string version, string? description,
         CancellationToken cancellationToken = default)
     {
         var payload = new WebhookOutboxPayload("wh_" + Guid.NewGuid().ToString("N"), eventType, @namespace, name, provider, version, description);
         var now = DateTime.UtcNow;
-        return outboxRepository.EnqueueAsync(new OutboxEvent
+        var enqueued = await outboxRepository.EnqueueAsync(new OutboxEvent
         {
             Id = Guid.NewGuid(),
             Kind = WebhookOutboxDeliveryHandler.Kind,
@@ -29,6 +29,7 @@ public class WebhookDispatcher(
             CreatedAt = now,
             UpdatedAt = now
         }, cancellationToken);
+        if (!enqueued) throw new InvalidOperationException("The webhook event could not be persisted to the durable outbox.");
     }
 
     public async Task DeliverAsync(WebhookOutboxPayload payload, CancellationToken cancellationToken)

--- a/TerraformRegistry/Services/WebhookOutboxDeliveryHandler.cs
+++ b/TerraformRegistry/Services/WebhookOutboxDeliveryHandler.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Services;
+
+public sealed class WebhookOutboxDeliveryHandler(WebhookDispatcher dispatcher) : IOutboxDeliveryHandler
+{
+    public const string Kind = "webhook";
+
+    public bool CanHandle(string kind) => string.Equals(kind, Kind, StringComparison.Ordinal);
+
+    public async Task HandleAsync(OutboxEvent outboxEvent, CancellationToken cancellationToken)
+    {
+        var payload = JsonSerializer.Deserialize<WebhookOutboxPayload>(outboxEvent.PayloadJson)
+            ?? throw new InvalidOperationException("Durable webhook event payload is invalid.");
+        await dispatcher.DeliverAsync(payload, cancellationToken);
+    }
+}

--- a/TerraformRegistry/Startup/EndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/EndpointMappingExtensions.cs
@@ -100,8 +100,8 @@ internal static class EndpointMappingExtensions
             .WithTags("Authentication")
             .WithDescription("Checks if user has a valid session");
 
-        app.MapGet("/api/auth/terraform/authorize", (HttpContext context) =>
-                AuthHandlers.BeginTerraformAuthorization(context))
+        app.MapGet("/api/auth/terraform/authorize",
+                (Func<HttpContext, Task<IResult>>)AuthHandlers.BeginTerraformAuthorization)
             .WithTags("Authentication")
             .WithDescription("Begins Terraform CLI OAuth authorization flow");
 

--- a/TerraformRegistry/Startup/ModuleEndpointMappingExtensions.cs
+++ b/TerraformRegistry/Startup/ModuleEndpointMappingExtensions.cs
@@ -50,8 +50,8 @@ internal static class ModuleEndpointMappingExtensions
 
         app.MapGet("/v1/modules/{namespace}/{name}/{provider}/{version}/download",
                 (string @namespace, string name, string provider, string version, IModuleService moduleService,
-                        IModuleMirrorService moduleMirrorService, IDatabaseService dbService, HttpContext context) =>
-                    ModuleHandlers.DownloadModule(@namespace, name, provider, version, moduleService, moduleMirrorService, dbService,
+                        IModuleMirrorService moduleMirrorService, ModuleDownloadAnalyticsBuffer downloadAnalytics, HttpContext context) =>
+                    ModuleHandlers.DownloadModule(@namespace, name, provider, version, moduleService, moduleMirrorService, downloadAnalytics,
                         context))
             .WithTags("Modules")
             .WithDescription("Downloads a specific module version")
@@ -60,8 +60,8 @@ internal static class ModuleEndpointMappingExtensions
 
         app.MapGet("/v1/modules/{namespace}/{name}/{provider}/download",
                 (string @namespace, string name, string provider, IModuleService moduleService,
-                        IModuleMirrorService moduleMirrorService, IDatabaseService dbService, HttpContext context) =>
-                    ModuleHandlers.DownloadLatestModule(@namespace, name, provider, moduleService, moduleMirrorService, dbService, context))
+                        IModuleMirrorService moduleMirrorService, ModuleDownloadAnalyticsBuffer downloadAnalytics, HttpContext context) =>
+                    ModuleHandlers.DownloadLatestModule(@namespace, name, provider, moduleService, moduleMirrorService, downloadAnalytics, context))
             .WithTags("Modules")
             .WithDescription("Downloads the latest version of a module for a provider")
             .Produces(302)

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -29,6 +29,14 @@ internal static class ServiceRegistrationExtensions
         services.AddSingleton<ArtifactDownloadTokenService>();
         services.Configure<DatabaseRetryOptions>(configuration.GetSection("DatabaseRetry"));
         services.Configure<WebhookSecurityOptions>(configuration.GetSection("WebhookSecurity"));
+        services.AddOptions<DurableOutboxOptions>()
+            .Bind(configuration.GetSection("DurableOutbox"))
+            .Validate(options =>
+            {
+                try { options.Validate(); return true; }
+                catch (InvalidOperationException) { return false; }
+            }, "Durable outbox worker limits must be greater than zero.")
+            .ValidateOnStart();
         services.AddOptions<ModuleExtractionOptions>()
             .Bind(configuration.GetSection("ModuleExtraction"))
             .Validate(options =>
@@ -172,6 +180,7 @@ internal static class ServiceRegistrationExtensions
 
         services.AddAnalyticsService();
         services.AddDurableOutboxServices();
+        services.AddHostedService<DurableOutboxHostedService>();
         services.AddWebhookServices();
         services.AddVcsServices();
         services.AddMirrorServices();

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -375,6 +375,7 @@ internal static class ServiceRegistrationExtensions
                 _ => throw new InvalidOperationException($"Invalid database provider: '{databaseProvider}'")
             };
         });
+        services.AddSingleton<IOutboxDeliveryHandler, AuditOutboxDeliveryHandler>();
 
         return services;
     }

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -37,6 +37,14 @@ internal static class ServiceRegistrationExtensions
                 catch (InvalidOperationException) { return false; }
             }, "Durable outbox worker limits must be greater than zero.")
             .ValidateOnStart();
+        services.AddOptions<DownloadAnalyticsOptions>()
+            .Bind(configuration.GetSection(DownloadAnalyticsOptions.SectionName))
+            .Validate(options =>
+            {
+                try { options.Validate(); return true; }
+                catch (InvalidOperationException) { return false; }
+            }, "Download analytics queue capacity must be greater than zero.")
+            .ValidateOnStart();
         services.AddOptions<ModuleExtractionOptions>()
             .Bind(configuration.GetSection("ModuleExtraction"))
             .Validate(options =>
@@ -179,7 +187,10 @@ internal static class ServiceRegistrationExtensions
         services.AddScoped<IApiKeyService, ApiKeyService>();
 
         services.AddAnalyticsService();
+        services.AddSingleton<ModuleDownloadAnalyticsBuffer>();
+        services.AddHostedService<ModuleDownloadAnalyticsHostedService>();
         services.AddDurableOutboxServices();
+        services.AddSingleton<DurableOutboxProcessor>();
         services.AddHostedService<DurableOutboxHostedService>();
         services.AddWebhookServices();
         services.AddVcsServices();
@@ -556,7 +567,7 @@ internal static class ServiceRegistrationExtensions
             };
         });
 
-        services.AddSingleton<IAuditService>(provider =>
+        services.AddSingleton<IAuditLogStore>(provider =>
         {
             var config = provider.GetRequiredService<IConfiguration>();
             var databaseProvider = config["DatabaseProvider"]?.ToLowerInvariant() ?? "sqlite";
@@ -572,6 +583,7 @@ internal static class ServiceRegistrationExtensions
                 _ => throw new InvalidOperationException($"Invalid database provider: '{databaseProvider}'")
             };
         });
+        services.AddSingleton<IAuditService, DurableAuditService>();
 
         return services;
     }

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -376,6 +376,7 @@ internal static class ServiceRegistrationExtensions
             };
         });
         services.AddSingleton<IOutboxDeliveryHandler, AuditOutboxDeliveryHandler>();
+        services.AddSingleton<IOutboxDeliveryHandler, WebhookOutboxDeliveryHandler>();
 
         return services;
     }

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -171,6 +171,7 @@ internal static class ServiceRegistrationExtensions
         services.AddScoped<IApiKeyService, ApiKeyService>();
 
         services.AddAnalyticsService();
+        services.AddDurableOutboxServices();
         services.AddWebhookServices();
         services.AddVcsServices();
         services.AddMirrorServices();
@@ -344,6 +345,24 @@ internal static class ServiceRegistrationExtensions
                     config["PostgreSQL:ConnectionString"]
                     ?? throw new InvalidOperationException("PostgreSQL connection string is missing for analytics service.")),
                 "sqlite" => new SqliteAnalyticsService(config["Sqlite:ConnectionString"] ?? "Data Source=terraform.db"),
+                _ => throw new InvalidOperationException($"Invalid database provider: '{databaseProvider}'")
+            };
+        });
+
+        return services;
+    }
+
+    private static IServiceCollection AddDurableOutboxServices(this IServiceCollection services)
+    {
+        services.AddSingleton<IOutboxEventRepository>(provider =>
+        {
+            var config = provider.GetRequiredService<IConfiguration>();
+            var databaseProvider = config["DatabaseProvider"]?.ToLowerInvariant() ?? "sqlite";
+            return databaseProvider switch
+            {
+                "postgres" => new PostgreSqlOutboxEventRepository(config["PostgreSQL:ConnectionString"]
+                    ?? throw new InvalidOperationException("PostgreSQL connection string is missing for durable outbox.")),
+                "sqlite" => new SqliteOutboxEventRepository(config["Sqlite:ConnectionString"] ?? "Data Source=terraform.db"),
                 _ => throw new InvalidOperationException($"Invalid database provider: '{databaseProvider}'")
             };
         });


### PR DESCRIPTION
## Summary
- persist audit and webhook delivery through leased durable outbox workers
- make download analytics bounded and observable instead of detached work
- add outbox delivery, audit, webhook, and analytics coverage

## Verification
- dotnet build terraform-registry.sln --no-restore
- dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-build (712 passed)