### PR TITLE
refactor: propagate cancellation through module publication

### DIFF
--- a/TerraformRegistry.API/Interfaces/IModulePublicationRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IModulePublicationRepository.cs
@@ -4,12 +4,14 @@ namespace TerraformRegistry.API.Interfaces;
 
 public interface IModulePublicationRepository
 {
-    Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job);
+    Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job,
+        CancellationToken cancellationToken = default);
     Task<bool> TryCommitStagedPublicationAsync(
         ModulePublicationAttempt attempt,
         ModuleStorage newModule,
-        ModuleStorage? expectedModule);
-    Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason);
+        ModuleStorage? expectedModule, CancellationToken cancellationToken = default);
+    Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason,
+        CancellationToken cancellationToken = default);
     Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id);
     Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id);
 }

--- a/TerraformRegistry.API/Interfaces/IModuleService.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleService.cs
@@ -46,7 +46,8 @@ public interface IModuleService
     ///     Uploads a new module
     /// </summary>
     Task<bool> UploadModuleAsync(string moduleNamespace, string name, string provider, string version, Stream moduleContent,
-        string description, bool replace = false, ModuleArtifactMetadata? metadata = null);
+        string description, bool replace = false, ModuleArtifactMetadata? metadata = null,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Soft deletes a module version

--- a/TerraformRegistry.API/ModuleService.cs
+++ b/TerraformRegistry.API/ModuleService.cs
@@ -51,7 +51,8 @@ public abstract class ModuleService : IModuleService
     ///     Uploads a new module with SemVer validation
     /// </summary>
     public async Task<bool> UploadModuleAsync(string moduleNamespace, string name, string provider, string version,
-        Stream moduleContent, string description, bool replace = false, ModuleArtifactMetadata? metadata = null)
+        Stream moduleContent, string description, bool replace = false, ModuleArtifactMetadata? metadata = null,
+        CancellationToken cancellationToken = default)
     {
         var coordinateError = ModuleIdentifierValidator.GetModuleCoordinateError(moduleNamespace, name, provider);
         if (coordinateError != null)
@@ -67,14 +68,15 @@ public abstract class ModuleService : IModuleService
 
         // Delegate to the implementation-specific upload method
         return await UploadModuleAsyncCore(moduleNamespace, name, provider, version, moduleContent, description, replace,
-            metadata);
+            metadata, cancellationToken);
     }
 
     /// <summary>
     ///     Implementation-specific method to upload a module after validation
     /// </summary>
     protected abstract Task<bool> UploadModuleAsyncCore(string moduleNamespace, string name, string provider, string version,
-        Stream moduleContent, string description, bool replace, ModuleArtifactMetadata? metadata);
+        Stream moduleContent, string description, bool replace, ModuleArtifactMetadata? metadata,
+        CancellationToken cancellationToken);
 
     /// <summary>
     ///     Soft deletes a module version

--- a/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
+++ b/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
@@ -221,7 +221,8 @@ public class AzureBlobModuleService : ModuleService
     ///     actual module content is stored in Azure Blob Storage.
     /// </remarks>
     protected override async Task<bool> UploadModuleAsyncCore(string moduleNamespace, string name, string provider,
-        string version, Stream moduleContent, string description, bool replace, ModuleArtifactMetadata? metadata)
+        string version, Stream moduleContent, string description, bool replace, ModuleArtifactMetadata? metadata,
+        CancellationToken cancellationToken)
     {
         var existing = await _databaseService.GetModuleStorageAsync(moduleNamespace, name, provider, version);
         if (!replace && existing is not null)
@@ -259,7 +260,8 @@ public class AzureBlobModuleService : ModuleService
         var committed = false;
         try
         {
-            await _databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+            cancellationToken.ThrowIfCancellationRequested();
+            await _databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job, cancellationToken);
             await blobClient.UploadAsync(moduleContent, new BlobUploadOptions
             {
                 Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -271,7 +273,7 @@ public class AzureBlobModuleService : ModuleService
                     { "description", description },
                     { "publishedAt", now.ToString("o", CultureInfo.InvariantCulture) }
                 }
-            });
+            }, cancellationToken);
 
             var module = new ModuleStorage
             {
@@ -286,12 +288,19 @@ public class AzureBlobModuleService : ModuleService
                 Metadata = metadata ?? new ModuleArtifactMetadata()
             };
 
-            committed = await _databaseService.TryCommitStagedPublicationAsync(attempt, module, existing);
+            cancellationToken.ThrowIfCancellationRequested();
+            committed = await _databaseService.TryCommitStagedPublicationAsync(attempt, module, existing, cancellationToken);
             if (committed)
                 return true;
 
             await CleanupFailedPublicationAsync(blobClient, attemptId, "Catalog changed before publication could commit.");
             return false;
+        }
+        catch (OperationCanceledException)
+        {
+            if (!committed)
+                await CleanupFailedPublicationAsync(blobClient, attemptId, "Publication canceled.");
+            throw;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -493,7 +502,7 @@ public class AzureBlobModuleService : ModuleService
 
         try
         {
-            await _databaseService.TryFailStagedPublicationAsync(attemptId, reason);
+            await _databaseService.TryFailStagedPublicationAsync(attemptId, reason, CancellationToken.None);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
@@ -37,14 +37,17 @@ public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRep
     public Task<ModuleList> ListModulesAsync(ModuleSearchRequest request) =>
         _modules.ListModulesAsync(request);
 
-    public Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job) => _publications.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+    public Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job,
+        CancellationToken cancellationToken = default) =>
+        _publications.CreatePublicationAttemptWithExtractionJobAsync(attempt, job, cancellationToken);
     public Task<bool> TryCommitStagedPublicationAsync(
         ModulePublicationAttempt attempt,
         ModuleStorage newModule,
-        ModuleStorage? expectedModule) =>
-        _publications.TryCommitStagedPublicationAsync(attempt, newModule, expectedModule);
-    public Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason) =>
-        _publications.TryFailStagedPublicationAsync(attemptId, failureReason);
+        ModuleStorage? expectedModule, CancellationToken cancellationToken = default) =>
+        _publications.TryCommitStagedPublicationAsync(attempt, newModule, expectedModule, cancellationToken);
+    public Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason,
+        CancellationToken cancellationToken = default) =>
+        _publications.TryFailStagedPublicationAsync(attemptId, failureReason, cancellationToken);
     public Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) => _publications.GetPublicationAttemptAsync(id);
     public Task<ModuleExtractionJob?> GetExtractionJobAsync(Guid id) => _publications.GetExtractionJobAsync(id);
 

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
@@ -12,11 +12,12 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
 {
     public async Task CreatePublicationAttemptWithExtractionJobAsync(
         ModulePublicationAttempt attempt,
-        ModuleExtractionJob job)
+        ModuleExtractionJob job,
+        CancellationToken cancellationToken = default)
     {
         await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync();
-        await using var transaction = await connection.BeginTransactionAsync();
+        await connection.OpenAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken: cancellationToken);
         await using var command = new NpgsqlCommand(
             """
             INSERT INTO module_publication_attempts (
@@ -39,8 +40,8 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         AddAttemptParameters(command, attempt);
         AddJobParameters(command, job);
 
-        await command.ExecuteNonQueryAsync();
-        await transaction.CommitAsync();
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
     }
 
     public async Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id)
@@ -61,10 +62,11 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         return await reader.ReadAsync() ? ReadAttempt(reader) : null;
     }
 
-    public async Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason)
+    public async Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason,
+        CancellationToken cancellationToken = default)
     {
         await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
         await using var command = new NpgsqlCommand(
             """
             UPDATE module_publication_attempts
@@ -78,21 +80,22 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         command.Parameters.AddWithValue("@completedAt", DateTime.UtcNow);
         command.Parameters.AddWithValue("@id", attemptId);
         command.Parameters.AddWithValue("@staged", ModulePublicationAttemptState.Staged);
-        return await command.ExecuteNonQueryAsync() == 1;
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
     }
 
     public async Task<bool> TryCommitStagedPublicationAsync(
         ModulePublicationAttempt attempt,
         ModuleStorage newModule,
-        ModuleStorage? expectedModule)
+        ModuleStorage? expectedModule,
+        CancellationToken cancellationToken = default)
     {
         await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync();
-        await using var transaction = await connection.BeginTransactionAsync();
+        await connection.OpenAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken: cancellationToken);
 
         var catalogChanged = expectedModule is null
-            ? await TryInsertCatalogAsync(connection, transaction, newModule)
-            : await TryReplaceCatalogAsync(connection, transaction, expectedModule, newModule);
+            ? await TryInsertCatalogAsync(connection, transaction, newModule, cancellationToken)
+            : await TryReplaceCatalogAsync(connection, transaction, expectedModule, newModule, cancellationToken);
         if (!catalogChanged)
             return false;
 
@@ -118,7 +121,7 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         attemptCommand.Parameters.AddWithValue("@provider", newModule.Provider);
         attemptCommand.Parameters.AddWithValue("@version", newModule.Version);
         attemptCommand.Parameters.AddWithValue("@staged", ModulePublicationAttemptState.Staged);
-        if (await attemptCommand.ExecuteNonQueryAsync() != 1)
+        if (await attemptCommand.ExecuteNonQueryAsync(cancellationToken) != 1)
             return false;
 
         await using var jobCommand = new NpgsqlCommand(
@@ -133,10 +136,10 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         jobCommand.Parameters.AddWithValue("@updatedAt", DateTime.UtcNow);
         jobCommand.Parameters.AddWithValue("@attemptId", attempt.Id);
         jobCommand.Parameters.AddWithValue("@staged", ModuleExtractionJobState.Staged);
-        if (await jobCommand.ExecuteNonQueryAsync() != 1)
+        if (await jobCommand.ExecuteNonQueryAsync(cancellationToken) != 1)
             return false;
 
-        await transaction.CommitAsync();
+        await transaction.CommitAsync(cancellationToken);
         return true;
     }
 
@@ -264,7 +267,8 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
     private static async Task<bool> TryInsertCatalogAsync(
         NpgsqlConnection connection,
         NpgsqlTransaction transaction,
-        ModuleStorage module)
+        ModuleStorage module,
+        CancellationToken cancellationToken)
     {
         await using var command = new NpgsqlCommand(
             """
@@ -277,14 +281,15 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
             connection,
             transaction);
         AddModuleParameters(command, module, string.Empty);
-        return await command.ExecuteNonQueryAsync() == 1;
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
     }
 
     private static async Task<bool> TryReplaceCatalogAsync(
         NpgsqlConnection connection,
         NpgsqlTransaction transaction,
         ModuleStorage expected,
-        ModuleStorage replacement)
+        ModuleStorage replacement,
+        CancellationToken cancellationToken)
     {
         await using var command = new NpgsqlCommand(
             """
@@ -309,7 +314,7 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
             transaction);
         AddModuleParameters(command, expected, string.Empty);
         AddModuleParameters(command, replacement, "new");
-        return await command.ExecuteNonQueryAsync() == 1;
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
     }
 
     private static void AddModuleParameters(NpgsqlCommand command, ModuleStorage module, string prefix)

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModulePublicationRepository.cs
@@ -139,7 +139,12 @@ public sealed class PostgreSqlModulePublicationRepository(string connectionStrin
         if (await jobCommand.ExecuteNonQueryAsync(cancellationToken) != 1)
             return false;
 
-        await transaction.CommitAsync(cancellationToken);
+        // Once the catalog and attempt updates are ready, the transaction must either be rolled back because the
+        // request was already cancelled or be committed conclusively. Passing the request token to CommitAsync
+        // leaves an ambiguous window where PostgreSQL commits but the client observes cancellation, causing the
+        // caller to delete an artifact that the catalog now references.
+        cancellationToken.ThrowIfCancellationRequested();
+        await transaction.CommitAsync(CancellationToken.None);
         return true;
     }
 

--- a/TerraformRegistry.S3/S3ModuleObjectStore.cs
+++ b/TerraformRegistry.S3/S3ModuleObjectStore.cs
@@ -144,7 +144,8 @@ internal sealed class S3ModuleObjectStore(
         }
     }
 
-    public async Task<bool> UploadTemporaryObjectAsync(ModuleStorage module, Stream moduleContent, string tempKey)
+    public async Task<bool> UploadTemporaryObjectAsync(ModuleStorage module, Stream moduleContent, string tempKey,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -156,8 +157,12 @@ internal sealed class S3ModuleObjectStore(
                 AutoCloseStream = false
             };
             AddModuleMetadata(putRequest.Metadata, module);
-            await s3Client.PutObjectAsync(putRequest);
+            await s3Client.PutObjectAsync(putRequest, cancellationToken);
             return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -193,7 +198,8 @@ internal sealed class S3ModuleObjectStore(
         }
     }
 
-    public async Task<bool> TryPromoteTemporaryObjectAsync(string tempKey, ModuleStorage module, string operation)
+    public async Task<bool> TryPromoteTemporaryObjectAsync(string tempKey, ModuleStorage module, string operation,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -204,8 +210,12 @@ internal sealed class S3ModuleObjectStore(
                 DestinationBucket = bucketName,
                 DestinationKey = module.FilePath,
                 IfNoneMatch = "*"
-            });
+            }, cancellationToken);
             return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/TerraformRegistry.S3/S3ModuleService.cs
+++ b/TerraformRegistry.S3/S3ModuleService.cs
@@ -104,10 +104,11 @@ public class S3ModuleService : ModuleService
     }
 
     protected override Task<bool> UploadModuleAsyncCore(string moduleNamespace, string name, string provider,
-        string version, Stream moduleContent, string description, bool replace, ModuleArtifactMetadata? metadata)
+        string version, Stream moduleContent, string description, bool replace, ModuleArtifactMetadata? metadata,
+        CancellationToken cancellationToken)
     {
         return _uploadWorkflow.UploadModuleAsync(moduleNamespace, name, provider, version, moduleContent, description,
-            replace, metadata);
+            replace, metadata, cancellationToken);
     }
 
     public override Task<bool> DeleteModuleVersionAsync(string moduleNamespace, string name, string provider,

--- a/TerraformRegistry.S3/S3ModuleUploadWorkflow.cs
+++ b/TerraformRegistry.S3/S3ModuleUploadWorkflow.cs
@@ -18,7 +18,8 @@ internal sealed class S3ModuleUploadWorkflow(
         Stream moduleContent,
         string description,
         bool replace,
-        ModuleArtifactMetadata? metadata)
+        ModuleArtifactMetadata? metadata,
+        CancellationToken cancellationToken)
     {
         ModuleStorage? existingModule;
         try
@@ -98,7 +99,8 @@ internal sealed class S3ModuleUploadWorkflow(
         };
         try
         {
-            await databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+            cancellationToken.ThrowIfCancellationRequested();
+            await databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job, cancellationToken);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -108,13 +110,31 @@ internal sealed class S3ModuleUploadWorkflow(
             return false;
         }
 
-        if (!await objectStore.UploadTemporaryObjectAsync(newModule, moduleContent, tempKey))
+        try
         {
-            await TryFailPublicationAsync(attemptId, "Temporary S3 upload failed.");
-            return false;
+            if (!await objectStore.UploadTemporaryObjectAsync(newModule, moduleContent, tempKey, cancellationToken))
+            {
+                await TryFailPublicationAsync(attemptId, "Temporary S3 upload failed.");
+                return false;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            await CleanupFailedPublicationAsync(newModule, tempKey, attemptId, "Publication canceled.");
+            throw;
         }
 
-        return await FinalizeUploadAsync(existingModule, newModule, tempKey, attempt, replace && existingModule != null);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await FinalizeUploadAsync(existingModule, newModule, tempKey, attempt, replace && existingModule != null,
+                cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            await CleanupFailedPublicationAsync(newModule, tempKey, attemptId, "Publication canceled.");
+            throw;
+        }
     }
 
     private async Task<bool> EnsureNoDeletedModuleBlocksUploadAsync(
@@ -158,9 +178,11 @@ internal sealed class S3ModuleUploadWorkflow(
         ModuleStorage newModule,
         string tempKey,
         ModulePublicationAttempt attempt,
-        bool replacingExisting)
+        bool replacingExisting,
+        CancellationToken cancellationToken)
     {
-        if (!await objectStore.TryPromoteTemporaryObjectAsync(tempKey, newModule, replacingExisting ? "replace" : "create"))
+        if (!await objectStore.TryPromoteTemporaryObjectAsync(tempKey, newModule, replacingExisting ? "replace" : "create",
+                cancellationToken))
         {
             await CleanupFailedPublicationAsync(newModule, tempKey, attempt.Id, "S3 finalization failed.");
             return false;
@@ -169,7 +191,9 @@ internal sealed class S3ModuleUploadWorkflow(
         bool committed;
         try
         {
-            committed = await databaseService.TryCommitStagedPublicationAsync(attempt, newModule, existingModule);
+            cancellationToken.ThrowIfCancellationRequested();
+            committed = await databaseService.TryCommitStagedPublicationAsync(attempt, newModule, existingModule,
+                cancellationToken);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -208,7 +232,7 @@ internal sealed class S3ModuleUploadWorkflow(
 
     private async Task TryFailPublicationAsync(Guid attemptId, string reason)
     {
-        try { await databaseService.TryFailStagedPublicationAsync(attemptId, reason); }
+        try { await databaseService.TryFailStagedPublicationAsync(attemptId, reason, CancellationToken.None); }
         catch (Exception ex) when (ex is not OperationCanceledException) { RegistryLog.Error(logger, ex, "Failed to mark staged S3 publication {AttemptId} as failed.", attemptId); }
     }
 }

--- a/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceUploadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceUploadTests.cs
@@ -137,7 +137,7 @@ public class AzureBlobModuleServiceUploadTests
             .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
         _mockContainerClient.Setup(cc => cc.GetBlobClient(It.IsAny<string>())).Returns(mockBlobClient.Object);
         _mockDatabaseService.Setup(db => db.GetModuleStorageAsync("ns", "name", "prov", "1.0.0"))
-            .ReturnsAsync(null);
+            .ReturnsAsync((ModuleStorage?)null);
         _mockDatabaseService.Setup(db => db.CreatePublicationAttemptWithExtractionJobAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);

--- a/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceUploadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceUploadTests.cs
@@ -127,6 +127,39 @@ public class AzureBlobModuleServiceUploadTests
     }
 
     [Fact]
+    public async Task UploadModuleAsyncKeepsCommittedBlobWhenRequestIsCanceledAfterCommit()
+    {
+        var mockBlobClient = new Mock<BlobClient>();
+        mockBlobClient.Setup(bc => bc.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Mock.Of<Response<BlobContentInfo>>());
+        mockBlobClient.Setup(bc => bc.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(),
+                It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
+        _mockContainerClient.Setup(cc => cc.GetBlobClient(It.IsAny<string>())).Returns(mockBlobClient.Object);
+        _mockDatabaseService.Setup(db => db.GetModuleStorageAsync("ns", "name", "prov", "1.0.0"))
+            .ReturnsAsync((ModuleStorage?)null);
+        _mockDatabaseService.Setup(db => db.CreatePublicationAttemptWithExtractionJobAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        using var cancellation = new CancellationTokenSource();
+        _mockDatabaseService.Setup(db => db.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null, cancellation.Token))
+            .Callback(() => cancellation.Cancel())
+            .ReturnsAsync(true);
+        var service = CreateService();
+        using var stream = new MemoryStream([1, 2, 3]);
+
+        var result = await service.UploadModuleAsync("ns", "name", "prov", "1.0.0", stream, "desc",
+            cancellationToken: cancellation.Token);
+
+        Assert.True(result);
+        mockBlobClient.Verify(bc => bc.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(),
+            It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockDatabaseService.Verify(db => db.TryFailStagedPublicationAsync(It.IsAny<Guid>(), It.IsAny<string>(),
+            CancellationToken.None), Times.Never);
+    }
+
+    [Fact]
     public async Task UploadModuleAsyncStagesAnAttemptOwnedBlobAndCommitsTheCatalog()
     {
         var blobPaths = new List<string>();

--- a/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceUploadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceUploadTests.cs
@@ -137,7 +137,7 @@ public class AzureBlobModuleServiceUploadTests
             .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
         _mockContainerClient.Setup(cc => cc.GetBlobClient(It.IsAny<string>())).Returns(mockBlobClient.Object);
         _mockDatabaseService.Setup(db => db.GetModuleStorageAsync("ns", "name", "prov", "1.0.0"))
-            .ReturnsAsync((ModuleStorage?)null);
+            .ReturnsAsync(null);
         _mockDatabaseService.Setup(db => db.CreatePublicationAttemptWithExtractionJobAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);

--- a/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
@@ -268,7 +268,7 @@ public class LocalModuleServiceTests
             .Returns(Task.FromResult<ModuleStorage?>(null));
         _mockDbService.Setup(x => x.TryCommitStagedPublicationAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null))
-            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?>((_, module, _) => committed = module)
+            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?, CancellationToken>((_, module, _, _) => committed = module)
             .ReturnsAsync(true);
         // Act
         var result = await service.CallUploadModuleAsyncCore(ns, name, provider, version, content, desc);
@@ -291,7 +291,7 @@ public class LocalModuleServiceTests
             .Returns(Task.FromResult<ModuleStorage?>(null));
         _mockDbService.Setup(x => x.CreatePublicationAttemptWithExtractionJobAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
-            .Callback<ModulePublicationAttempt, ModuleExtractionJob>((attempt, job) =>
+            .Callback<ModulePublicationAttempt, ModuleExtractionJob, CancellationToken>((attempt, job, _) =>
             {
                 capturedAttempt = attempt;
                 capturedJob = job;
@@ -299,7 +299,7 @@ public class LocalModuleServiceTests
             .Returns(Task.CompletedTask);
         _mockDbService.Setup(x => x.TryCommitStagedPublicationAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null))
-            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?>((_, module, _) => capturedModule = module)
+            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?, CancellationToken>((_, module, _, _) => capturedModule = module)
             .ReturnsAsync(true);
 
         var result = await service.CallUploadModuleAsyncCore("ns", "name", "provider", "1.0.0", content, "desc");
@@ -340,11 +340,11 @@ public class LocalModuleServiceTests
             .ReturnsAsync(existing);
         _mockDbService.Setup(x => x.CreatePublicationAttemptWithExtractionJobAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
-            .Callback<ModulePublicationAttempt, ModuleExtractionJob>((attempt, _) => attemptedPublication = attempt)
+            .Callback<ModulePublicationAttempt, ModuleExtractionJob, CancellationToken>((attempt, _, _) => attemptedPublication = attempt)
             .Returns(Task.CompletedTask);
         _mockDbService.Setup(x => x.TryCommitStagedPublicationAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), existing))
-            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?>((_, module, _) => attemptedModule = module)
+            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?, CancellationToken>((_, module, _, _) => attemptedModule = module)
             .ReturnsAsync(false);
         _mockDbService.Setup(x => x.TryFailStagedPublicationAsync(It.IsAny<Guid>(), It.IsAny<string>()))
             .ReturnsAsync(true);
@@ -462,9 +462,10 @@ public class LocalModuleServiceTests
         }
 
         public Task<bool> CallUploadModuleAsyncCore(string ns, string name, string provider, string version,
-            Stream content, string desc, bool replace = false)
+            Stream content, string desc, bool replace = false, CancellationToken cancellationToken = default)
         {
-            return base.UploadModuleAsyncCore(ns, name, provider, version, content, desc, replace, null);
+            return base.UploadModuleAsyncCore(ns, name, provider, version, content, desc, replace, null,
+                cancellationToken);
         }
     }
 

--- a/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LocalModuleServiceTests.cs
@@ -316,6 +316,33 @@ public class LocalModuleServiceTests
     }
 
     [Fact]
+    public async Task UploadModuleAsyncCoreKeepsCommittedArtifactWhenRequestIsCanceledAfterCommit()
+    {
+        var service = new TestableLocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);
+        await using var content = new MemoryStream(Encoding.UTF8.GetBytes("committed"));
+        using var cancellation = new CancellationTokenSource();
+        ModuleStorage? committedModule = null;
+
+        _mockDbService.Setup(x => x.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null, cancellation.Token))
+            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?, CancellationToken>((_, module, _, _) =>
+            {
+                committedModule = module;
+                cancellation.Cancel();
+            })
+            .ReturnsAsync(true);
+
+        var result = await service.CallUploadModuleAsyncCore("ns", "name", "provider", "1.0.0", content, "desc",
+            cancellationToken: cancellation.Token);
+
+        Assert.True(result);
+        Assert.NotNull(committedModule);
+        Assert.True(File.Exists(committedModule!.FilePath));
+        _mockDbService.Verify(x => x.TryFailStagedPublicationAsync(It.IsAny<Guid>(), It.IsAny<string>(),
+            CancellationToken.None), Times.Never);
+    }
+
+    [Fact]
     public async Task UploadModuleAsyncCoreRemovesOnlyItsArtifactWhenCatalogCommitLoses()
     {
         var service = new TestableLocalModuleService(_configuration, _mockDbService.Object, _mockLogger.Object);

--- a/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
@@ -126,6 +126,46 @@ public class ModulePublishCoordinatorTests
     }
 
     [Fact]
+    public async Task PublishAsyncPassesCancellationTokenToModuleStorageBeforePublicationCommits()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var moduleService = new Mock<IModuleService>();
+        moduleService
+            .Setup(x => x.UploadModuleAsync(
+                "acme",
+                "network",
+                "aws",
+                "1.2.3",
+                It.IsAny<Stream>(),
+                "VPC module",
+                false,
+                It.IsAny<ModuleArtifactMetadata>(),
+                cancellation.Token))
+            .ReturnsAsync(true);
+
+        var coordinator = new ModulePublishCoordinator(
+            moduleService.Object,
+            Mock.Of<IModuleExtractionService>(),
+            CreateWebhookDispatcher(),
+            Mock.Of<IAuditService>(),
+            NullLogger<ModulePublishCoordinator>.Instance);
+        await using var content = new MemoryStream([1, 2, 3]);
+
+        await coordinator.PublishAsync(new ModulePublishRequest
+        {
+            Namespace = "acme",
+            Name = "network",
+            Provider = "aws",
+            Version = "1.2.3",
+            Description = "VPC module",
+            ModuleContent = content,
+            Metadata = new ModuleArtifactMetadata { Source = new ModuleSourceInfo { Kind = "api-upload" } }
+        }, cancellation.Token);
+
+        moduleService.VerifyAll();
+    }
+
+    [Fact]
     public async Task PublishAsyncReturnsFalseWhenStorageRejectsDuplicate()
     {
         var moduleService = new Mock<IModuleService>();

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceUploadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceUploadTests.cs
@@ -83,11 +83,11 @@ public class S3ModuleServiceUploadTests
             .ReturnsAsync(new CopyObjectResponse());
         _database.Setup(x => x.CreatePublicationAttemptWithExtractionJobAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()))
-            .Callback<ModulePublicationAttempt, ModuleExtractionJob>((value, _) => attempt = value)
+            .Callback<ModulePublicationAttempt, ModuleExtractionJob, CancellationToken>((value, _, _) => attempt = value)
             .Returns(Task.CompletedTask);
         _database.Setup(x => x.TryCommitStagedPublicationAsync(
                 It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null))
-            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?>((_, module, _) => committed = module)
+            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?, CancellationToken>((_, module, _, _) => committed = module)
             .ReturnsAsync(true);
         using var content = new MemoryStream([1]);
 
@@ -104,6 +104,35 @@ public class S3ModuleServiceUploadTests
         Assert.Equal(promotion.DestinationKey, committed!.FilePath);
         _database.Verify(x => x.AddModuleAsync(It.IsAny<ModuleStorage>()), Times.Never);
         _database.Verify(x => x.ReplaceModuleExactAsync(It.IsAny<ModuleStorage>(), It.IsAny<ModuleStorage>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadModuleAsyncCancelsBeforeCatalogCommitAndRemovesAttemptObjects()
+    {
+        using var cancellation = new CancellationTokenSource();
+        _s3.Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), cancellation.Token))
+            .ReturnsAsync(new PutObjectResponse());
+        _s3.Setup(x => x.CopyObjectAsync(It.IsAny<CopyObjectRequest>(), cancellation.Token))
+            .Callback(() => cancellation.Cancel())
+            .ReturnsAsync(new CopyObjectResponse());
+        _s3.Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeleteObjectResponse());
+        _database.Setup(x => x.TryFailStagedPublicationAsync(It.IsAny<Guid>(), It.IsAny<string>(),
+                CancellationToken.None))
+            .ReturnsAsync(true);
+        using var content = new MemoryStream([1]);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            CreateService().UploadModuleAsync("ns", "name", "aws", "1.0.0", content, "desc",
+                cancellationToken: cancellation.Token));
+
+        _database.Verify(x => x.TryCommitStagedPublicationAsync(
+            It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), It.IsAny<ModuleStorage?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        _database.Verify(x => x.TryFailStagedPublicationAsync(It.IsAny<Guid>(), "Publication canceled.",
+            CancellationToken.None), Times.Once);
+        _s3.Verify(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
     }
 
     [Fact]

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceUploadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceUploadTests.cs
@@ -136,6 +136,35 @@ public class S3ModuleServiceUploadTests
     }
 
     [Fact]
+    public async Task UploadModuleAsyncKeepsFinalObjectWhenRequestIsCanceledAfterCommit()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var deleted = new List<string>();
+        ModuleStorage? committedModule = null;
+        _database.Setup(x => x.TryCommitStagedPublicationAsync(
+                It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleStorage>(), null, cancellation.Token))
+            .Callback<ModulePublicationAttempt, ModuleStorage, ModuleStorage?, CancellationToken>((_, module, _, _) =>
+            {
+                committedModule = module;
+                cancellation.Cancel();
+            })
+            .ReturnsAsync(true);
+        _s3.Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<DeleteObjectRequest, CancellationToken>((request, _) => deleted.Add(request.Key))
+            .ReturnsAsync(new DeleteObjectResponse());
+        using var content = new MemoryStream([1]);
+
+        var result = await CreateService().UploadModuleAsync("ns", "name", "aws", "1.0.0", content, "desc",
+            cancellationToken: cancellation.Token);
+
+        Assert.True(result);
+        Assert.NotNull(committedModule);
+        Assert.DoesNotContain(committedModule!.FilePath, deleted);
+        _database.Verify(x => x.TryFailStagedPublicationAsync(It.IsAny<Guid>(), It.IsAny<string>(),
+            CancellationToken.None), Times.Never);
+    }
+
+    [Fact]
     public async Task UploadModuleAsyncCleansOnlyAttemptObjectsWhenCatalogCommitLoses()
     {
         var deleted = new List<string>();

--- a/TerraformRegistry/Handlers/ModuleHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleHandlers.cs
@@ -279,7 +279,7 @@ public static class ModuleHandlers
                 $"Version '{version}' is not a valid Semantic Version (SemVer 2.0.0). Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILDMETADATA]");
         }
 
-        var form = await request.ReadFormAsync();
+        var form = await request.ReadFormAsync(context.RequestAborted);
         var moduleFile = form.Files["moduleFile"];
         var description = form["description"].ToString() ?? string.Empty;
 

--- a/TerraformRegistry/Services/LocalModuleService.cs
+++ b/TerraformRegistry/Services/LocalModuleService.cs
@@ -274,7 +274,8 @@ public class LocalModuleService : ModuleService
     ///     Implementation-specific method to upload a module after validation
     /// </summary>
     protected override async Task<bool> UploadModuleAsyncCore(string moduleNamespace, string name, string provider,
-        string version, Stream moduleContent, string description, bool replace, ModuleArtifactMetadata? metadata)
+        string version, Stream moduleContent, string description, bool replace, ModuleArtifactMetadata? metadata,
+        CancellationToken cancellationToken)
     {
         var coordinateError = ModuleIdentifierValidator.GetModuleCoordinateError(moduleNamespace, name, provider);
         if (coordinateError != null)
@@ -321,13 +322,15 @@ public class LocalModuleService : ModuleService
 
         try
         {
-            await _databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+            cancellationToken.ThrowIfCancellationRequested();
+            await _databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job, cancellationToken);
             Directory.CreateDirectory(stagingDirectory);
             await using (var fileStream = File.Create(stagingFilePath))
             {
-                await moduleContent.CopyToAsync(fileStream);
+                await moduleContent.CopyToAsync(fileStream, cancellationToken);
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             Directory.CreateDirectory(finalDirectory);
             File.Move(stagingFilePath, finalFilePath);
 
@@ -344,13 +347,23 @@ public class LocalModuleService : ModuleService
                 Metadata = metadata ?? new ModuleArtifactMetadata()
             };
 
-            committed = await _databaseService.TryCommitStagedPublicationAsync(attempt, module, existing);
+            cancellationToken.ThrowIfCancellationRequested();
+            committed = await _databaseService.TryCommitStagedPublicationAsync(attempt, module, existing, cancellationToken);
             if (committed)
                 return true;
 
             CleanupOwnedArtifact(finalDirectory, stagingFilePath);
-            await _databaseService.TryFailStagedPublicationAsync(attemptId, "Catalog changed before publication could commit.");
+            await _databaseService.TryFailStagedPublicationAsync(attemptId, "Catalog changed before publication could commit.", CancellationToken.None);
             return false;
+        }
+        catch (OperationCanceledException)
+        {
+            if (!committed)
+            {
+                CleanupOwnedArtifact(finalDirectory, stagingFilePath);
+                await TryFailPublicationAttemptAsync(attemptId, "Publication canceled.");
+            }
+            throw;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -472,7 +485,7 @@ public class LocalModuleService : ModuleService
     {
         try
         {
-            await _databaseService.TryFailStagedPublicationAsync(attemptId, reason);
+            await _databaseService.TryFailStagedPublicationAsync(attemptId, reason, CancellationToken.None);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionService.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionService.cs
@@ -77,7 +77,7 @@ public sealed class ModuleExtractionService : IModuleExtractionService
             CreatedAt = now,
             UpdatedAt = now
         };
-        await _databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+        await _databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job, cancellationToken);
         await MarkPendingAsync(request);
         return true;
     }

--- a/TerraformRegistry/Services/Publishing/ModulePublishCoordinator.cs
+++ b/TerraformRegistry/Services/Publishing/ModulePublishCoordinator.cs
@@ -34,7 +34,8 @@ public sealed class ModulePublishCoordinator(
             content,
             request.Description,
             request.Replace,
-            request.Metadata);
+            request.Metadata,
+            cancellationToken);
 
         if (!uploaded)
             return false;

--- a/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
@@ -142,6 +142,8 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         if (await jobCommand.ExecuteNonQueryAsync(cancellationToken) != 1)
             return false;
 
+        // Keep the same irreversible boundary as PostgreSQL: cancellation is honored before commit, never during it.
+        cancellationToken.ThrowIfCancellationRequested();
         transaction.Commit();
         return true;
     }

--- a/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModulePublicationRepository.cs
@@ -12,10 +12,11 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
 {
     public async Task CreatePublicationAttemptWithExtractionJobAsync(
         ModulePublicationAttempt attempt,
-        ModuleExtractionJob job)
+        ModuleExtractionJob job,
+        CancellationToken cancellationToken = default)
     {
         await using var connection = new SqliteConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
         await using var transaction = connection.BeginTransaction();
 
         await using (var command = connection.CreateCommand())
@@ -30,7 +31,7 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
                     $expectedRevision, $committedRevision, $error, $createdAt, $updatedAt, $completedAt)
                 """;
             AddAttemptParameters(command, attempt);
-            await command.ExecuteNonQueryAsync();
+            await command.ExecuteNonQueryAsync(cancellationToken);
         }
 
         await using (var command = connection.CreateCommand())
@@ -44,7 +45,7 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
                     $leaseExpiresAt, $attemptCount, $lastError, $createdAt, $updatedAt, $completedAt)
                 """;
             AddJobParameters(command, job);
-            await command.ExecuteNonQueryAsync();
+            await command.ExecuteNonQueryAsync(cancellationToken);
         }
 
         transaction.Commit();
@@ -67,10 +68,11 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         return await reader.ReadAsync() ? ReadAttempt(reader) : null;
     }
 
-    public async Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason)
+    public async Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason,
+        CancellationToken cancellationToken = default)
     {
         await using var connection = new SqliteConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
         await using var command = connection.CreateCommand();
         command.CommandText = """
             UPDATE module_publication_attempts
@@ -83,21 +85,22 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         command.Parameters.AddWithValue("$completedAt", DateTime.UtcNow.ToString("O"));
         command.Parameters.AddWithValue("$id", attemptId.ToString());
         command.Parameters.AddWithValue("$staged", ModulePublicationAttemptState.Staged);
-        return await command.ExecuteNonQueryAsync() == 1;
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
     }
 
     public async Task<bool> TryCommitStagedPublicationAsync(
         ModulePublicationAttempt attempt,
         ModuleStorage newModule,
-        ModuleStorage? expectedModule)
+        ModuleStorage? expectedModule,
+        CancellationToken cancellationToken = default)
     {
         await using var connection = new SqliteConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
         await using var transaction = connection.BeginTransaction();
 
         var catalogChanged = expectedModule is null
-            ? await TryInsertCatalogAsync(connection, transaction, newModule)
-            : await TryReplaceCatalogAsync(connection, transaction, expectedModule, newModule);
+            ? await TryInsertCatalogAsync(connection, transaction, newModule, cancellationToken)
+            : await TryReplaceCatalogAsync(connection, transaction, expectedModule, newModule, cancellationToken);
         if (!catalogChanged)
             return false;
 
@@ -122,7 +125,7 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         attemptCommand.Parameters.AddWithValue("$provider", newModule.Provider);
         attemptCommand.Parameters.AddWithValue("$version", newModule.Version);
         attemptCommand.Parameters.AddWithValue("$staged", ModulePublicationAttemptState.Staged);
-        if (await attemptCommand.ExecuteNonQueryAsync() != 1)
+        if (await attemptCommand.ExecuteNonQueryAsync(cancellationToken) != 1)
             return false;
 
         await using var jobCommand = connection.CreateCommand();
@@ -136,7 +139,7 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
         jobCommand.Parameters.AddWithValue("$updatedAt", DateTime.UtcNow.ToString("O"));
         jobCommand.Parameters.AddWithValue("$attemptId", attempt.Id.ToString());
         jobCommand.Parameters.AddWithValue("$staged", ModuleExtractionJobState.Staged);
-        if (await jobCommand.ExecuteNonQueryAsync() != 1)
+        if (await jobCommand.ExecuteNonQueryAsync(cancellationToken) != 1)
             return false;
 
         transaction.Commit();
@@ -262,7 +265,8 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
     private static async Task<bool> TryInsertCatalogAsync(
         SqliteConnection connection,
         SqliteTransaction transaction,
-        ModuleStorage module)
+        ModuleStorage module,
+        CancellationToken cancellationToken)
     {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
@@ -274,14 +278,15 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
             ON CONFLICT(namespace, name, provider, version) DO NOTHING
             """;
         AddModuleParameters(command, module, "");
-        return await command.ExecuteNonQueryAsync() == 1;
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
     }
 
     private static async Task<bool> TryReplaceCatalogAsync(
         SqliteConnection connection,
         SqliteTransaction transaction,
         ModuleStorage expected,
-        ModuleStorage replacement)
+        ModuleStorage replacement,
+        CancellationToken cancellationToken)
     {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
@@ -305,7 +310,7 @@ public sealed class SqliteModulePublicationRepository(string connectionString) :
             """;
         AddModuleParameters(command, expected, "");
         AddModuleParameters(command, replacement, "new");
-        return await command.ExecuteNonQueryAsync() == 1;
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
     }
 
     private static void AddModuleParameters(SqliteCommand command, ModuleStorage module, string prefix)

--- a/TerraformRegistry/Services/SqliteDatabaseService.cs
+++ b/TerraformRegistry/Services/SqliteDatabaseService.cs
@@ -40,17 +40,19 @@ public class SqliteDatabaseService : IDatabaseService, IModulePublicationReposit
         return Task.CompletedTask;
     }
 
-    public Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job) =>
-        _publications.CreatePublicationAttemptWithExtractionJobAsync(attempt, job);
+    public Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job,
+        CancellationToken cancellationToken = default) =>
+        _publications.CreatePublicationAttemptWithExtractionJobAsync(attempt, job, cancellationToken);
 
     public Task<bool> TryCommitStagedPublicationAsync(
         ModulePublicationAttempt attempt,
         ModuleStorage newModule,
-        ModuleStorage? expectedModule) =>
-        _publications.TryCommitStagedPublicationAsync(attempt, newModule, expectedModule);
+        ModuleStorage? expectedModule, CancellationToken cancellationToken = default) =>
+        _publications.TryCommitStagedPublicationAsync(attempt, newModule, expectedModule, cancellationToken);
 
-    public Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason) =>
-        _publications.TryFailStagedPublicationAsync(attemptId, failureReason);
+    public Task<bool> TryFailStagedPublicationAsync(Guid attemptId, string failureReason,
+        CancellationToken cancellationToken = default) =>
+        _publications.TryFailStagedPublicationAsync(attemptId, failureReason, cancellationToken);
 
     public Task<ModulePublicationAttempt?> GetPublicationAttemptAsync(Guid id) => _publications.GetPublicationAttemptAsync(id);
 


### PR DESCRIPTION
## Summary
- carry request cancellation through module upload, publication storage, and transactional catalog commits
- cancel Local, Azure Blob, and S3 publication flows while cleaning attempt-owned artifacts
- add cancellation-boundary regression coverage for coordinator and S3 publication

## Verification
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --filter ...` (37 passed)
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore` (exit 0 before rebase)