### PR TITLE
feat: add browser security headers

### DIFF
--- a/TerraformRegistry.Tests/IntegrationTests/BrowserSecurityHeaderTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/BrowserSecurityHeaderTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace TerraformRegistry.Tests.IntegrationTests;
+
+public sealed class BrowserSecurityHeaderTests
+{
+    [Fact]
+    public async Task ApiResponseIncludesBaselineBrowserSecurityHeaders()
+    {
+        using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(
+                new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["AuthorizationToken"] = "browser-security-test-token",
+                    ["Sqlite:ConnectionString"] = "Data Source=/tmp/terraform-registry-browser-security-tests.db"
+                }));
+        });
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/api/missing");
+
+        Assert.Equal("nosniff", response.Headers.GetValues("X-Content-Type-Options").Single());
+        Assert.Equal("DENY", response.Headers.GetValues("X-Frame-Options").Single());
+        Assert.Equal("strict-origin-when-cross-origin", response.Headers.GetValues("Referrer-Policy").Single());
+        Assert.Contains("default-src 'self'", response.Headers.GetValues("Content-Security-Policy").Single());
+        Assert.Equal("camera=(), microphone=(), geolocation=()", response.Headers.GetValues("Permissions-Policy").Single());
+    }
+}

--- a/TerraformRegistry.Tests/IntegrationTests/BrowserSecurityHeaderTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/BrowserSecurityHeaderTests.cs
@@ -9,7 +9,8 @@ public sealed class BrowserSecurityHeaderTests
     [Fact]
     public async Task ApiResponseIncludesBaselineBrowserSecurityHeaders()
     {
-        using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        using var baseFactory = new WebApplicationFactory<Program>();
+        using var factory = baseFactory.WithWebHostBuilder(builder =>
         {
             builder.UseEnvironment("Development");
             builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(

--- a/TerraformRegistry/Program.cs
+++ b/TerraformRegistry/Program.cs
@@ -109,12 +109,20 @@ if (!string.IsNullOrWhiteSpace(trustedProxies))
 
 app.UseHttpsRedirection();
 
+if (app.Environment.IsProduction())
+    app.UseHsts();
+
 // Add global exception handling middleware early in the pipeline
 app.UseMiddleware<GlobalExceptionMiddleware>();
 
 app.UseResponseCompression();
 app.Use(async (context, next) =>
 {
+    context.Response.Headers["Content-Security-Policy"] = "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'";
+    context.Response.Headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()";
+    context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+    context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+    context.Response.Headers["X-Frame-Options"] = "DENY";
     context.Response.Headers.CacheControl = "no-store";
     await next(context);
 });


### PR DESCRIPTION
## Summary
- add production HSTS and baseline browser security headers
- add CSP compatible with generated frontend assets and OIDC flows

## Verification
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --filter FullyQualifiedName~BrowserSecurityHeaderTests --no-restore`
- `dotnet build TerraformRegistry/TerraformRegistry.csproj --no-restore`