### PR TITLE
build: pin reproducible release inputs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,10 +54,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -89,7 +89,7 @@ jobs:
           ASPNETCORE_ENVIRONMENT: Test
 
       - name: Upload test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: test-results
@@ -98,7 +98,7 @@ jobs:
           retention-days: 14
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: code-coverage-report
@@ -107,7 +107,7 @@ jobs:
           retention-days: 14
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@f2274c2c340e0c81c8f7dc407b2a477b8935f171 # v6
         if: env.CODECOV_TOKEN != ''
         with:
           files: ${{ env.TEST_RESULTS_DIR }}/**/coverage.cobertura.xml
@@ -124,10 +124,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -136,6 +136,9 @@ jobs:
       - name: Install frontend dependencies
         working-directory: TerraformRegistry/web-src
         run: npm ci
+
+      - name: Verify reproducible release inputs
+        run: bash scripts/remediation/gates/test-supply-chain-pinning.sh
 
       - name: Run npm audit
         working-directory: TerraformRegistry/web-src
@@ -146,7 +149,7 @@ jobs:
         run: npm run generate
 
       - name: Upload generated frontend
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: generated-frontend
           path: TerraformRegistry/web-src/.output/public
@@ -161,7 +164,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Verify storage emulator harness scripts
         run: |
@@ -184,7 +187,7 @@ jobs:
 
       - name: Upload storage emulator logs
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: storage-emulator-compose-logs
           path: storage-emulator-compose.log
@@ -206,7 +209,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run portable Phase 1 deployment gate
         run: bash scripts/remediation/gates/phase-1.sh
@@ -220,7 +223,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run bounded ingestion security gate
         run: bash scripts/remediation/gates/bounded-ingestion-security.sh
@@ -234,7 +237,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run mirror containment gate
         run: bash scripts/remediation/gates/mirror-containment-gate.sh
@@ -248,10 +251,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -270,12 +273,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Test version resolver
         run: bash .github/scripts/test-resolve-version.sh
@@ -289,7 +292,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: metadata
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.IMAGE_NAME }}
           labels: |
@@ -302,7 +305,7 @@ jobs:
             type=raw,value=release,enable=${{ startsWith(github.ref, 'refs/heads/release/') }}
 
       - name: Build Docker image for scan
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           load: true
@@ -319,7 +322,7 @@ jobs:
           test "$actual" = "$expected"
 
       - name: Run Trivy image scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: ${{ env.SCAN_IMAGE_NAME }}
           format: sarif
@@ -331,7 +334,7 @@ jobs:
           limit-severities-for-sarif: true
 
       - name: Upload Trivy image scan
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@1ad29ea4a422cce9a242a9fae469541dcd08addc # v4
         if: always() && hashFiles('trivy-image.sarif') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           sarif_file: trivy-image.sarif
@@ -361,12 +364,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Resolve version
         id: resolved-version
@@ -376,7 +379,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: metadata
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.IMAGE_NAME }}
           labels: |
@@ -389,14 +392,14 @@ jobs:
             type=raw,value=release,enable=${{ startsWith(github.ref, 'refs/heads/release/') }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: true

--- a/.github/workflows/phase-1-real-azure-gate.yaml
+++ b/.github/workflows/phase-1-real-azure-gate.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Authenticate to Azure with OIDC
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Review dependency changes
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@56339e523c0409420f6c2c9a2f4292bbb3c07dd3 # v4.8.0
         with:
           config-file: ./.github/dependency-review-config.yml
 
@@ -67,16 +67,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup .NET
         if: matrix.language == 'csharp'
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@1ad29ea4a422cce9a242a9fae469541dcd08addc # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -93,7 +93,7 @@ jobs:
           dotnet build --no-restore --configuration "$CONFIGURATION"
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@1ad29ea4a422cce9a242a9fae469541dcd08addc # v4
 
   trivy-filesystem:
     name: Trivy filesystem scan
@@ -104,10 +104,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -124,7 +124,7 @@ jobs:
           skip-files: Dockerfile.dev
 
       - name: Upload Trivy filesystem scan
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@1ad29ea4a422cce9a242a9fae469541dcd08addc # v4
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           sarif_file: trivy-filesystem.sarif
@@ -144,19 +144,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
         with:
           results_file: scorecard.sarif
           results_format: sarif
           publish_results: false
 
       - name: Upload Scorecard artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openssf-scorecard
           path: scorecard.sarif
@@ -164,7 +164,7 @@ jobs:
           retention-days: 14
 
       - name: Upload Scorecard SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@1ad29ea4a422cce9a242a9fae469541dcd08addc # v4
         with:
           sarif_file: scorecard.sarif
           category: openssf-scorecard

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN dotnet publish TerraformRegistry.csproj -c Release -o /app/publish /p:UseApp
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:57bd717ac18ff6c8a39cc0ee4a76c1f15adc46df50434c73eff0c3f1df4c88f0 AS final
 WORKDIR /app
 ENV TF_REG_Sqlite__ConnectionString="Data Source=/data/terraform.db"
-RUN apk upgrade --no-cache
 COPY --from=publish /app/publish .
 COPY --from=terraform-config-inspect /out/terraform-config-inspect /usr/local/bin/terraform-config-inspect
 RUN mkdir -p /app/modules /app/providers /data && chown app:app /app/modules /app/providers /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.26-alpine AS terraform-config-inspect
-ARG TERRAFORM_CONFIG_INSPECT_VERSION=latest
+FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS terraform-config-inspect
+ARG TERRAFORM_CONFIG_INSPECT_VERSION=2fb54c236733ee65ee877105d595c124c993c64d
 RUN GOBIN=/out go install github.com/hashicorp/terraform-config-inspect@${TERRAFORM_CONFIG_INSPECT_VERSION}
 
-FROM node:24-alpine AS frontend
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS frontend
 WORKDIR /app/TerraformRegistry/web-src
 COPY TerraformRegistry/web-src/package.json TerraformRegistry/web-src/package-lock.json ./
 RUN npm ci
@@ -10,7 +10,7 @@ COPY TerraformRegistry/web-src/ ./
 ARG FRONTEND_BUILD_MARKER=local
 RUN printf '%s\n' "$FRONTEND_BUILD_MARKER" > public/.build-marker && npm run generate
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:940f919ae84dd92ccd4aab7686fa5b777870b006c9360351039e16bcaad73d89 AS build
 WORKDIR /app
 
 
@@ -37,7 +37,7 @@ RUN dotnet build TerraformRegistry.csproj -c Release -o /app/build
 FROM build AS publish
 RUN dotnet publish TerraformRegistry.csproj -c Release -o /app/publish /p:UseAppHost=false
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:57bd717ac18ff6c8a39cc0ee4a76c1f15adc46df50434c73eff0c3f1df4c88f0 AS final
 WORKDIR /app
 ENV TF_REG_Sqlite__ConnectionString="Data Source=/data/terraform.db"
 RUN apk upgrade --no-cache

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630f2c8201ed0572b295d5 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore dependencies

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630f2c8201ed0572b295d5 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore dependencies

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: postgres:18
+    image: postgres:18@sha256:48ebba8b80dc3be58b5ae431f47a33535289959cddfe13f5f887298de959fae0
     ports:
       - "5433:5432"
     volumes:
@@ -47,7 +47,7 @@ services:
       start_period: 10s
 
   pgadmin:
-    image: dpage/pgadmin4:latest
+    image: dpage/pgadmin4:latest@sha256:40fa840c5bb7c8463957f1255b01283732c2d8c9396a956d180f8e6c296753b3
     container_name: terraform-registry-pgadmin
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@example.com

--- a/docker-compose.psql.yml
+++ b/docker-compose.psql.yml
@@ -1,7 +1,7 @@
 ---
 services:
   postgres:
-    image: postgres:18
+    image: postgres:18@sha256:48ebba8b80dc3be58b5ae431f47a33535289959cddfe13f5f887298de959fae0
     ports:
       - "5433:5432"
     volumes:
@@ -19,7 +19,7 @@ services:
       start_period: 10s
 
   pgadmin:
-    image: dpage/pgadmin4:latest
+    image: dpage/pgadmin4:latest@sha256:40fa840c5bb7c8463957f1255b01283732c2d8c9396a956d180f8e6c296753b3
     container_name: terraform-registry-pgadmin
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@example.com

--- a/docs/build-inputs.md
+++ b/docs/build-inputs.md
@@ -12,7 +12,7 @@ is responsible for proposing reviewed updates.
 | Node builder | `node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd` | Generated frontend build stage |
 | .NET SDK builder | `mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:940f919ae84dd92ccd4aab7686fa5b777870b006c9360351039e16bcaad73d89` | Release Docker image |
 | ASP.NET runtime | `mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:57bd717ac18ff6c8a39cc0ee4a76c1f15adc46df50434c73eff0c3f1df4c88f0` | Release Docker image |
-| Development .NET SDK | `mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630f2c8201ed0572b295d5` | Development Docker image |
+| Development .NET SDK | `mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5` | Development Docker image |
 | PostgreSQL | `postgres:18@sha256:48ebba8b80dc3be58b5ae431f47a33535289959cddfe13f5f887298de959fae0` | Development Compose stack and storage-emulator smoke tests |
 | pgAdmin | `dpage/pgadmin4:latest@sha256:40fa840c5bb7c8463957f1255b01283732c2d8c9396a956d180f8e6c296753b3` | Development Compose stack |
 | Azurite | `mcr.microsoft.com/azure-storage/azurite:3.33.0@sha256:2628ee10a72833cc344b9d194cd8b245543892b307d16cf26a2cf55a15b816af` | Azure Blob storage-emulator smoke tests |

--- a/docs/build-inputs.md
+++ b/docs/build-inputs.md
@@ -13,8 +13,16 @@ is responsible for proposing reviewed updates.
 | .NET SDK builder | `mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:940f919ae84dd92ccd4aab7686fa5b777870b006c9360351039e16bcaad73d89` | Release Docker image |
 | ASP.NET runtime | `mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:57bd717ac18ff6c8a39cc0ee4a76c1f15adc46df50434c73eff0c3f1df4c88f0` | Release Docker image |
 | Development .NET SDK | `mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630f2c8201ed0572b295d5` | Development Docker image |
+| PostgreSQL | `postgres:18@sha256:48ebba8b80dc3be58b5ae431f47a33535289959cddfe13f5f887298de959fae0` | Development Compose stack and storage-emulator smoke tests |
+| pgAdmin | `dpage/pgadmin4:latest@sha256:40fa840c5bb7c8463957f1255b01283732c2d8c9396a956d180f8e6c296753b3` | Development Compose stack |
+| Azurite | `mcr.microsoft.com/azure-storage/azurite:3.33.0@sha256:2628ee10a72833cc344b9d194cd8b245543892b307d16cf26a2cf55a15b816af` | Azure Blob storage-emulator smoke tests |
+| MinIO server | `minio/minio:RELEASE.2025-04-22T22-12-26Z@sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e` | S3-compatible storage-emulator smoke tests |
+| MinIO client | `minio/mc:RELEASE.2025-03-12T17-29-24Z@sha256:470f5546b596e16c7816b9c3fa7a78ce4076bb73c2c73f7faeec0c8043923123` | S3-compatible storage-emulator initialization |
+| Caddy | `caddy:2.11-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648` | Storage-emulator smoke-test reverse proxy |
 
 The gate at `scripts/remediation/gates/supply-chain-pinning.sh` ensures these
-references remain immutable and that all workflow actions use a 40-character
-commit SHA. It deliberately permits a human-readable version comment beside an
-action SHA, but never a mutable action tag as the executable reference.
+references remain immutable, including every Compose image used by development
+or the CI storage-emulator smoke tests, and that all workflow actions use a
+40-character commit SHA. It deliberately permits a human-readable version
+comment beside an action SHA, but never a mutable action tag as the executable
+reference.

--- a/docs/build-inputs.md
+++ b/docs/build-inputs.md
@@ -1,0 +1,20 @@
+# Reproducible release build inputs
+
+This record is the source of truth for external inputs used to build a release
+artifact. Every image digest and GitHub Action revision is immutable; Renovate
+is responsible for proposing reviewed updates.
+
+| Input | Pinned revision | Used by |
+| --- | --- | --- |
+| Terraform CLI | `1.14.2`, `hashicorp/terraform@sha256:eee2f7d5725bfcfd734dfc9fe5a3df4b58b00eb8cc874993458108d8943265cf` | Local, Azure, and S3-compatible Terraform smoke tests |
+| terraform-config-inspect | `2fb54c236733ee65ee877105d595c124c993c64d` | Release Docker image |
+| Go builder | `golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2` | terraform-config-inspect build stage |
+| Node builder | `node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd` | Generated frontend build stage |
+| .NET SDK builder | `mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:940f919ae84dd92ccd4aab7686fa5b777870b006c9360351039e16bcaad73d89` | Release Docker image |
+| ASP.NET runtime | `mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:57bd717ac18ff6c8a39cc0ee4a76c1f15adc46df50434c73eff0c3f1df4c88f0` | Release Docker image |
+| Development .NET SDK | `mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630f2c8201ed0572b295d5` | Development Docker image |
+
+The gate at `scripts/remediation/gates/supply-chain-pinning.sh` ensures these
+references remain immutable and that all workflow actions use a 40-character
+commit SHA. It deliberately permits a human-readable version comment beside an
+action SHA, but never a mutable action tag as the executable reference.

--- a/docs/security-exceptions/SUP-003-nuxt-ui.md
+++ b/docs/security-exceptions/SUP-003-nuxt-ui.md
@@ -1,0 +1,24 @@
+# SUP-003 — Nuxt UI UAuthForm/UForm advisory exception
+
+- Advisory: [GHSA-gj2h-2fpw-fhv9](https://github.com/advisories/GHSA-gj2h-2fpw-fhv9)
+- Affected dependency: `@nuxt/ui` 3.3.7, which is within the advisory range
+- Owner: `matty` (repository maintainer)
+- Expiry: 2026-10-14
+
+## Reachability assessment
+
+The advisory applies to `UAuthForm` and `UForm` server-rendered markup when a
+user submits the component before client-side hydration. The registry frontend
+does not render either component. The automated supply-chain gate searches the
+frontend source (excluding generated dependency and lockfile content) for both
+component names and fails if either is introduced.
+
+## Compensating control
+
+The workflow runs `npm audit --audit-level=high`, so a High/Critical escalation
+remains release-blocking. This Moderate finding is isolated to components that
+are absent from the shipped frontend; the reachability gate prevents an affected
+component from being added without first upgrading `@nuxt/ui` or replacing this
+exception through normal review. The owner must upgrade or re-assess before the
+expiry date; the automated gate fails on that date until the exception is
+replaced or renewed through review.

--- a/scripts/remediation/gates/supply-chain-pinning.sh
+++ b/scripts/remediation/gates/supply-chain-pinning.sh
@@ -7,12 +7,48 @@ DEV_DOCKERFILE="$ROOT/Dockerfile.dev"
 MANIFEST="$ROOT/docs/build-inputs.md"
 EXCEPTION="$ROOT/docs/security-exceptions/SUP-003-nuxt-ui.md"
 
+validate_dockerfile_bases() {
+  local dockerfile="$1"
+  local line remainder reference stage index
+  local -a tokens
+  local -A stages=()
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ ! "$line" =~ ^[[:space:]]*[Ff][Rr][Oo][Mm][[:space:]]+(.+)$ ]]; then
+      continue
+    fi
+
+    remainder="${BASH_REMATCH[1]}"
+    read -r -a tokens <<< "$remainder"
+    index=0
+    while [[ "${tokens[$index]:-}" == --* ]]; do
+      ((index += 1))
+    done
+
+    reference="${tokens[$index]:-}"
+    if [[ -z "$reference" ]]; then
+      echo "Docker FROM instruction has no base image in $dockerfile: $line" >&2
+      return 1
+    fi
+
+    if [[ -z "${stages[$reference]:-}" && ! "$reference" =~ @sha256:[0-9a-f]{64}$ ]]; then
+      echo "External Docker base image must be pinned by digest in $dockerfile: $reference" >&2
+      return 1
+    fi
+
+    if [[ "${tokens[$((index + 1))]:-}" =~ ^[Aa][Ss]$ && -n "${tokens[$((index + 2))]:-}" ]]; then
+      stage="${tokens[$((index + 2))]}"
+      stages["$stage"]=1
+    fi
+  done < "$dockerfile"
+}
+
 test -f "$MANIFEST"
 test -f "$EXCEPTION"
 
 grep -Eq '^ARG TERRAFORM_CONFIG_INSPECT_VERSION=[0-9a-f]{40}$' "$DOCKERFILE"
-! grep -Eq '^FROM .*(latest|:[^@[:space:]]+([[:space:]]|$))' "$DOCKERFILE"
-! grep -Eq '^FROM .*(latest|:[^@[:space:]]+([[:space:]]|$))' "$DEV_DOCKERFILE"
+validate_dockerfile_bases "$DOCKERFILE"
+validate_dockerfile_bases "$DEV_DOCKERFILE"
 if grep -Eq '^[[:space:]]*RUN .*apk[[:space:]]+upgrade' "$DOCKERFILE" "$DEV_DOCKERFILE"; then
   echo 'Unpinned Alpine package upgrades are not reproducible.' >&2
   exit 1

--- a/scripts/remediation/gates/supply-chain-pinning.sh
+++ b/scripts/remediation/gates/supply-chain-pinning.sh
@@ -47,10 +47,14 @@ contains_affected_nuxt_form() {
       printf '%s\n' "$file"
       return 0
     fi
-  done < <(find "$ROOT/TerraformRegistry/web-src" -type f \
-    ! -name package-lock.json \
-    ! -name pnpm-lock.yaml \
-    ! -path '*/node_modules/*' -print)
+  done < <(find "$ROOT/TerraformRegistry/web-src" \
+    \( -path '*/.nuxt' -o -path '*/.nuxt/*' \
+      -o -path '*/.output' -o -path '*/.output/*' \
+      -o -path '*/coverage' -o -path '*/coverage/*' \
+      -o -path '*/dist' -o -path '*/dist/*' \
+      -o -path '*/node_modules' -o -path '*/node_modules/*' \) -prune -o \
+    -type f \( -name '*.vue' -o -name '*.ts' -o -name '*.tsx' \
+      -o -name '*.js' -o -name '*.jsx' \) -print)
 
   return 1
 }

--- a/scripts/remediation/gates/supply-chain-pinning.sh
+++ b/scripts/remediation/gates/supply-chain-pinning.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ROOT="${SUPPLY_CHAIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
 DOCKERFILE="$ROOT/Dockerfile"
 DEV_DOCKERFILE="$ROOT/Dockerfile.dev"
 MANIFEST="$ROOT/docs/build-inputs.md"
@@ -13,12 +13,34 @@ test -f "$EXCEPTION"
 grep -Eq '^ARG TERRAFORM_CONFIG_INSPECT_VERSION=[0-9a-f]{40}$' "$DOCKERFILE"
 ! grep -Eq '^FROM .*(latest|:[^@[:space:]]+([[:space:]]|$))' "$DOCKERFILE"
 ! grep -Eq '^FROM .*(latest|:[^@[:space:]]+([[:space:]]|$))' "$DEV_DOCKERFILE"
+if rg -n '^[[:space:]]*RUN .*apk[[:space:]]+upgrade' "$DOCKERFILE" "$DEV_DOCKERFILE"; then
+  echo 'Unpinned Alpine package upgrades are not reproducible.' >&2
+  exit 1
+fi
 
 grep -Eq '^\| Terraform CLI \| `1\.14\.2`, `hashicorp/terraform@sha256:[0-9a-f]{64}`' "$MANIFEST"
 grep -Eq '^\| terraform-config-inspect \| `[0-9a-f]{40}`' "$MANIFEST"
-grep -Eq '^\| .* \| `.*@sha256:[0-9a-f]{64}`' "$MANIFEST"
+for image in \
+  'postgres:18@sha256:48ebba8b80dc3be58b5ae431f47a33535289959cddfe13f5f887298de959fae0' \
+  'dpage/pgadmin4:latest@sha256:40fa840c5bb7c8463957f1255b01283732c2d8c9396a956d180f8e6c296753b3' \
+  'mcr.microsoft.com/azure-storage/azurite:3.33.0@sha256:2628ee10a72833cc344b9d194cd8b245543892b307d16cf26a2cf55a15b816af' \
+  'minio/minio:RELEASE.2025-04-22T22-12-26Z@sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e' \
+  'minio/mc:RELEASE.2025-03-12T17-29-24Z@sha256:470f5546b596e16c7816b9c3fa7a78ce4076bb73c2c73f7faeec0c8043923123' \
+  'caddy:2.11-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648'; do
+  grep -Fq "\`$image\`" "$MANIFEST"
+done
 
-if rg -n -i '<u(auth)?form\\b|\\bU(Auth)?Form\\b|u-auth-form|u-form' \
+while IFS= read -r image; do
+  if [[ ! "$image" =~ ^[[:space:]]*image:[[:space:]]+[^[:space:]]+@sha256:[0-9a-f]{64}[[:space:]]*$ ]]; then
+    echo "Mutable Compose image reference: $image" >&2
+    exit 1
+  fi
+done < <(rg -N --no-filename '^\s*image:' \
+  "$ROOT/docker-compose.dev.yml" \
+  "$ROOT/docker-compose.psql.yml" \
+  "$ROOT/scripts/remediation/storage-emulators/compose.yaml")
+
+if rg -n -i '<u(auth)?form\b|\bU(Auth)?Form\b|u-auth-form|u-form' \
   "$ROOT/TerraformRegistry/web-src" \
   --glob '!package-lock.json' --glob '!pnpm-lock.yaml' --glob '!node_modules/**'; then
   echo 'The SUP-003 exception is no longer valid: an affected Nuxt UI form is reachable.' >&2

--- a/scripts/remediation/gates/supply-chain-pinning.sh
+++ b/scripts/remediation/gates/supply-chain-pinning.sh
@@ -13,7 +13,7 @@ test -f "$EXCEPTION"
 grep -Eq '^ARG TERRAFORM_CONFIG_INSPECT_VERSION=[0-9a-f]{40}$' "$DOCKERFILE"
 ! grep -Eq '^FROM .*(latest|:[^@[:space:]]+([[:space:]]|$))' "$DOCKERFILE"
 ! grep -Eq '^FROM .*(latest|:[^@[:space:]]+([[:space:]]|$))' "$DEV_DOCKERFILE"
-if rg -n '^[[:space:]]*RUN .*apk[[:space:]]+upgrade' "$DOCKERFILE" "$DEV_DOCKERFILE"; then
+if grep -Eq '^[[:space:]]*RUN .*apk[[:space:]]+upgrade' "$DOCKERFILE" "$DEV_DOCKERFILE"; then
   echo 'Unpinned Alpine package upgrades are not reproducible.' >&2
   exit 1
 fi
@@ -35,14 +35,27 @@ while IFS= read -r image; do
     echo "Mutable Compose image reference: $image" >&2
     exit 1
   fi
-done < <(rg -N --no-filename '^\s*image:' \
+done < <(grep -hE '^[[:space:]]*image:' \
   "$ROOT/docker-compose.dev.yml" \
   "$ROOT/docker-compose.psql.yml" \
   "$ROOT/scripts/remediation/storage-emulators/compose.yaml")
 
-if rg -n -i '<u(auth)?form\b|\bU(Auth)?Form\b|u-auth-form|u-form' \
-  "$ROOT/TerraformRegistry/web-src" \
-  --glob '!package-lock.json' --glob '!pnpm-lock.yaml' --glob '!node_modules/**'; then
+contains_affected_nuxt_form() {
+  local file
+  while IFS= read -r file; do
+    if grep -Eiq '<u(auth)?form\b|\bU(Auth)?Form\b|u-auth-form|u-form' "$file"; then
+      printf '%s\n' "$file"
+      return 0
+    fi
+  done < <(find "$ROOT/TerraformRegistry/web-src" -type f \
+    ! -name package-lock.json \
+    ! -name pnpm-lock.yaml \
+    ! -path '*/node_modules/*' -print)
+
+  return 1
+}
+
+if contains_affected_nuxt_form; then
   echo 'The SUP-003 exception is no longer valid: an affected Nuxt UI form is reachable.' >&2
   exit 1
 fi
@@ -61,4 +74,4 @@ while IFS= read -r action; do
     echo "Mutable GitHub Action reference: $action" >&2
     exit 1
   fi
-done < <(rg -N '^\s*uses: [^[:space:]]+@' "$ROOT/.github/workflows")
+done < <(find "$ROOT/.github/workflows" -type f -exec grep -hE '^[[:space:]]*uses: [^[:space:]]+@' {} +)

--- a/scripts/remediation/gates/supply-chain-pinning.sh
+++ b/scripts/remediation/gates/supply-chain-pinning.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+DOCKERFILE="$ROOT/Dockerfile"
+DEV_DOCKERFILE="$ROOT/Dockerfile.dev"
+MANIFEST="$ROOT/docs/build-inputs.md"
+EXCEPTION="$ROOT/docs/security-exceptions/SUP-003-nuxt-ui.md"
+
+test -f "$MANIFEST"
+test -f "$EXCEPTION"
+
+grep -Eq '^ARG TERRAFORM_CONFIG_INSPECT_VERSION=[0-9a-f]{40}$' "$DOCKERFILE"
+! grep -Eq '^FROM .*(latest|:[^@[:space:]]+([[:space:]]|$))' "$DOCKERFILE"
+! grep -Eq '^FROM .*(latest|:[^@[:space:]]+([[:space:]]|$))' "$DEV_DOCKERFILE"
+
+grep -Eq '^\| Terraform CLI \| `1\.14\.2`, `hashicorp/terraform@sha256:[0-9a-f]{64}`' "$MANIFEST"
+grep -Eq '^\| terraform-config-inspect \| `[0-9a-f]{40}`' "$MANIFEST"
+grep -Eq '^\| .* \| `.*@sha256:[0-9a-f]{64}`' "$MANIFEST"
+
+if rg -n -i '<u(auth)?form\\b|\\bU(Auth)?Form\\b|u-auth-form|u-form' \
+  "$ROOT/TerraformRegistry/web-src" \
+  --glob '!package-lock.json' --glob '!pnpm-lock.yaml' --glob '!node_modules/**'; then
+  echo 'The SUP-003 exception is no longer valid: an affected Nuxt UI form is reachable.' >&2
+  exit 1
+fi
+
+grep -Fq 'Owner: `matty`' "$EXCEPTION"
+grep -Eq '^[-] Expiry: 20[0-9]{2}-[0-9]{2}-[0-9]{2}$' "$EXCEPTION"
+grep -Fq 'Compensating control' "$EXCEPTION"
+expiry="$(sed -n 's/^- Expiry: //p' "$EXCEPTION")"
+if [[ "$expiry" < "$(date -u +%F)" || "$expiry" == "$(date -u +%F)" ]]; then
+  echo "The SUP-003 exception has expired; upgrade or re-assess @nuxt/ui." >&2
+  exit 1
+fi
+
+while IFS= read -r action; do
+  if [[ ! "$action" =~ @[0-9a-f]{40}([[:space:]]|$) ]]; then
+    echo "Mutable GitHub Action reference: $action" >&2
+    exit 1
+  fi
+done < <(rg -N '^\s*uses: [^[:space:]]+@' "$ROOT/.github/workflows")

--- a/scripts/remediation/gates/test-supply-chain-pinning.sh
+++ b/scripts/remediation/gates/test-supply-chain-pinning.sh
@@ -38,6 +38,13 @@ expect_failure() {
   fi
 }
 
+mkdir -p "$fixture_root/TerraformRegistry/web-src/.nuxt"
+printf 'declare const UAuthForm: typeof import("@nuxt/ui")["UAuthForm"]\n' > "$fixture_root/TerraformRegistry/web-src/.nuxt/components.d.ts"
+if ! SUPPLY_CHAIN_ROOT="$fixture_root" bash "$ROOT/scripts/remediation/gates/supply-chain-pinning.sh"; then
+  echo 'Generated Nuxt declarations must not invalidate the SUP-003 exception.' >&2
+  exit 1
+fi
+
 printf '<template><UAuthForm /></template>\n' > "$fixture_root/TerraformRegistry/web-src/affected.vue"
 expect_failure 'UAuthForm'
 rm "$fixture_root/TerraformRegistry/web-src/affected.vue"

--- a/scripts/remediation/gates/test-supply-chain-pinning.sh
+++ b/scripts/remediation/gates/test-supply-chain-pinning.sh
@@ -5,8 +5,21 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
 bash "$ROOT/scripts/remediation/gates/supply-chain-pinning.sh"
 
+portable_bin="$(mktemp -d)"
+portable_output="$(mktemp)"
+trap 'rm -rf "${fixture_root:-}" "$portable_bin" "$portable_output"' EXIT
+for command in bash date find grep sed; do
+  ln -s "$(command -v "$command")" "$portable_bin/$command"
+done
+
+PATH="$portable_bin" SUPPLY_CHAIN_ROOT="$ROOT" bash "$ROOT/scripts/remediation/gates/supply-chain-pinning.sh" > "$portable_output" 2>&1
+if grep -Fq 'command not found' "$portable_output"; then
+  echo 'Supply-chain gate must not require tools outside its portable toolset.' >&2
+  cat "$portable_output" >&2
+  exit 1
+fi
+
 fixture_root="$(mktemp -d)"
-trap 'rm -rf "$fixture_root"' EXIT
 
 mkdir -p "$fixture_root"/{docs/security-exceptions,scripts/remediation/gates,TerraformRegistry/web-src,.github}
 cp "$ROOT/Dockerfile" "$ROOT/Dockerfile.dev" "$fixture_root/"

--- a/scripts/remediation/gates/test-supply-chain-pinning.sh
+++ b/scripts/remediation/gates/test-supply-chain-pinning.sh
@@ -4,3 +4,38 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
 bash "$ROOT/scripts/remediation/gates/supply-chain-pinning.sh"
+
+fixture_root="$(mktemp -d)"
+trap 'rm -rf "$fixture_root"' EXIT
+
+mkdir -p "$fixture_root"/{docs/security-exceptions,scripts/remediation/gates,TerraformRegistry/web-src,.github}
+cp "$ROOT/Dockerfile" "$ROOT/Dockerfile.dev" "$fixture_root/"
+cp "$ROOT/docs/build-inputs.md" "$fixture_root/docs/"
+cp "$ROOT/docs/security-exceptions/SUP-003-nuxt-ui.md" "$fixture_root/docs/security-exceptions/"
+cp -a "$ROOT/.github/workflows" "$fixture_root/.github/"
+mkdir -p "$fixture_root/scripts/remediation"
+cp -a "$ROOT/scripts/remediation/storage-emulators" "$fixture_root/scripts/remediation/"
+cp "$ROOT/docker-compose.dev.yml" "$ROOT/docker-compose.psql.yml" "$fixture_root/"
+
+expect_failure() {
+  local name="$1"
+  if SUPPLY_CHAIN_ROOT="$fixture_root" bash "$ROOT/scripts/remediation/gates/supply-chain-pinning.sh"; then
+    echo "Expected supply-chain gate to reject $name." >&2
+    exit 1
+  fi
+}
+
+printf '<template><UAuthForm /></template>\n' > "$fixture_root/TerraformRegistry/web-src/affected.vue"
+expect_failure 'UAuthForm'
+rm "$fixture_root/TerraformRegistry/web-src/affected.vue"
+
+printf '<template><UForm /></template>\n' > "$fixture_root/TerraformRegistry/web-src/affected.vue"
+expect_failure 'UForm'
+rm "$fixture_root/TerraformRegistry/web-src/affected.vue"
+
+sed -i 's/@sha256:[0-9a-f]*/:latest/' "$fixture_root/docker-compose.dev.yml"
+expect_failure 'a mutable Compose image'
+cp "$ROOT/docker-compose.dev.yml" "$fixture_root/docker-compose.dev.yml"
+
+printf '\nRUN apk upgrade --no-cache\n' >> "$fixture_root/Dockerfile"
+expect_failure 'an unpinned Alpine package upgrade'

--- a/scripts/remediation/gates/test-supply-chain-pinning.sh
+++ b/scripts/remediation/gates/test-supply-chain-pinning.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+bash "$ROOT/scripts/remediation/gates/supply-chain-pinning.sh"

--- a/scripts/remediation/gates/test-supply-chain-pinning.sh
+++ b/scripts/remediation/gates/test-supply-chain-pinning.sh
@@ -45,6 +45,15 @@ if ! SUPPLY_CHAIN_ROOT="$fixture_root" bash "$ROOT/scripts/remediation/gates/sup
   exit 1
 fi
 
+sed -i '0,/^FROM node:/s|^FROM node:.* AS frontend$|FROM node AS frontend|' "$fixture_root/Dockerfile"
+expect_failure 'a bare external Docker base image'
+cp "$ROOT/Dockerfile" "$fixture_root/Dockerfile"
+
+if ! SUPPLY_CHAIN_ROOT="$fixture_root" bash "$ROOT/scripts/remediation/gates/supply-chain-pinning.sh"; then
+  echo 'A Docker build stage based on an earlier pinned stage must remain valid.' >&2
+  exit 1
+fi
+
 printf '<template><UAuthForm /></template>\n' > "$fixture_root/TerraformRegistry/web-src/affected.vue"
 expect_failure 'UAuthForm'
 rm "$fixture_root/TerraformRegistry/web-src/affected.vue"

--- a/scripts/remediation/phase-1-local-terraform-smoke.sh
+++ b/scripts/remediation/phase-1-local-terraform-smoke.sh
@@ -54,6 +54,6 @@ docker run --rm --network "$NETWORK" --add-host "registry.local:$caddy_ip" \
   -e SSL_CERT_FILE=/certs/caddy/pki/authorities/local/root.crt \
   -e TF_CLI_CONFIG_FILE=/work/terraform.rc \
   -v "$CADDY_DATA:/certs:ro" -v "$SMOKE_VOLUME:/work" -w /work \
-  hashicorp/terraform:1.14.2 init -input=false -no-color
+  hashicorp/terraform:1.14.2@sha256:eee2f7d5725bfcfd734dfc9fe5a3df4b58b00eb8cc874993458108d8943265cf init -input=false -no-color
 
 printf 'Phase 1 Local Terraform smoke passed.\n'

--- a/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
+++ b/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
@@ -97,7 +97,7 @@ EOF
       -e SSL_CERT_FILE=/certs/caddy/pki/authorities/local/root.crt \
       -e TF_CLI_CONFIG_FILE=/work/terraform.rc \
       -v "${project}_caddy-data:/certs:ro" -v "$workspace/$archive:/work" -w /work \
-      hashicorp/terraform:1.14.2 init -input=false -no-color
+      hashicorp/terraform:1.14.2@sha256:eee2f7d5725bfcfd734dfc9fe5a3df4b58b00eb8cc874993458108d8943265cf init -input=false -no-color
   done
 
   printf 'Phase 1 %s emulator Terraform smoke passed.\n' "$storage_provider"

--- a/scripts/remediation/storage-emulators/compose.yaml
+++ b/scripts/remediation/storage-emulators/compose.yaml
@@ -1,12 +1,12 @@
 services:
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite:3.33.0
+    image: mcr.microsoft.com/azure-storage/azurite:3.33.0@sha256:2628ee10a72833cc344b9d194cd8b245543892b307d16cf26a2cf55a15b816af
     command: azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --location /workspace --skipApiVersionCheck
     volumes:
       - azurite-data:/workspace
 
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z@sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e
     command: server /data --console-address :9001
     environment:
       MINIO_ROOT_USER: minioadmin
@@ -15,7 +15,7 @@ services:
       - minio-data:/data
 
   minio-init:
-    image: minio/mc:RELEASE.2025-03-12T17-29-24Z
+    image: minio/mc:RELEASE.2025-03-12T17-29-24Z@sha256:470f5546b596e16c7816b9c3fa7a78ce4076bb73c2c73f7faeec0c8043923123
     depends_on:
       - minio
     entrypoint: >-
@@ -23,7 +23,7 @@ services:
       mc mb --ignore-existing local/modules'
 
   postgres:
-    image: postgres:18
+    image: postgres:18@sha256:48ebba8b80dc3be58b5ae431f47a33535289959cddfe13f5f887298de959fae0
     environment:
       POSTGRES_USER: terraform_reg_user
       POSTGRES_PASSWORD: terraform_reg_password
@@ -60,7 +60,7 @@ services:
       - "5131"
 
   caddy:
-    image: caddy:2.11-alpine
+    image: caddy:2.11-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
     depends_on:
       - app
     volumes:


### PR DESCRIPTION
## Summary
- pin release Docker bases, Terraform smoke image, terraform-config-inspect, and GitHub Actions to immutable revisions
- record release inputs and add a CI-enforced validation gate
- document the time-bounded, reachability-tested SUP-003 Nuxt UI advisory exception

## Verification
- `bash scripts/remediation/gates/test-supply-chain-pinning.sh`
- `docker build --target terraform-config-inspect -t terraform-registry-config-inspect-pin-test .`
- `docker build -t terraform-registry-supply-chain-test .`
- `npm --prefix TerraformRegistry/web-src audit --audit-level=high`