### PR TITLE
fix: configure browser security test storage

### DIFF
--- a/TerraformRegistry.Tests/IntegrationTests/BrowserSecurityHeaderTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/BrowserSecurityHeaderTests.cs
@@ -17,6 +17,7 @@ public sealed class BrowserSecurityHeaderTests
                 new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
                 {
                     ["AuthorizationToken"] = "browser-security-test-token",
+                    ["DatabaseProvider"] = "sqlite",
                     ["Sqlite:ConnectionString"] = "Data Source=/tmp/terraform-registry-browser-security-tests.db"
                 }));
         });


### PR DESCRIPTION
Configures the browser-security integration fixture to use its declared SQLite connection rather than the PostgreSQL default, preventing CI from attempting a local PostgreSQL connection.