### PR TITLE
feat: add safe HTTP delivery policies

### DIFF
--- a/TerraformRegistry.Tests/IntegrationTests/HttpDeliveryPolicyTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/HttpDeliveryPolicyTests.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Tests.IntegrationTests;
+
+public sealed class HttpDeliveryPolicyTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), $"tf-reg-delivery-{Guid.NewGuid():N}");
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public HttpDeliveryPolicyTests()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureAppConfiguration((_, config) => config.AddInMemoryCollection(
+                new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["AuthorizationToken"] = "http-delivery-test-token",
+                    ["DatabaseProvider"] = "sqlite",
+                    ["Sqlite:ConnectionString"] = $"Data Source={Path.Combine(_tempDirectory, "registry.db")}",
+                    ["StorageProvider"] = "local",
+                    ["ModuleStoragePath"] = Path.Combine(_tempDirectory, "modules"),
+                    ["ProviderStoragePath"] = Path.Combine(_tempDirectory, "providers"),
+                    ["Oidc:JwtSecretKey"] = "http-delivery-test-jwt-secret-key-32-chars-minimum"
+                }));
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<OidcOptions>();
+                services.AddSingleton(new OidcOptions
+                {
+                    JwtSecretKey = "http-delivery-test-jwt-secret-key-32-chars-minimum",
+                    JwtExpiryHours = 24
+                });
+            });
+        });
+    }
+
+    [Fact]
+    public async Task FingerprintedFrontendAssetIsCompressedAndCachedImmutably()
+    {
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            HandleCookies = false
+        });
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Accept-Encoding", "gzip");
+
+        using var response = await client.GetAsync("/_nuxt/8_MDK3Q6.js", HttpCompletionOption.ResponseHeadersRead);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("gzip", Assert.Single(response.Content.Headers.ContentEncoding));
+        Assert.True(response.Headers.CacheControl?.Public);
+        Assert.Equal(TimeSpan.FromDays(365), response.Headers.CacheControl?.MaxAge);
+        Assert.Contains(response.Headers.CacheControl?.Extensions ?? [], extension =>
+            string.Equals(extension.Name, "immutable", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ApiResponsesAreNeverCacheable()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.GetAsync("/v1/modules");
+
+        Assert.Contains("no-store", response.Headers.CacheControl?.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task FingerprintedFrontendAssetSupportsBrotli()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Accept-Encoding", "br");
+
+        using var response = await client.GetAsync("/_nuxt/8_MDK3Q6.js", HttpCompletionOption.ResponseHeadersRead);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("br", Assert.Single(response.Content.Headers.ContentEncoding));
+    }
+
+    public void Dispose()
+    {
+        _factory.Dispose();
+        Directory.Delete(_tempDirectory, recursive: true);
+    }
+}

--- a/TerraformRegistry.Tests/IntegrationTests/HttpDeliveryPolicyTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/HttpDeliveryPolicyTests.cs
@@ -10,13 +10,19 @@ namespace TerraformRegistry.Tests.IntegrationTests;
 
 public sealed class HttpDeliveryPolicyTests : IDisposable
 {
-    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), $"tf-reg-delivery-{Guid.NewGuid():N}");
+    private readonly string _tempDirectory = Path.GetTempFileName();
     private readonly WebApplicationFactory<Program> _factory;
 
     public HttpDeliveryPolicyTests()
     {
+        File.Delete(_tempDirectory);
         Directory.CreateDirectory(_tempDirectory);
-        _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        _factory = new DeliveryPolicyFactory(_tempDirectory);
+    }
+
+    private sealed class DeliveryPolicyFactory(string tempDirectory) : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             builder.UseEnvironment("Test");
             builder.ConfigureAppConfiguration((_, config) => config.AddInMemoryCollection(
@@ -24,10 +30,10 @@ public sealed class HttpDeliveryPolicyTests : IDisposable
                 {
                     ["AuthorizationToken"] = "http-delivery-test-token",
                     ["DatabaseProvider"] = "sqlite",
-                    ["Sqlite:ConnectionString"] = $"Data Source={Path.Combine(_tempDirectory, "registry.db")}",
+                    ["Sqlite:ConnectionString"] = $"Data Source={Path.Join(tempDirectory, "registry.db")}",
                     ["StorageProvider"] = "local",
-                    ["ModuleStoragePath"] = Path.Combine(_tempDirectory, "modules"),
-                    ["ProviderStoragePath"] = Path.Combine(_tempDirectory, "providers"),
+                    ["ModuleStoragePath"] = Path.Join(tempDirectory, "modules"),
+                    ["ProviderStoragePath"] = Path.Join(tempDirectory, "providers"),
                     ["Oidc:JwtSecretKey"] = "http-delivery-test-jwt-secret-key-32-chars-minimum"
                 }));
             builder.ConfigureServices(services =>
@@ -39,7 +45,7 @@ public sealed class HttpDeliveryPolicyTests : IDisposable
                     JwtExpiryHours = 24
                 });
             });
-        });
+        }
     }
 
     [Fact]

--- a/TerraformRegistry/Program.cs
+++ b/TerraformRegistry/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.FileProviders;
 using System.Net;
 using NSwag;
@@ -28,6 +29,12 @@ builder.Configuration
     .AddEnvironmentVariables("TF_REG_");
 
 builder.Services.AddTerraformRegistryServices(builder.Configuration);
+builder.Services.AddResponseCompression(options =>
+{
+    options.EnableForHttps = true;
+    options.Providers.Add<BrotliCompressionProvider>();
+    options.Providers.Add<GzipCompressionProvider>();
+});
 
 var enableSwagger = false;
 var enableSwaggerConfig = builder.Configuration["EnableSwagger"];
@@ -105,13 +112,25 @@ app.UseHttpsRedirection();
 // Add global exception handling middleware early in the pipeline
 app.UseMiddleware<GlobalExceptionMiddleware>();
 
-var webFolderPath = Path.Combine(Directory.GetCurrentDirectory(), "web");
+app.UseResponseCompression();
+app.Use(async (context, next) =>
+{
+    context.Response.Headers.CacheControl = "no-store";
+    await next(context);
+});
+
+var webFolderPath = Path.Combine(app.Environment.ContentRootPath, "web");
 if (Directory.Exists(webFolderPath))
 {
     app.UseStaticFiles(new StaticFileOptions
     {
         FileProvider = new PhysicalFileProvider(webFolderPath),
-        RequestPath = ""
+        RequestPath = "",
+        OnPrepareResponse = context =>
+        {
+            if (IsFingerprintedFrontendAsset(context.Context.Request.Path))
+                context.Context.Response.Headers.CacheControl = "public,max-age=31536000,immutable";
+        }
     });
 }
 
@@ -196,5 +215,15 @@ app.MapFallback(async context =>
 });
 
 app.Run($"http://0.0.0.0:{portNumber}");
+
+static bool IsFingerprintedFrontendAsset(PathString requestPath)
+{
+    if (!requestPath.StartsWithSegments("/_nuxt") && !requestPath.StartsWithSegments("/_fonts"))
+        return false;
+
+    var fingerprint = Path.GetFileNameWithoutExtension(requestPath.Value ?? string.Empty);
+    return fingerprint.Length >= 8 && fingerprint.All(character =>
+        char.IsAsciiLetterOrDigit(character) || character is '-' or '_');
+}
 
 public partial class Program;


### PR DESCRIPTION
## Summary
- negotiate Brotli and gzip responses
- cache fingerprinted frontend assets immutably
- prevent API and application responses from being cached

## Verification
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --logger "console;verbosity=minimal"` (715 passed)
- `dotnet build TerraformRegistry/TerraformRegistry.csproj --no-restore`