### PR TITLE
refactor: propagate request cancellation

### DIFF
--- a/TerraformRegistry.API/Interfaces/IProviderRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IProviderRepository.cs
@@ -14,7 +14,8 @@ public interface IProviderRepository
     Task<IReadOnlyList<ProviderVersionEntry>> GetProviderVersionsAsync(string providerNamespace, string type);
     Task<IReadOnlyList<ProviderManagementVersionEntry>> GetProviderManagementVersionsAsync(string providerNamespace, string type);
     Task<ProviderVersion?> GetProviderVersionAsync(string providerNamespace, string type, string version);
-    Task<ProviderPackageDetails?> GetProviderPackageDetailsAsync(string providerNamespace, string type, string version, string os, string arch);
+    Task<ProviderPackageDetails?> GetProviderPackageDetailsAsync(string providerNamespace, string type, string version, string os,
+        string arch, CancellationToken cancellationToken);
     Task<ProviderVersion> CreateProviderVersionAsync(Guid providerId, string version, string[] protocols, string keyId);
     Task<bool> SetVersionShasumsPathAsync(Guid versionId, string storagePath);
     Task<bool> SetVersionShasumsSignaturePathAsync(Guid versionId, string storagePath);
@@ -34,5 +35,5 @@ public interface IProviderRepository
     Task<bool> RevokeGpgKeyAsync(string providerNamespace, string keyId);
 
     Task RecordProviderDownloadAsync(Guid? providerId, string providerNamespace, string type, string version, string os,
-        string arch, string? clientIp, string? userAgent);
+        string arch, string? clientIp, string? userAgent, CancellationToken cancellationToken);
 }

--- a/TerraformRegistry.PostgreSQL/PostgreSqlProviderRepository.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSqlProviderRepository.cs
@@ -251,9 +251,10 @@ public sealed class PostgreSqlProviderRepository : IProviderRepository
         return await reader.ReadAsync() ? MapVersion(reader) : null;
     }
 
-    public async Task<ProviderPackageDetails?> GetProviderPackageDetailsAsync(string providerNamespace, string type, string version, string os, string arch)
+    public async Task<ProviderPackageDetails?> GetProviderPackageDetailsAsync(string providerNamespace, string type, string version,
+        string os, string arch, CancellationToken cancellationToken)
     {
-        await using var connection = await OpenConnectionAsync();
+        await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = new NpgsqlCommand(@"
             SELECT p.id, pv.protocols::text, pv.key_id, pv.shasums_storage_path, pv.shasums_signature_storage_path,
                    pp.os, pp.arch, pp.filename, pp.shasum, pp.package_storage_path,
@@ -270,8 +271,8 @@ public sealed class PostgreSqlProviderRepository : IProviderRepository
         command.Parameters.AddWithValue("@os", os);
         command.Parameters.AddWithValue("@arch", arch);
 
-        await using var reader = await command.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return null;
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken)) return null;
         if (reader.IsDBNull(3) || reader.IsDBNull(4) || reader.IsDBNull(9)) return null;
         return new ProviderPackageDetails(reader.GetGuid(0), DeserializeProtocols(reader.GetString(1)), reader.GetString(2),
             reader.GetString(3), reader.GetString(4), reader.GetString(5), reader.GetString(6), reader.GetString(7), reader.GetString(8),
@@ -604,9 +605,9 @@ public sealed class PostgreSqlProviderRepository : IProviderRepository
     }
 
     public async Task RecordProviderDownloadAsync(Guid? providerId, string providerNamespace, string type, string version, string os,
-        string arch, string? clientIp, string? userAgent)
+        string arch, string? clientIp, string? userAgent, CancellationToken cancellationToken)
     {
-        await using var connection = await OpenConnectionAsync();
+        await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = new NpgsqlCommand(@"
             INSERT INTO provider_downloads (provider_id, namespace, type, version, os, arch, download_time, client_ip, user_agent)
             VALUES (@providerId, @providerNamespace, @type, @version, @os, @arch, @downloadTime, @clientIp, @userAgent)", connection);
@@ -619,7 +620,7 @@ public sealed class PostgreSqlProviderRepository : IProviderRepository
         command.Parameters.AddWithValue("@downloadTime", DateTime.UtcNow);
         command.Parameters.AddWithValue("@clientIp", DbValue(clientIp));
         command.Parameters.AddWithValue("@userAgent", DbValue(userAgent));
-        await command.ExecuteNonQueryAsync();
+        await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     private async Task<bool> UpdateSinglePathAsync(string table, string column, string idColumn, Guid id, string storagePath)
@@ -678,6 +679,13 @@ public sealed class PostgreSqlProviderRepository : IProviderRepository
     {
         var connection = new NpgsqlConnection(_connectionString);
         await connection.OpenAsync();
+        return connection;
+    }
+
+    private async Task<NpgsqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken);
         return connection;
     }
 

--- a/TerraformRegistry.Tests/UnitTests/ModuleExtractionServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleExtractionServiceTests.cs
@@ -224,4 +224,57 @@ public class ModuleExtractionServiceTests
                 Assert.Equal("tool missing", failed.Extraction.Error);
             });
     }
+
+    [Fact]
+    public async Task ExtractAsyncDoesNotPersistResultsWhenCancellationIsRequestedDuringInspection()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var moduleService = new Mock<IModuleService>(MockBehavior.Strict);
+        moduleService
+            .Setup(x => x.OpenModulePackageStreamAsync("acme", "network", "aws", "1.2.3"))
+            .ReturnsAsync(new MemoryStream([1, 2, 3]));
+
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"module-extraction-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+
+        var workspaceFactory = new Mock<IArchiveWorkspaceFactory>(MockBehavior.Strict);
+        workspaceFactory
+            .Setup(x => x.CreateAsync(It.IsAny<Stream>(), cancellation.Token))
+            .ReturnsAsync(new ArchiveWorkspace(tempRoot, tempRoot));
+
+        var inspector = new Mock<ITerraformModuleInspector>(MockBehavior.Strict);
+        inspector
+            .Setup(x => x.InspectAsync(tempRoot, cancellation.Token))
+            .Callback(() => cancellation.Cancel())
+            .ReturnsAsync(new ModuleExtractionDocument());
+
+        var database = new Mock<IDatabaseService>(MockBehavior.Strict);
+        database
+            .Setup(x => x.UpdateModuleMetadataAsync(
+                "acme",
+                "network",
+                "aws",
+                "1.2.3",
+                It.IsAny<Action<ModuleArtifactMetadata>>()))
+            .Returns(Task.CompletedTask);
+        var service = new ModuleExtractionService(
+            moduleService.Object,
+            database.Object,
+            workspaceFactory.Object,
+            inspector.Object,
+            Mock.Of<IModuleLlmContextGenerator>(),
+            Mock.Of<IModuleExtractionConfigService>(),
+            NullLogger<ModuleExtractionService>.Instance);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            service.ExtractAsync(new ModuleExtractionRequest("acme", "network", "aws", "1.2.3"), cancellation.Token));
+
+        database.Verify(x => x.UpdateModuleMetadataAsync(
+            "acme",
+            "network",
+            "aws",
+            "1.2.3",
+            It.IsAny<Action<ModuleArtifactMetadata>>()), Times.Once);
+        Assert.False(Directory.Exists(tempRoot));
+    }
 }

--- a/TerraformRegistry.Tests/UnitTests/ModuleExtractionServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleExtractionServiceTests.cs
@@ -229,12 +229,13 @@ public class ModuleExtractionServiceTests
     public async Task ExtractAsyncDoesNotPersistResultsWhenCancellationIsRequestedDuringInspection()
     {
         using var cancellation = new CancellationTokenSource();
+        using var packageStream = new MemoryStream([1, 2, 3]);
         var moduleService = new Mock<IModuleService>(MockBehavior.Strict);
         moduleService
             .Setup(x => x.OpenModulePackageStreamAsync("acme", "network", "aws", "1.2.3"))
-            .ReturnsAsync(new MemoryStream([1, 2, 3]));
+            .ReturnsAsync(packageStream);
 
-        var tempRoot = Path.Combine(Path.GetTempPath(), $"module-extraction-test-{Guid.NewGuid():N}");
+        var tempRoot = Path.Join(Path.GetTempPath(), $"module-extraction-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempRoot);
 
         var workspaceFactory = new Mock<IArchiveWorkspaceFactory>(MockBehavior.Strict);

--- a/TerraformRegistry.Tests/UnitTests/ProviderRegistryServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ProviderRegistryServiceTests.cs
@@ -72,7 +72,8 @@ public class ProviderRegistryServiceTests
                 AsciiArmor = "key",
                 CreatedAt = DateTime.UtcNow
             });
-        repository.Setup(x => x.GetProviderPackageDetailsAsync("acme", "example", "1.0.0", "linux", "amd64"))
+        repository.Setup(x => x.GetProviderPackageDetailsAsync("acme", "example", "1.0.0", "linux", "amd64",
+                CancellationToken.None))
             .ReturnsAsync(new ProviderPackageDetails(
                 providerId,
                 ["5.0"],
@@ -108,12 +109,14 @@ public class ProviderRegistryServiceTests
             "linux",
             "amd64",
             "127.0.0.1",
-            "Terraform"), Times.Once);
+            "Terraform",
+            CancellationToken.None), Times.Once);
     }
 
     [Fact]
     public async Task GetPackageAsyncUsesOneRepositoryReadAndCreatesArtifactUrlsConcurrently()
     {
+        using var cancellation = new CancellationTokenSource();
         var repository = new Mock<IProviderRepository>(MockBehavior.Strict);
         var storage = new Mock<IProviderArtifactStorage>(MockBehavior.Strict);
         var packageDetails = new ProviderPackageDetails(
@@ -132,10 +135,12 @@ public class ProviderRegistryServiceTests
             null,
             null);
         repository
-            .Setup(x => x.GetProviderPackageDetailsAsync("acme", "example", "1.0.0", "linux", "amd64"))
+            .Setup(x => x.GetProviderPackageDetailsAsync("acme", "example", "1.0.0", "linux", "amd64",
+                cancellation.Token))
             .ReturnsAsync(packageDetails);
         repository
-            .Setup(x => x.RecordProviderDownloadAsync(packageDetails.ProviderId, "acme", "example", "1.0.0", "linux", "amd64", null, null))
+            .Setup(x => x.RecordProviderDownloadAsync(packageDetails.ProviderId, "acme", "example", "1.0.0", "linux",
+                "amd64", null, null, cancellation.Token))
             .Returns(Task.CompletedTask);
 
         var urlsStarted = 0;
@@ -152,12 +157,15 @@ public class ProviderRegistryServiceTests
             });
         var service = CreateService(repository, storage);
 
-        var response = await service.GetPackageAsync("acme", "example", "1.0.0", "linux", "amd64", null, null, CancellationToken.None);
+        var response = await service.GetPackageAsync("acme", "example", "1.0.0", "linux", "amd64", null, null,
+            cancellation.Token);
 
         Assert.NotNull(response);
         Assert.Equal(3, urlsStarted);
-        repository.Verify(x => x.GetProviderPackageDetailsAsync("acme", "example", "1.0.0", "linux", "amd64"), Times.Once);
-        repository.Verify(x => x.RecordProviderDownloadAsync(packageDetails.ProviderId, "acme", "example", "1.0.0", "linux", "amd64", null, null), Times.Once);
+        repository.Verify(x => x.GetProviderPackageDetailsAsync("acme", "example", "1.0.0", "linux", "amd64",
+            cancellation.Token), Times.Once);
+        repository.Verify(x => x.RecordProviderDownloadAsync(packageDetails.ProviderId, "acme", "example", "1.0.0", "linux",
+            "amd64", null, null, cancellation.Token), Times.Once);
     }
 
     [Fact]

--- a/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionService.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionService.cs
@@ -183,6 +183,7 @@ public sealed class ModuleExtractionService : IModuleExtractionService
 
             await using var workspace = await _workspaceFactory.CreateAsync(packageStream, cancellationToken);
             var document = await _inspector.InspectAsync(workspace.RootPath, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             var module = await _databaseService.GetModuleAsync(
                 request.Namespace,
                 request.Name,

--- a/TerraformRegistry/Services/ProviderRegistryService.cs
+++ b/TerraformRegistry/Services/ProviderRegistryService.cs
@@ -77,7 +77,8 @@ public sealed class ProviderRegistryService : IProviderRegistryService
     {
         ValidateCoordinate(providerNamespace, type);
 
-        var details = await _repository.GetProviderPackageDetailsAsync(providerNamespace, type, version, os, arch);
+        var details = await _repository.GetProviderPackageDetailsAsync(providerNamespace, type, version, os, arch,
+            cancellationToken);
         if (details is null)
             return null;
 
@@ -88,7 +89,8 @@ public sealed class ProviderRegistryService : IProviderRegistryService
             var signatureUrlTask = _storage.CreateDownloadUrlAsync(details.ShasumsSignatureStoragePath, cancellationToken);
             await Task.WhenAll(packageUrlTask, shasumsUrlTask, signatureUrlTask);
 
-            await _repository.RecordProviderDownloadAsync(details.ProviderId, providerNamespace, type, version, os, arch, clientIp, userAgent);
+            await _repository.RecordProviderDownloadAsync(details.ProviderId, providerNamespace, type, version, os, arch,
+                clientIp, userAgent, cancellationToken);
 
             return new ProviderPackageResponse
             {

--- a/TerraformRegistry/Services/SqliteProviderRepository.cs
+++ b/TerraformRegistry/Services/SqliteProviderRepository.cs
@@ -255,9 +255,10 @@ public sealed class SqliteProviderRepository : IProviderRepository
         return await reader.ReadAsync() ? MapVersion(reader) : null;
     }
 
-    public async Task<ProviderPackageDetails?> GetProviderPackageDetailsAsync(string providerNamespace, string type, string version, string os, string arch)
+    public async Task<ProviderPackageDetails?> GetProviderPackageDetailsAsync(string providerNamespace, string type, string version,
+        string os, string arch, CancellationToken cancellationToken)
     {
-        await using var connection = await OpenConnectionAsync();
+        await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();
         command.CommandText = @"
             SELECT p.id, pv.protocols, pv.key_id, pv.shasums_storage_path, pv.shasums_signature_storage_path,
@@ -275,8 +276,8 @@ public sealed class SqliteProviderRepository : IProviderRepository
         command.Parameters.AddWithValue("$os", os);
         command.Parameters.AddWithValue("$arch", arch);
 
-        await using var reader = await command.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return null;
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken)) return null;
         if (reader.IsDBNull(3) || reader.IsDBNull(4) || reader.IsDBNull(9)) return null;
         return new ProviderPackageDetails(Guid.Parse(reader.GetString(0)), DeserializeProtocols(reader.GetString(1)), reader.GetString(2),
             reader.GetString(3), reader.GetString(4), reader.GetString(5), reader.GetString(6), reader.GetString(7), reader.GetString(8),
@@ -622,9 +623,9 @@ public sealed class SqliteProviderRepository : IProviderRepository
     }
 
     public async Task RecordProviderDownloadAsync(Guid? providerId, string providerNamespace, string type, string version, string os,
-        string arch, string? clientIp, string? userAgent)
+        string arch, string? clientIp, string? userAgent, CancellationToken cancellationToken)
     {
-        await using var connection = await OpenConnectionAsync();
+        await using var connection = await OpenConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();
         command.CommandText = @"
             INSERT INTO provider_downloads (provider_id, namespace, type, version, os, arch, download_time, client_ip, user_agent)
@@ -638,7 +639,7 @@ public sealed class SqliteProviderRepository : IProviderRepository
         command.Parameters.AddWithValue("$downloadTime", DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture));
         command.Parameters.AddWithValue("$clientIp", DbValue(clientIp));
         command.Parameters.AddWithValue("$userAgent", DbValue(userAgent));
-        await command.ExecuteNonQueryAsync();
+        await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     private async Task<bool> UpdateSinglePathAsync(string table, string column, string idColumn, Guid id, string storagePath)
@@ -700,6 +701,13 @@ public sealed class SqliteProviderRepository : IProviderRepository
     {
         var connection = new SqliteConnection(_connectionString);
         await connection.OpenAsync();
+        return connection;
+    }
+
+    private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken);
         return connection;
     }
 


### PR DESCRIPTION
## Summary
- stop extraction persistence when cancellation arrives during Terraform configuration inspection
- add a regression test covering the parser-to-persistence boundary

## Verification
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --filter FullyQualifiedName~ModuleExtractionServiceTests -v minimal` (3 passed)
- `ASPNETCORE_ENVIRONMENT=Test dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --configuration Release -v minimal` (release build completed; local unfiltered test host did not emit a result summary)

## Cancellation behavior
The extraction worker already passes its cancellation token into archive workspace creation and Terraform inspection. This change checks the token immediately before persistence, so an aborted operation cannot create extraction/LLM records after parsing completes.