### PR TITLE
refactor: propagate cancellation through module reads

### DIFF
--- a/TerraformRegistry.API/Interfaces/IModuleExtractionRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleExtractionRepository.cs
@@ -25,7 +25,8 @@ public interface IModuleExtractionRepository
         string moduleNamespace,
         string name,
         string provider,
-        string version);
+        string version,
+        CancellationToken cancellationToken = default);
 
     Task UpsertModuleLlmContextAsync(
         string moduleNamespace,

--- a/TerraformRegistry.API/Interfaces/IModuleRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleRepository.cs
@@ -73,7 +73,7 @@ public interface IModuleRepository
     /// <summary>
     ///     Lists all soft-deleted modules.
     /// </summary>
-    Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request);
+    Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Gets a module including soft-deleted ones.

--- a/TerraformRegistry.API/Interfaces/IModuleRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleRepository.cs
@@ -10,22 +10,25 @@ public interface IModuleRepository
     /// <summary>
     ///     Lists all modules based on search criteria.
     /// </summary>
-    Task<ModuleList> ListModulesAsync(ModuleSearchRequest request);
+    Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Gets detailed information about a specific module.
     /// </summary>
-    Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version);
+    Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Gets all versions of a specific module.
     /// </summary>
-    Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider);
+    Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Gets the storage path information for a specific module version.
     /// </summary>
-    Task<ModuleStorage?> GetModuleStorageAsync(string moduleNamespace, string name, string provider, string version);
+    Task<ModuleStorage?> GetModuleStorageAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Adds a new module to the database.

--- a/TerraformRegistry.API/Interfaces/IModuleService.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleService.cs
@@ -20,22 +20,25 @@ public interface IModuleService
     /// <summary>
     ///     Lists all modules
     /// </summary>
-    Task<ModuleList> ListModulesAsync(ModuleSearchRequest request);
+    Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Gets detailed information about a specific module
     /// </summary>
-    Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version);
+    Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Gets all versions of a specific module
     /// </summary>
-    Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider);
+    Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Gets the download path for a specific module version
     /// </summary>
-    Task<string?> GetModuleDownloadPathAsync(string moduleNamespace, string name, string provider, string version);
+    Task<string?> GetModuleDownloadPathAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Opens the stored module package for internal processing

--- a/TerraformRegistry.API/Interfaces/IModuleService.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleService.cs
@@ -70,7 +70,7 @@ public interface IModuleService
     /// <summary>
     ///     Lists all soft-deleted modules
     /// </summary>
-    Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request);
+    Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Updates the description for all active versions of a module

--- a/TerraformRegistry.API/ModuleService.cs
+++ b/TerraformRegistry.API/ModuleService.cs
@@ -23,23 +23,25 @@ public abstract class ModuleService : IModuleService
     /// <summary>
     ///     Lists all modules
     /// </summary>
-    public abstract Task<ModuleList> ListModulesAsync(ModuleSearchRequest request);
+    public abstract Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Gets detailed information about a specific module
     /// </summary>
-    public abstract Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version);
+    public abstract Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Gets all versions of a specific module
     /// </summary>
-    public abstract Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider);
+    public abstract Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Gets the download path for a specific module version
     /// </summary>
     public abstract Task<string?> GetModuleDownloadPathAsync(string moduleNamespace, string name, string provider,
-        string version);
+        string version, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Opens the stored module package for internal processing

--- a/TerraformRegistry.API/ModuleService.cs
+++ b/TerraformRegistry.API/ModuleService.cs
@@ -100,7 +100,8 @@ public abstract class ModuleService : IModuleService
     /// <summary>
     ///     Lists all soft-deleted modules
     /// </summary>
-    public abstract Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request);
+    public abstract Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Updates the description for all active versions of a module

--- a/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
+++ b/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
@@ -484,9 +484,10 @@ public class AzureBlobModuleService : ModuleService
         return await _databaseService.RemoveModuleAsync(moduleStorage);
     }
 
-    public override Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request)
+    public override Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request,
+        CancellationToken cancellationToken = default)
     {
-        return _databaseService.ListDeletedModulesAsync(request);
+        return _databaseService.ListDeletedModulesAsync(request, cancellationToken);
     }
 
     public override Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider,

--- a/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
+++ b/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
@@ -108,35 +108,37 @@ public class AzureBlobModuleService : ModuleService
     /// <summary>
     ///     Lists all modules based on search criteria
     /// </summary>
-    public override Task<ModuleList> ListModulesAsync(ModuleSearchRequest request)
+    public override Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default)
     {
-        return _databaseService.ListModulesAsync(request);
+        return _databaseService.ListModulesAsync(request, cancellationToken);
     }
 
     /// <summary>
     ///     Gets detailed information about a specific module
     /// </summary>
-    public override Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version)
+    public override Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
-        return _databaseService.GetModuleAsync(moduleNamespace, name, provider, version);
+        return _databaseService.GetModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
     }
 
     /// <summary>
     ///     Gets all versions of a specific module
     /// </summary>
-    public override Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider)
+    public override Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider,
+        CancellationToken cancellationToken = default)
     {
-        return _databaseService.GetModuleVersionsAsync(moduleNamespace, name, provider);
+        return _databaseService.GetModuleVersionsAsync(moduleNamespace, name, provider, cancellationToken);
     }
 
     /// <summary>
     ///     Gets the download URL for a specific module version using SAS token
     /// </summary>
     public override async Task<string?> GetModuleDownloadPathAsync(string moduleNamespace, string name, string provider,
-        string version)
+        string version, CancellationToken cancellationToken = default)
     {
         // First query the database to get storage metadata
-        var moduleStorage = await _databaseService.GetModuleStorageAsync(moduleNamespace, name, provider, version);
+        var moduleStorage = await _databaseService.GetModuleStorageAsync(moduleNamespace, name, provider, version, cancellationToken);
         if (moduleStorage == null)
         {
             // Module not found in database
@@ -152,7 +154,7 @@ public class AzureBlobModuleService : ModuleService
             var blobClient = _containerClient.GetBlobClient(blobPath);
 
             // Check if the blob exists in Azure Storage
-            if (!await blobClient.ExistsAsync())
+            if (!await blobClient.ExistsAsync(cancellationToken))
             {
                 // This indicates data inconsistency - database record exists but no blob
                 RegistryLog.Warning(_logger,
@@ -184,8 +186,12 @@ public class AzureBlobModuleService : ModuleService
                 {
                     StartsOn = startsOn
                 },
-                CancellationToken.None);
+                cancellationToken);
             return blobClient.GenerateUserDelegationSasUri(sasBuilder, delegationKey.Value).ToString();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
@@ -34,8 +34,8 @@ public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRep
         _downloads = new PostgreSqlModuleDownloadRecorder(connectionString, logger);
     }
 
-    public Task<ModuleList> ListModulesAsync(ModuleSearchRequest request) =>
-        _modules.ListModulesAsync(request);
+    public Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default) =>
+        _modules.ListModulesAsync(request, cancellationToken);
 
     public Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job,
         CancellationToken cancellationToken = default) =>
@@ -66,14 +66,17 @@ public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRep
     public Task<int> CountPendingExtractionJobsAsync(CancellationToken cancellationToken = default) =>
         _publications.CountPendingExtractionJobsAsync(cancellationToken);
 
-    public Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version) =>
-        _modules.GetModuleAsync(moduleNamespace, name, provider, version);
+    public Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default) =>
+        _modules.GetModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
 
-    public Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider) =>
-        _modules.GetModuleVersionsAsync(moduleNamespace, name, provider);
+    public Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider,
+        CancellationToken cancellationToken = default) =>
+        _modules.GetModuleVersionsAsync(moduleNamespace, name, provider, cancellationToken);
 
-    public Task<ModuleStorage?> GetModuleStorageAsync(string moduleNamespace, string name, string provider, string version) =>
-        _modules.GetModuleStorageAsync(moduleNamespace, name, provider, version);
+    public Task<ModuleStorage?> GetModuleStorageAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default) =>
+        _modules.GetModuleStorageAsync(moduleNamespace, name, provider, version, cancellationToken);
 
     public Task<bool> AddModuleAsync(ModuleStorage moduleStorage) =>
         _modules.AddModuleAsync(moduleStorage);

--- a/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
@@ -102,8 +102,8 @@ public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRep
     public Task<bool> RestoreModuleAsync(string moduleNamespace, string name, string provider, string version) =>
         _modules.RestoreModuleAsync(moduleNamespace, name, provider, version);
 
-    public Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request) =>
-        _modules.ListDeletedModulesAsync(request);
+    public Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default) =>
+        _modules.ListDeletedModulesAsync(request, cancellationToken);
 
     public Task<ModuleStorage?> GetModuleStorageIncludingDeletedAsync(
         string moduleNamespace,
@@ -135,8 +135,9 @@ public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRep
         string moduleNamespace,
         string name,
         string provider,
-        string version) =>
-        _moduleExtractions.GetModuleLlmContextAsync(moduleNamespace, name, provider, version);
+        string version,
+        CancellationToken cancellationToken = default) =>
+        _moduleExtractions.GetModuleLlmContextAsync(moduleNamespace, name, provider, version, cancellationToken);
 
     public Task UpsertModuleLlmContextAsync(
         string moduleNamespace,

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleExtractionRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleExtractionRepository.cs
@@ -66,7 +66,7 @@ public sealed class PostgreSqlModuleExtractionRepository(string connectionString
     }
 
     public async Task<ModuleLlmContextDocument?> GetModuleLlmContextAsync(string moduleNamespace, string name,
-        string provider, string version)
+        string provider, string version, CancellationToken cancellationToken = default)
     {
         const string sql = @"
             SELECT c.document_json::text
@@ -78,14 +78,14 @@ public sealed class PostgreSqlModuleExtractionRepository(string connectionString
               AND m.version = @version";
 
         await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
         await using var command = new NpgsqlCommand(sql, connection);
         command.Parameters.AddWithValue("moduleNamespace", moduleNamespace);
         command.Parameters.AddWithValue("@name", name);
         command.Parameters.AddWithValue("@provider", provider);
         command.Parameters.AddWithValue("@version", version);
 
-        var json = (string?)await command.ExecuteScalarAsync();
+        var json = (string?)await command.ExecuteScalarAsync(cancellationToken);
         return string.IsNullOrWhiteSpace(json)
             ? null
             : JsonSerializer.Deserialize<ModuleLlmContextDocument>(json);

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleRepository.cs
@@ -611,7 +611,8 @@ public sealed class PostgreSqlModuleRepository(
         }
     }
 
-    public async Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request)
+    public async Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request,
+        CancellationToken cancellationToken = default)
     {
         var modules = new List<ModuleListItem>();
         var conditions = new List<string>();
@@ -648,13 +649,13 @@ public sealed class PostgreSqlModuleRepository(
         parameters.Add(new NpgsqlParameter($"@p{paramCounter + 1}", request.Offset));
 
         await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         await using var command = new NpgsqlCommand(sql, connection);
         command.Parameters.AddRange(parameters.ToArray());
 
-        await using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
         {
             var ns = reader.GetString(0);
             var n = reader.GetString(1);

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleRepository.cs
@@ -19,11 +19,11 @@ public sealed class PostgreSqlModuleRepository(
     {
         cancellationToken.ThrowIfCancellationRequested();
         await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
         var (whereClause, parameters) = BuildListFilter(request);
         await using var countCommand = new NpgsqlCommand($"SELECT COUNT(*) FROM (SELECT 1 FROM modules m {whereClause} GROUP BY m.namespace, m.name, m.provider) coordinates", connection);
         AddParameters(countCommand, parameters);
-        var total = Convert.ToInt32(await countCommand.ExecuteScalarAsync(), CultureInfo.InvariantCulture);
+        var total = Convert.ToInt32(await countCommand.ExecuteScalarAsync(cancellationToken), CultureInfo.InvariantCulture);
 
         var coordinates = new List<(string Namespace, string Name, string Provider)>();
         await using (var pageCommand = new NpgsqlCommand($"SELECT m.namespace, m.name, m.provider FROM modules m {whereClause} GROUP BY m.namespace, m.name, m.provider ORDER BY m.namespace, m.name, m.provider LIMIT @limit OFFSET @offset", connection))
@@ -31,11 +31,11 @@ public sealed class PostgreSqlModuleRepository(
             AddParameters(pageCommand, parameters);
             pageCommand.Parameters.AddWithValue("@limit", request.Limit);
             pageCommand.Parameters.AddWithValue("@offset", request.Offset);
-            await using var reader = await pageCommand.ExecuteReaderAsync();
-            while (await reader.ReadAsync()) coordinates.Add((reader.GetString(0), reader.GetString(1), reader.GetString(2)));
+            await using var reader = await pageCommand.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken)) coordinates.Add((reader.GetString(0), reader.GetString(1), reader.GetString(2)));
         }
 
-        var rows = await GetPageRowsAsync(connection, coordinates);
+        var rows = await GetPageRowsAsync(connection, coordinates, cancellationToken);
         var modules = rows
             .GroupBy(row => new { row.Namespace, row.Name, row.Provider })
             .Select(group =>
@@ -94,7 +94,8 @@ public sealed class PostgreSqlModuleRepository(
         foreach (var parameter in parameters) command.Parameters.Add(new NpgsqlParameter(parameter.ParameterName, parameter.Value));
     }
 
-    private static async Task<List<ModuleRow>> GetPageRowsAsync(NpgsqlConnection connection, List<(string Namespace, string Name, string Provider)> coordinates)
+    private static async Task<List<ModuleRow>> GetPageRowsAsync(NpgsqlConnection connection, List<(string Namespace, string Name, string Provider)> coordinates,
+        CancellationToken cancellationToken)
     {
         if (coordinates.Count == 0) return [];
         await using var command = new NpgsqlCommand();
@@ -109,8 +110,8 @@ public sealed class PostgreSqlModuleRepository(
         }
         command.CommandText = $"WITH page(namespace, name, provider) AS (VALUES {string.Join(", ", values)}) SELECT m.namespace, m.name, m.provider, m.version, m.description, m.published_at FROM modules m JOIN page p ON p.namespace = m.namespace AND p.name = m.name AND p.provider = m.provider WHERE m.deleted_at IS NULL";
         var rows = new List<ModuleRow>();
-        await using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync()) rows.Add(new ModuleRow { Namespace = reader.GetString(0), Name = reader.GetString(1), Provider = reader.GetString(2), Version = reader.GetString(3), Description = reader.IsDBNull(4) ? string.Empty : reader.GetString(4), PublishedAt = reader.GetDateTime(5).ToString("o", CultureInfo.InvariantCulture) });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken)) rows.Add(new ModuleRow { Namespace = reader.GetString(0), Name = reader.GetString(1), Provider = reader.GetString(2), Version = reader.GetString(3), Description = reader.IsDBNull(4) ? string.Empty : reader.GetString(4), PublishedAt = reader.GetDateTime(5).ToString("o", CultureInfo.InvariantCulture) });
         return rows;
     }
 
@@ -142,7 +143,7 @@ public sealed class PostgreSqlModuleRepository(
                 deleted_at IS NULL";
 
         await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         await using var command = new NpgsqlCommand(sql, connection);
         command.Parameters.AddWithValue("moduleNamespace", moduleNamespace);
@@ -150,8 +151,8 @@ public sealed class PostgreSqlModuleRepository(
         command.Parameters.AddWithValue("@provider", provider);
         command.Parameters.AddWithValue("@version", version);
 
-        await using var reader = await command.ExecuteReaderAsync();
-        if (!await reader.ReadAsync())
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
             return null;
 
         var metadata = DeserializeModuleMetadata(reader.GetString(8));
@@ -193,7 +194,7 @@ public sealed class PostgreSqlModuleRepository(
     {
         cancellationToken.ThrowIfCancellationRequested();
         await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var versions = await GetVersionsInternalAsync(connection, moduleNamespace, name, provider, cancellationToken);
 
@@ -237,7 +238,7 @@ public sealed class PostgreSqlModuleRepository(
                 deleted_at IS NULL";
 
         await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         await using var command = new NpgsqlCommand(sql, connection);
         command.Parameters.AddWithValue("moduleNamespace", moduleNamespace);
@@ -245,8 +246,8 @@ public sealed class PostgreSqlModuleRepository(
         command.Parameters.AddWithValue("@provider", provider);
         command.Parameters.AddWithValue("@version", version);
 
-        await using var reader = await command.ExecuteReaderAsync();
-        if (!await reader.ReadAsync())
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
             return null;
 
         var dependenciesJson = reader.GetString(7);

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleRepository.cs
@@ -15,8 +15,9 @@ public sealed class PostgreSqlModuleRepository(
     string baseUrl,
     ILogger logger) : IModuleRepository
 {
-    public async Task<ModuleList> ListModulesAsync(ModuleSearchRequest request)
+    public async Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync();
         var (whereClause, parameters) = BuildListFilter(request);
@@ -116,8 +117,10 @@ public sealed class PostgreSqlModuleRepository(
     /// <summary>
     ///     Gets detailed information about a specific module
     /// </summary>
-    public async Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version)
+    public async Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var sql = @"
             SELECT 
                 namespace,
@@ -156,7 +159,7 @@ public sealed class PostgreSqlModuleRepository(
         var publishedAt = reader.GetDateTime(6);
         await reader.DisposeAsync();
 
-        var versions = await GetVersionsInternalAsync(connection, moduleNamespace, name, provider);
+        var versions = await GetVersionsInternalAsync(connection, moduleNamespace, name, provider, cancellationToken);
 
         return new TerraformModule
         {
@@ -185,12 +188,14 @@ public sealed class PostgreSqlModuleRepository(
     /// <summary>
     ///     Gets all versions of a specific module
     /// </summary>
-    public async Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider)
+    public async Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync();
 
-        var versions = await GetVersionsInternalAsync(connection, moduleNamespace, name, provider);
+        var versions = await GetVersionsInternalAsync(connection, moduleNamespace, name, provider, cancellationToken);
 
         return new ModuleVersions
         {
@@ -208,8 +213,9 @@ public sealed class PostgreSqlModuleRepository(
     ///     Gets the storage path information for a specific module version
     /// </summary>
     public async Task<ModuleStorage?> GetModuleStorageAsync(string moduleNamespace, string name, string provider,
-        string version)
+        string version, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var sql = @"
             SELECT
                 namespace,
@@ -740,7 +746,7 @@ public sealed class PostgreSqlModuleRepository(
         }
     }
     private static async Task<List<string>> GetVersionsInternalAsync(NpgsqlConnection connection, string moduleNamespace,
-        string name, string provider)
+        string name, string provider, CancellationToken cancellationToken)
     {
         const string sql = @"
             SELECT version
@@ -756,8 +762,8 @@ public sealed class PostgreSqlModuleRepository(
         command.Parameters.AddWithValue("@provider", provider);
 
         var versions = new List<string>();
-        await using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync()) versions.Add(reader.GetString(0));
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken)) versions.Add(reader.GetString(0));
 
         return versions.OrderByDescending(version => version, SemVerVersionComparer.Instance).ToList();
     }

--- a/TerraformRegistry.S3/S3ModuleObjectStore.cs
+++ b/TerraformRegistry.S3/S3ModuleObjectStore.cs
@@ -46,7 +46,8 @@ internal sealed class S3ModuleObjectStore(
         string @namespace,
         string name,
         string provider,
-        string version)
+        string version,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -54,7 +55,7 @@ internal sealed class S3ModuleObjectStore(
             {
                 BucketName = bucketName,
                 Key = moduleStorage.FilePath
-            });
+            }, cancellationToken);
         }
         catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
@@ -66,6 +67,10 @@ internal sealed class S3ModuleObjectStore(
                 version,
                 moduleStorage.FilePath);
             return null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/TerraformRegistry.S3/S3ModuleService.cs
+++ b/TerraformRegistry.S3/S3ModuleService.cs
@@ -131,9 +131,10 @@ public class S3ModuleService : ModuleService
         return _purgeWorkflow.PurgeModuleVersionAsync(moduleNamespace, name, provider, version);
     }
 
-    public override Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request)
+    public override Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request,
+        CancellationToken cancellationToken = default)
     {
-        return _databaseService.ListDeletedModulesAsync(request);
+        return _databaseService.ListDeletedModulesAsync(request, cancellationToken);
     }
 
     public override Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider,

--- a/TerraformRegistry.S3/S3ModuleService.cs
+++ b/TerraformRegistry.S3/S3ModuleService.cs
@@ -58,25 +58,27 @@ public class S3ModuleService : ModuleService
     public override Task InitializeStorageAsync(CancellationToken cancellationToken) =>
         _objectStore.InitializeStorageAsync(cancellationToken);
 
-    public override Task<ModuleList> ListModulesAsync(ModuleSearchRequest request)
+    public override Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default)
     {
-        return _databaseService.ListModulesAsync(request);
+        return _databaseService.ListModulesAsync(request, cancellationToken);
     }
 
-    public override Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version)
+    public override Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
-        return _databaseService.GetModuleAsync(moduleNamespace, name, provider, version);
+        return _databaseService.GetModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
     }
 
-    public override Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider)
+    public override Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider,
+        CancellationToken cancellationToken = default)
     {
-        return _databaseService.GetModuleVersionsAsync(moduleNamespace, name, provider);
+        return _databaseService.GetModuleVersionsAsync(moduleNamespace, name, provider, cancellationToken);
     }
 
     public override async Task<string?> GetModuleDownloadPathAsync(string moduleNamespace, string name, string provider,
-        string version)
+        string version, CancellationToken cancellationToken = default)
     {
-        var moduleStorage = await _databaseService.GetModuleStorageAsync(moduleNamespace, name, provider, version);
+        var moduleStorage = await _databaseService.GetModuleStorageAsync(moduleNamespace, name, provider, version, cancellationToken);
         if (moduleStorage == null)
         {
             RegistryLog.Warning(_logger,
@@ -88,7 +90,8 @@ public class S3ModuleService : ModuleService
             return null;
         }
 
-        return await _objectStore.GetModuleDownloadPathAsync(moduleStorage, moduleNamespace, name, provider, version);
+        return await _objectStore.GetModuleDownloadPathAsync(moduleStorage, moduleNamespace, name, provider, version,
+            cancellationToken);
     }
 
     public override async Task<Stream?> OpenModulePackageStreamAsync(string moduleNamespace, string name, string provider,

--- a/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceDelegationTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceDelegationTests.cs
@@ -143,4 +143,36 @@ public class AzureBlobModuleServiceDelegationTests
                 options.ExpiresOn > DateTimeOffset.UtcNow),
             CancellationToken.None), Times.Once);
     }
+
+    [Fact]
+    public async Task GetModuleDownloadPathAsyncForwardsCancellationToDatabaseBlobAndDelegationKey()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var moduleStorage = new ModuleStorage
+        {
+            Namespace = "ns", Name = "name", Provider = "provider", Version = "1.0.0", Description = "description",
+            FilePath = "path/to/module.zip", Dependencies = []
+        };
+        var blobClient = new Mock<BlobClient>();
+        _mockDatabaseService
+            .Setup(x => x.GetModuleStorageAsync("ns", "name", "provider", "1.0.0", cancellation.Token))
+            .ReturnsAsync(moduleStorage);
+        _mockContainerClient.Setup(x => x.GetBlobClient(moduleStorage.FilePath)).Returns(blobClient.Object);
+        blobClient.Setup(x => x.ExistsAsync(cancellation.Token))
+            .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
+        blobClient.SetupGet(x => x.CanGenerateSasUri).Returns(false);
+        _mockBlobServiceClient
+            .Setup(x => x.GetUserDelegationKeyAsync(It.IsAny<BlobGetUserDelegationKeyOptions>(), cancellation.Token))
+            .ThrowsAsync(new OperationCanceledException(cancellation.Token));
+
+        cancellation.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            CreateService().GetModuleDownloadPathAsync("ns", "name", "provider", "1.0.0", cancellation.Token));
+
+        _mockDatabaseService.Verify(x => x.GetModuleStorageAsync("ns", "name", "provider", "1.0.0", cancellation.Token), Times.Once);
+        blobClient.Verify(x => x.ExistsAsync(cancellation.Token), Times.Once);
+        _mockBlobServiceClient.Verify(
+            x => x.GetUserDelegationKeyAsync(It.IsAny<BlobGetUserDelegationKeyOptions>(), cancellation.Token), Times.Once);
+    }
 }

--- a/TerraformRegistry.Tests/UnitTests/LlmHandlersCancellationTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LlmHandlersCancellationTests.cs
@@ -36,7 +36,7 @@ public class LlmHandlersCancellationTests
             Modules = [new ModuleVersionInfo { Versions = [new VersionInfo { Version = "1.0.0" }] }]
         });
         database.Setup(x => x.GetModuleLlmContextAsync("ns", "name", "aws", "1.0.0", source.Token))
-            .ReturnsAsync((ModuleLlmContextDocument?)null);
+            .Returns(Task.FromResult<ModuleLlmContextDocument?>(null));
 
         await LlmHandlers.GetModuleVersions("ns", "name", "aws", service.Object, database.Object, Configuration(), context);
 
@@ -57,7 +57,7 @@ public class LlmHandlersCancellationTests
                 Version = "1.0.0", PublishedAt = "", Versions = [], Root = "main", Submodules = [], Providers = []
             });
         database.Setup(x => x.GetModuleLlmContextAsync("ns", "name", "aws", "1.0.0", source.Token))
-            .ReturnsAsync((ModuleLlmContextDocument?)null);
+            .Returns(Task.FromResult<ModuleLlmContextDocument?>(null));
 
         await LlmHandlers.GetModuleContext("ns", "name", "aws", "1.0.0", database.Object, context);
 

--- a/TerraformRegistry.Tests/UnitTests/LlmHandlersCancellationTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/LlmHandlersCancellationTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using TerraformRegistry.API;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Handlers;
+using TerraformRegistry.Models;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public class LlmHandlersCancellationTests
+{
+    [Fact]
+    public async Task ListModulesPassesRequestAbortedToModuleService()
+    {
+        using var source = new CancellationTokenSource();
+        var context = AuthenticatedContext(source.Token);
+        var service = new Mock<IModuleService>();
+        service.Setup(x => x.ListModulesAsync(It.IsAny<ModuleSearchRequest>(), source.Token))
+            .ReturnsAsync(new ModuleList { Modules = [], Meta = [] });
+
+        await LlmHandlers.ListModules(service.Object, Configuration(), context);
+
+        service.Verify(x => x.ListModulesAsync(It.IsAny<ModuleSearchRequest>(), source.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetModuleVersionsPassesRequestAbortedToEachRead()
+    {
+        using var source = new CancellationTokenSource();
+        var context = AuthenticatedContext(source.Token);
+        var service = new Mock<IModuleService>();
+        var database = new Mock<IDatabaseService>();
+        service.Setup(x => x.GetModuleVersionsAsync("ns", "name", "aws", source.Token)).ReturnsAsync(new ModuleVersions
+        {
+            Modules = [new ModuleVersionInfo { Versions = [new VersionInfo { Version = "1.0.0" }] }]
+        });
+        database.Setup(x => x.GetModuleLlmContextAsync("ns", "name", "aws", "1.0.0", source.Token))
+            .ReturnsAsync((ModuleLlmContextDocument?)null);
+
+        await LlmHandlers.GetModuleVersions("ns", "name", "aws", service.Object, database.Object, Configuration(), context);
+
+        service.Verify(x => x.GetModuleVersionsAsync("ns", "name", "aws", source.Token), Times.Once);
+        database.Verify(x => x.GetModuleLlmContextAsync("ns", "name", "aws", "1.0.0", source.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetModuleContextPassesRequestAbortedToEachDatabaseRead()
+    {
+        using var source = new CancellationTokenSource();
+        var context = AuthenticatedContext(source.Token);
+        var database = new Mock<IDatabaseService>();
+        database.Setup(x => x.GetModuleAsync("ns", "name", "aws", "1.0.0", source.Token))
+            .ReturnsAsync(new TerraformModule
+            {
+                Id = "ns/name/aws/1.0.0", Owner = "ns", Namespace = "ns", Name = "name", Provider = "aws",
+                Version = "1.0.0", PublishedAt = "", Versions = [], Root = "main", Submodules = [], Providers = []
+            });
+        database.Setup(x => x.GetModuleLlmContextAsync("ns", "name", "aws", "1.0.0", source.Token))
+            .ReturnsAsync((ModuleLlmContextDocument?)null);
+
+        await LlmHandlers.GetModuleContext("ns", "name", "aws", "1.0.0", database.Object, context);
+
+        database.Verify(x => x.GetModuleAsync("ns", "name", "aws", "1.0.0", source.Token), Times.Once);
+        database.Verify(x => x.GetModuleLlmContextAsync("ns", "name", "aws", "1.0.0", source.Token), Times.Once);
+    }
+
+    private static DefaultHttpContext AuthenticatedContext(CancellationToken cancellationToken)
+    {
+        var context = new DefaultHttpContext { RequestAborted = cancellationToken };
+        context.User = new System.Security.Claims.ClaimsPrincipal(new System.Security.Claims.ClaimsIdentity(
+            [new System.Security.Claims.Claim("permission", Permissions.ModulesRead)], "test"));
+        return context;
+    }
+
+    private static IConfiguration Configuration() => new ConfigurationBuilder().Build();
+}

--- a/TerraformRegistry.Tests/UnitTests/ModuleHandlersPaginationTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleHandlersPaginationTests.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using Moq;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Handlers;
 using TerraformRegistry.Models;
+using TerraformRegistry.Services;
 
 namespace TerraformRegistry.Tests.UnitTests;
 
@@ -46,6 +48,83 @@ public class ModuleHandlersPaginationTests
     }
 
     [Fact]
+    public async Task GetModulePassesRequestAbortedToLocalAndMirrorServices()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var context = new DefaultHttpContext { RequestAborted = cancellation.Token };
+        var module = new TerraformModule
+        {
+            Id = "ns/name/aws/1.0.0", Owner = "ns", Namespace = "ns", Name = "name", Provider = "aws",
+            Version = "1.0.0", PublishedAt = "", Versions = [], Root = "main", Submodules = [], Providers = []
+        };
+        var local = new Mock<IModuleService>();
+        local.Setup(x => x.GetModuleAsync("ns", "name", "aws", "1.0.0", cancellation.Token)).ReturnsAsync(module);
+        var mirror = new Mock<IModuleMirrorService>();
+        mirror.Setup(x => x.GetModuleAsync("ns", "name", "aws", "1.0.0", module, cancellation.Token)).ReturnsAsync(module);
+
+        await ModuleHandlers.GetModule("ns", "name", "aws", "1.0.0", local.Object, mirror.Object, context);
+
+        local.Verify(x => x.GetModuleAsync("ns", "name", "aws", "1.0.0", cancellation.Token), Times.Once);
+        mirror.Verify(x => x.GetModuleAsync("ns", "name", "aws", "1.0.0", module, cancellation.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetModuleVersionsPassesRequestAbortedToLocalAndMirrorServices()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var context = new DefaultHttpContext { RequestAborted = cancellation.Token };
+        var versions = CreateVersions("1.0.0");
+        var local = new Mock<IModuleService>();
+        local.Setup(x => x.GetModuleVersionsAsync("ns", "name", "aws", cancellation.Token)).ReturnsAsync(versions);
+        var mirror = new Mock<IModuleMirrorService>();
+        mirror.Setup(x => x.GetModuleVersionsAsync("ns", "name", "aws", versions, cancellation.Token)).ReturnsAsync(versions);
+
+        await ModuleHandlers.GetModuleVersions("ns", "name", "aws", local.Object, mirror.Object, context);
+
+        local.Verify(x => x.GetModuleVersionsAsync("ns", "name", "aws", cancellation.Token), Times.Once);
+        mirror.Verify(x => x.GetModuleVersionsAsync("ns", "name", "aws", versions, cancellation.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task DownloadModulePassesRequestAbortedToLocalAndMirrorServices()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var analytics = new ModuleDownloadAnalyticsBuffer(Options.Create(new DownloadAnalyticsOptions()));
+        var context = new DefaultHttpContext { RequestAborted = cancellation.Token };
+        var local = new Mock<IModuleService>();
+        local.Setup(x => x.GetModuleDownloadPathAsync("ns", "name", "aws", "1.0.0", cancellation.Token)).ReturnsAsync("/local");
+        var mirror = new Mock<IModuleMirrorService>();
+        mirror.Setup(x => x.GetModuleDownloadPathAsync("ns", "name", "aws", "1.0.0", "/local", cancellation.Token)).ReturnsAsync("/download");
+
+        await ModuleHandlers.DownloadModule("ns", "name", "aws", "1.0.0", local.Object, mirror.Object, analytics, context);
+
+        local.Verify(x => x.GetModuleDownloadPathAsync("ns", "name", "aws", "1.0.0", cancellation.Token), Times.Once);
+        mirror.Verify(x => x.GetModuleDownloadPathAsync("ns", "name", "aws", "1.0.0", "/local", cancellation.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task DownloadLatestModulePassesRequestAbortedToBothLookupStages()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var analytics = new ModuleDownloadAnalyticsBuffer(Options.Create(new DownloadAnalyticsOptions()));
+        var context = new DefaultHttpContext { RequestAborted = cancellation.Token };
+        var versions = CreateVersions("1.0.0");
+        var local = new Mock<IModuleService>();
+        local.Setup(x => x.GetModuleVersionsAsync("ns", "name", "aws", cancellation.Token)).ReturnsAsync(versions);
+        local.Setup(x => x.GetModuleDownloadPathAsync("ns", "name", "aws", "1.0.0", cancellation.Token)).ReturnsAsync("/local");
+        var mirror = new Mock<IModuleMirrorService>();
+        mirror.Setup(x => x.GetModuleVersionsAsync("ns", "name", "aws", versions, cancellation.Token)).ReturnsAsync(versions);
+        mirror.Setup(x => x.GetModuleDownloadPathAsync("ns", "name", "aws", "1.0.0", "/local", cancellation.Token)).ReturnsAsync("/download");
+
+        await ModuleHandlers.DownloadLatestModule("ns", "name", "aws", local.Object, mirror.Object, analytics, context);
+
+        local.Verify(x => x.GetModuleVersionsAsync("ns", "name", "aws", cancellation.Token), Times.Once);
+        local.Verify(x => x.GetModuleDownloadPathAsync("ns", "name", "aws", "1.0.0", cancellation.Token), Times.Once);
+        mirror.Verify(x => x.GetModuleVersionsAsync("ns", "name", "aws", versions, cancellation.Token), Times.Once);
+        mirror.Verify(x => x.GetModuleDownloadPathAsync("ns", "name", "aws", "1.0.0", "/local", cancellation.Token), Times.Once);
+    }
+
+    [Fact]
     public async Task ListDeletedModulesClampsOffsetAndLimitBeforeCallingService()
     {
         ModuleSearchRequest? captured = null;
@@ -64,4 +143,9 @@ public class ModuleHandlersPaginationTests
         Assert.Equal(0, captured.Offset);
         Assert.Equal(100, captured.Limit);
     }
+
+    private static ModuleVersions CreateVersions(string version) => new()
+    {
+        Modules = [new ModuleVersionInfo { Versions = [new VersionInfo { Version = version }] }]
+    };
 }

--- a/TerraformRegistry.Tests/UnitTests/ModuleHandlersPaginationTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleHandlersPaginationTests.cs
@@ -34,7 +34,7 @@ public class ModuleHandlersPaginationTests
     [Fact]
     public async Task ListModulesPassesRequestAbortedToModuleService()
     {
-        var cancellation = new CancellationTokenSource();
+        using var cancellation = new CancellationTokenSource();
         CancellationToken captured = default;
         var context = new DefaultHttpContext();
         context.RequestAborted = cancellation.Token;

--- a/TerraformRegistry.Tests/UnitTests/ModuleHandlersPaginationTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleHandlersPaginationTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Moq;
+using TerraformRegistry.API;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Handlers;
 using TerraformRegistry.Models;
@@ -129,8 +130,8 @@ public class ModuleHandlersPaginationTests
     {
         ModuleSearchRequest? captured = null;
         var service = new Mock<IModuleService>();
-        service.Setup(x => x.ListDeletedModulesAsync(It.IsAny<ModuleSearchRequest>()))
-            .Callback<ModuleSearchRequest>(request => captured = request)
+        service.Setup(x => x.ListDeletedModulesAsync(It.IsAny<ModuleSearchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<ModuleSearchRequest, CancellationToken>((request, _) => captured = request)
             .ReturnsAsync(new ModuleList { Modules = [], Meta = [] });
 
         await ModuleHandlers.ListDeletedModules(
@@ -142,6 +143,22 @@ public class ModuleHandlersPaginationTests
         Assert.NotNull(captured);
         Assert.Equal(0, captured.Offset);
         Assert.Equal(100, captured.Limit);
+    }
+
+    [Fact]
+    public async Task ListDeletedModulesPassesRequestAbortedToModuleService()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var context = new DefaultHttpContext { RequestAborted = cancellation.Token };
+        context.User = new System.Security.Claims.ClaimsPrincipal(new System.Security.Claims.ClaimsIdentity(
+            [new System.Security.Claims.Claim("permission", Permissions.ModulesDelete)], "test"));
+        var service = new Mock<IModuleService>();
+        service.Setup(x => x.ListDeletedModulesAsync(It.IsAny<ModuleSearchRequest>(), cancellation.Token))
+            .ReturnsAsync(new ModuleList { Modules = [], Meta = [] });
+
+        await ModuleHandlers.ListDeletedModules(service.Object, context);
+
+        service.Verify(x => x.ListDeletedModulesAsync(It.IsAny<ModuleSearchRequest>(), cancellation.Token), Times.Once);
     }
 
     private static ModuleVersions CreateVersions(string version) => new()

--- a/TerraformRegistry.Tests/UnitTests/ModuleHandlersPaginationTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleHandlersPaginationTests.cs
@@ -13,8 +13,8 @@ public class ModuleHandlersPaginationTests
     {
         ModuleSearchRequest? captured = null;
         var service = new Mock<IModuleService>();
-        service.Setup(x => x.ListModulesAsync(It.IsAny<ModuleSearchRequest>()))
-            .Callback<ModuleSearchRequest>(request => captured = request)
+        service.Setup(x => x.ListModulesAsync(It.IsAny<ModuleSearchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<ModuleSearchRequest, CancellationToken>((request, _) => captured = request)
             .ReturnsAsync(new ModuleList { Modules = [], Meta = [] });
 
         await ModuleHandlers.ListModules(
@@ -26,6 +26,23 @@ public class ModuleHandlersPaginationTests
         Assert.NotNull(captured);
         Assert.Equal(0, captured.Offset);
         Assert.Equal(100, captured.Limit);
+    }
+
+    [Fact]
+    public async Task ListModulesPassesRequestAbortedToModuleService()
+    {
+        var cancellation = new CancellationTokenSource();
+        CancellationToken captured = default;
+        var context = new DefaultHttpContext();
+        context.RequestAborted = cancellation.Token;
+        var service = new Mock<IModuleService>();
+        service.Setup(x => x.ListModulesAsync(It.IsAny<ModuleSearchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<ModuleSearchRequest, CancellationToken>((_, token) => captured = token)
+            .ReturnsAsync(new ModuleList { Modules = [], Meta = [] });
+
+        await ModuleHandlers.ListModules(service.Object, context);
+
+        Assert.Equal(cancellation.Token, captured);
     }
 
     [Fact]

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceDelegationTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceDelegationTests.cs
@@ -52,6 +52,49 @@ public class S3ModuleServiceDelegationTests
     }
 
     [Fact]
+    public async Task ListModulesAsyncPassesCancellationToDatabaseService()
+    {
+        var request = new ModuleSearchRequest();
+        using var cancellation = new CancellationTokenSource();
+        _mockDatabaseService
+            .Setup(x => x.ListModulesAsync(request, cancellation.Token))
+            .ReturnsAsync(new ModuleList { Modules = [], Meta = [] });
+
+        var service = CreateService();
+        await service.ListModulesAsync(request, cancellation.Token);
+
+        _mockDatabaseService.Verify(x => x.ListModulesAsync(request, cancellation.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetModuleAsyncPassesCancellationToDatabaseService()
+    {
+        using var cancellation = new CancellationTokenSource();
+        _mockDatabaseService
+            .Setup(x => x.GetModuleAsync("ns", "name", "aws", "1.0.0", cancellation.Token))
+            .ReturnsAsync((TerraformModule?)null);
+
+        await CreateService().GetModuleAsync("ns", "name", "aws", "1.0.0", cancellation.Token);
+
+        _mockDatabaseService.Verify(
+            x => x.GetModuleAsync("ns", "name", "aws", "1.0.0", cancellation.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetModuleVersionsAsyncPassesCancellationToDatabaseService()
+    {
+        using var cancellation = new CancellationTokenSource();
+        _mockDatabaseService
+            .Setup(x => x.GetModuleVersionsAsync("ns", "name", "aws", cancellation.Token))
+            .ReturnsAsync(new ModuleVersions { Modules = [] });
+
+        await CreateService().GetModuleVersionsAsync("ns", "name", "aws", cancellation.Token);
+
+        _mockDatabaseService.Verify(
+            x => x.GetModuleVersionsAsync("ns", "name", "aws", cancellation.Token), Times.Once);
+    }
+
+    [Fact]
     public async Task GetModuleAsyncDelegatesToDatabaseService()
     {
         var expected = new TerraformModule

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceDelegationTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceDelegationTests.cs
@@ -72,7 +72,7 @@ public class S3ModuleServiceDelegationTests
         using var cancellation = new CancellationTokenSource();
         _mockDatabaseService
             .Setup(x => x.GetModuleAsync("ns", "name", "aws", "1.0.0", cancellation.Token))
-            .ReturnsAsync((TerraformModule?)null);
+            .Returns(Task.FromResult<TerraformModule?>(null));
 
         await CreateService().GetModuleAsync("ns", "name", "aws", "1.0.0", cancellation.Token);
 

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceDownloadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceDownloadTests.cs
@@ -77,6 +77,47 @@ public class S3ModuleServiceDownloadTests
     }
 
     [Fact]
+    public async Task GetModuleDownloadPathAsyncPassesCancellationToDatabaseAndS3()
+    {
+        var moduleStorage = CreateModuleStorage();
+        using var cancellation = new CancellationTokenSource();
+        _mockDatabaseService
+            .Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0", cancellation.Token))
+            .ReturnsAsync(moduleStorage);
+        _mockS3Client
+            .Setup(x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), cancellation.Token))
+            .ReturnsAsync(new GetObjectMetadataResponse());
+        _mockS3Client
+            .Setup(x => x.GetPreSignedURL(It.IsAny<GetPreSignedUrlRequest>()))
+            .Returns("https://example.test/module.zip");
+
+        var result = await CreateService().GetModuleDownloadPathAsync("ns", "name", "aws", "1.0.0", cancellation.Token);
+
+        Assert.Equal("https://example.test/module.zip", result);
+        _mockDatabaseService.Verify(
+            x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0", cancellation.Token), Times.Once);
+        _mockS3Client.Verify(
+            x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), cancellation.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetModuleDownloadPathAsyncDoesNotSwallowCancellation()
+    {
+        var moduleStorage = CreateModuleStorage();
+        using var cancellation = new CancellationTokenSource();
+        _mockDatabaseService
+            .Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0", cancellation.Token))
+            .ReturnsAsync(moduleStorage);
+        _mockS3Client
+            .Setup(x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), cancellation.Token))
+            .ThrowsAsync(new OperationCanceledException(cancellation.Token));
+        cancellation.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => CreateService().GetModuleDownloadPathAsync("ns", "name", "aws", "1.0.0", cancellation.Token));
+    }
+
+    [Fact]
     public async Task GetModuleDownloadPathAsyncReturnsNullWhenObjectIsMissingInS3()
     {
         var moduleStorage = CreateModuleStorage();

--- a/TerraformRegistry/Handlers/LlmHandlers.cs
+++ b/TerraformRegistry/Handlers/LlmHandlers.cs
@@ -50,7 +50,7 @@ Human-oriented browsing:
             Limit = boundedLimit
         };
 
-        var modules = await moduleService.ListModulesAsync(request);
+        var modules = await moduleService.ListModulesAsync(request, context.RequestAborted);
         var baseUrl = GetBaseUrl(configuration);
         var items = modules.Modules.Select(module => new ModuleLlmIndexItem
         {
@@ -94,7 +94,7 @@ Human-oriented browsing:
         var denied = RequireAuthenticatedModuleRead(context);
         if (denied != null) return denied;
 
-        var versions = await moduleService.GetModuleVersionsAsync(@namespace, name, provider);
+        var versions = await moduleService.GetModuleVersionsAsync(@namespace, name, provider, context.RequestAborted);
         var versionList = versions.Modules.FirstOrDefault()?.Versions;
         if (versionList == null || versionList.Count == 0)
             return Results.NotFound(new { error = "Module not found" });
@@ -108,7 +108,8 @@ Human-oriented browsing:
                 @namespace,
                 name,
                 provider,
-                version.Version);
+                version.Version,
+                context.RequestAborted);
 
             items.Add(new ModuleLlmVersionItem
             {
@@ -141,11 +142,12 @@ Human-oriented browsing:
         var denied = RequireAuthenticatedModuleRead(context);
         if (denied != null) return denied;
 
-        var module = await databaseService.GetModuleAsync(@namespace, name, provider, version);
+        var module = await databaseService.GetModuleAsync(@namespace, name, provider, version, context.RequestAborted);
         if (module == null)
             return Results.NotFound(new { error = "Module not found" });
 
-        var llmContext = await databaseService.GetModuleLlmContextAsync(@namespace, name, provider, version);
+        var llmContext = await databaseService.GetModuleLlmContextAsync(@namespace, name, provider, version,
+            context.RequestAborted);
         if (llmContext == null)
             return Results.Json(new { error = "LLM context not generated yet" }, statusCode: StatusCodes.Status409Conflict);
 

--- a/TerraformRegistry/Handlers/ModuleHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleHandlers.cs
@@ -502,7 +502,7 @@ public static class ModuleHandlers
             Limit = Math.Clamp(limit, 1, 100)
         };
 
-        var result = await moduleService.ListDeletedModulesAsync(request);
+        var result = await moduleService.ListDeletedModulesAsync(request, context.RequestAborted);
         return Ok(result);
     }
 

--- a/TerraformRegistry/Handlers/ModuleHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleHandlers.cs
@@ -95,7 +95,7 @@ public static class ModuleHandlers
             Limit = Math.Clamp(limit, 1, 100)
         };
 
-        var result = await moduleService.ListModulesAsync(request);
+        var result = await moduleService.ListModulesAsync(request, context.RequestAborted);
         return Ok(result);
     }
 
@@ -119,7 +119,7 @@ public static class ModuleHandlers
         RegistryLog.Information(_logger, "Getting module: {Namespace}/{Name}/{Provider}/{Version}",
             @namespace, name, provider, version);
 
-        var localModule = await moduleService.GetModuleAsync(@namespace, name, provider, version);
+        var localModule = await moduleService.GetModuleAsync(@namespace, name, provider, version, context.RequestAborted);
         var module = await moduleMirrorService.GetModuleAsync(
             @namespace,
             name,
@@ -151,7 +151,7 @@ public static class ModuleHandlers
         RegistryLog.Information(_logger, "Getting versions for module: {Namespace}/{Name}/{Provider}",
             @namespace, name, provider);
 
-        var localVersions = await moduleService.GetModuleVersionsAsync(@namespace, name, provider);
+        var localVersions = await moduleService.GetModuleVersionsAsync(@namespace, name, provider, context.RequestAborted);
         var versions = await moduleMirrorService.GetModuleVersionsAsync(
             @namespace,
             name,
@@ -188,7 +188,7 @@ public static class ModuleHandlers
         RegistryLog.Information(_logger, "Downloading module: {Namespace}/{Name}/{Provider}/{Version}",
             @namespace, name, provider, version);
 
-        var localDownloadPath = await moduleService.GetModuleDownloadPathAsync(@namespace, name, provider, version);
+        var localDownloadPath = await moduleService.GetModuleDownloadPathAsync(@namespace, name, provider, version, context.RequestAborted);
         var downloadPath = await moduleMirrorService.GetModuleDownloadPathAsync(
             @namespace,
             name,
@@ -232,7 +232,7 @@ public static class ModuleHandlers
             @namespace, name, provider);
 
         // Get all versions and pick the latest using SemVer sort
-        var localVersions = await moduleService.GetModuleVersionsAsync(@namespace, name, provider);
+        var localVersions = await moduleService.GetModuleVersionsAsync(@namespace, name, provider, context.RequestAborted);
         var versions = await moduleMirrorService.GetModuleVersionsAsync(
             @namespace,
             name,

--- a/TerraformRegistry/Services/LocalModuleService.cs
+++ b/TerraformRegistry/Services/LocalModuleService.cs
@@ -184,34 +184,37 @@ public class LocalModuleService : ModuleService
     /// <summary>
     ///     Lists all modules based on search criteria
     /// </summary>
-    public override Task<ModuleList> ListModulesAsync(ModuleSearchRequest request)
+    public override Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default)
     {
-        return _databaseService.ListModulesAsync(request);
+        return _databaseService.ListModulesAsync(request, cancellationToken);
     }
 
     /// <summary>
     ///     Gets detailed information about a specific module
     /// </summary>
-    public override Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version)
+    public override Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
-        return _databaseService.GetModuleAsync(moduleNamespace, name, provider, version);
+        return _databaseService.GetModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
     }
 
     /// <summary>
     ///     Gets all versions of a specific module
     /// </summary>
-    public override Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider)
+    public override Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider,
+        CancellationToken cancellationToken = default)
     {
-        return _databaseService.GetModuleVersionsAsync(moduleNamespace, name, provider);
+        return _databaseService.GetModuleVersionsAsync(moduleNamespace, name, provider, cancellationToken);
     }
 
     /// <summary>
     ///     Gets the download path for a specific module version
     /// </summary>
     public override async Task<string?> GetModuleDownloadPathAsync(string moduleNamespace, string name, string provider,
-        string version)
+        string version, CancellationToken cancellationToken = default)
     {
-        var moduleStorage = await _databaseService.GetModuleStorageAsync(moduleNamespace, name, provider, version);
+        cancellationToken.ThrowIfCancellationRequested();
+        var moduleStorage = await _databaseService.GetModuleStorageAsync(moduleNamespace, name, provider, version, cancellationToken);
         if (moduleStorage == null)
             return null;
         if (!IsInsideStorageRoot(moduleStorage.FilePath))

--- a/TerraformRegistry/Services/LocalModuleService.cs
+++ b/TerraformRegistry/Services/LocalModuleService.cs
@@ -423,9 +423,10 @@ public class LocalModuleService : ModuleService
         return await _databaseService.RemoveModuleAsync(moduleStorage);
     }
 
-    public override Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request)
+    public override Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request,
+        CancellationToken cancellationToken = default)
     {
-        return _databaseService.ListDeletedModulesAsync(request);
+        return _databaseService.ListDeletedModulesAsync(request, cancellationToken);
     }
 
     public override Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider,

--- a/TerraformRegistry/Services/Sqlite/SqliteModuleExtractionRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModuleExtractionRepository.cs
@@ -60,10 +60,10 @@ public sealed class SqliteModuleExtractionRepository(string connectionString) : 
     }
 
     public async Task<ModuleLlmContextDocument?> GetModuleLlmContextAsync(string moduleNamespace, string name, string provider,
-        string version)
+        string version, CancellationToken cancellationToken = default)
     {
         await using var connection = new SqliteConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -76,7 +76,7 @@ public sealed class SqliteModuleExtractionRepository(string connectionString) : 
         cmd.Parameters.AddWithValue("$prov", provider);
         cmd.Parameters.AddWithValue("$ver", version);
 
-        var json = (string?)await cmd.ExecuteScalarAsync();
+        var json = (string?)await cmd.ExecuteScalarAsync(cancellationToken);
         return string.IsNullOrWhiteSpace(json)
             ? null
             : JsonSerializer.Deserialize<ModuleLlmContextDocument>(json);

--- a/TerraformRegistry/Services/Sqlite/SqliteModuleRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModuleRepository.cs
@@ -512,12 +512,13 @@ public sealed class SqliteModuleRepository(
         }
     }
 
-    public async Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request)
+    public async Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request,
+        CancellationToken cancellationToken = default)
     {
         var modules = new List<ModuleListItem>();
 
         await using var connection = new SqliteConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var sql = @"SELECT namespace, name, provider, version, description, published_at
             FROM modules WHERE deleted_at IS NOT NULL";
@@ -552,8 +553,8 @@ public sealed class SqliteModuleRepository(
         command.CommandText = sql;
         foreach (var p in parameters) command.Parameters.Add(p);
 
-        await using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
         {
             modules.Add(new ModuleListItem
             {

--- a/TerraformRegistry/Services/Sqlite/SqliteModuleRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModuleRepository.cs
@@ -18,13 +18,13 @@ public sealed class SqliteModuleRepository(
     {
         cancellationToken.ThrowIfCancellationRequested();
         await using var connection = new SqliteConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
         var (whereClause, parameters) = BuildListFilter(request);
 
         await using var countCommand = connection.CreateCommand();
         countCommand.CommandText = $"SELECT COUNT(*) FROM (SELECT 1 FROM modules m {whereClause} GROUP BY m.namespace, m.name, m.provider)";
         AddParameters(countCommand, parameters);
-        var total = Convert.ToInt32(await countCommand.ExecuteScalarAsync(), CultureInfo.InvariantCulture);
+        var total = Convert.ToInt32(await countCommand.ExecuteScalarAsync(cancellationToken), CultureInfo.InvariantCulture);
 
         var coordinates = new List<(string Namespace, string Name, string Provider)>();
         await using (var pageCommand = connection.CreateCommand())
@@ -33,11 +33,11 @@ public sealed class SqliteModuleRepository(
             AddParameters(pageCommand, parameters);
             pageCommand.Parameters.AddWithValue("$limit", request.Limit);
             pageCommand.Parameters.AddWithValue("$offset", request.Offset);
-            await using var reader = await pageCommand.ExecuteReaderAsync();
-            while (await reader.ReadAsync()) coordinates.Add((reader.GetString(0), reader.GetString(1), reader.GetString(2)));
+            await using var reader = await pageCommand.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken)) coordinates.Add((reader.GetString(0), reader.GetString(1), reader.GetString(2)));
         }
 
-        var rows = await GetPageRowsAsync(connection, coordinates);
+        var rows = await GetPageRowsAsync(connection, coordinates, cancellationToken);
         var modules = rows
             .GroupBy(row => new { row.Namespace, row.Name, row.Provider })
             .Select(group =>
@@ -96,7 +96,8 @@ public sealed class SqliteModuleRepository(
         foreach (var parameter in parameters) command.Parameters.Add(new SqliteParameter(parameter.ParameterName, parameter.Value));
     }
 
-    private static async Task<List<ModuleRow>> GetPageRowsAsync(SqliteConnection connection, List<(string Namespace, string Name, string Provider)> coordinates)
+    private static async Task<List<ModuleRow>> GetPageRowsAsync(SqliteConnection connection, List<(string Namespace, string Name, string Provider)> coordinates,
+        CancellationToken cancellationToken)
     {
         if (coordinates.Count == 0) return [];
         await using var command = connection.CreateCommand();
@@ -110,8 +111,8 @@ public sealed class SqliteModuleRepository(
         }
         command.CommandText = $"WITH page(namespace, name, provider) AS (VALUES {string.Join(", ", values)}) SELECT m.namespace, m.name, m.provider, m.version, m.description, m.published_at FROM modules m JOIN page p ON p.namespace = m.namespace AND p.name = m.name AND p.provider = m.provider WHERE m.deleted_at IS NULL";
         var rows = new List<ModuleRow>();
-        await using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync()) rows.Add(new ModuleRow { Namespace = reader.GetString(0), Name = reader.GetString(1), Provider = reader.GetString(2), Version = reader.GetString(3), Description = reader.IsDBNull(4) ? string.Empty : reader.GetString(4), PublishedAt = reader.GetString(5) });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken)) rows.Add(new ModuleRow { Namespace = reader.GetString(0), Name = reader.GetString(1), Provider = reader.GetString(2), Version = reader.GetString(3), Description = reader.IsDBNull(4) ? string.Empty : reader.GetString(4), PublishedAt = reader.GetString(5) });
         return rows;
     }
 
@@ -120,7 +121,7 @@ public sealed class SqliteModuleRepository(
     {
         cancellationToken.ThrowIfCancellationRequested();
         await using var connection = new SqliteConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var sql = @"
             SELECT namespace, name, provider, version, description, storage_path, published_at, dependencies, metadata
@@ -134,8 +135,8 @@ public sealed class SqliteModuleRepository(
         cmd.Parameters.AddWithValue("$prov", provider);
         cmd.Parameters.AddWithValue("$ver", version);
 
-        await using var reader = await cmd.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return null;
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken)) return null;
 
         var publishedAtIso = reader.GetString(6);
         var versions = await GetVersionsInternal(connection, moduleNamespace, name, provider, cancellationToken);
@@ -165,7 +166,7 @@ public sealed class SqliteModuleRepository(
     {
         cancellationToken.ThrowIfCancellationRequested();
         await using var connection = new SqliteConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var versions = await GetVersionsInternal(connection, moduleNamespace, name, provider, cancellationToken);
         return new ModuleVersions
@@ -185,7 +186,7 @@ public sealed class SqliteModuleRepository(
     {
         cancellationToken.ThrowIfCancellationRequested();
         await using var connection = new SqliteConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var sql = @"
             SELECT namespace, name, provider, version, description, storage_path, published_at, dependencies, metadata
@@ -199,8 +200,8 @@ public sealed class SqliteModuleRepository(
         cmd.Parameters.AddWithValue("$prov", provider);
         cmd.Parameters.AddWithValue("$ver", version);
 
-        await using var reader = await cmd.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return null;
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken)) return null;
 
         var depsJson = reader.GetString(7);
         var deps = string.IsNullOrWhiteSpace(depsJson)

--- a/TerraformRegistry/Services/Sqlite/SqliteModuleRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModuleRepository.cs
@@ -14,8 +14,9 @@ public sealed class SqliteModuleRepository(
     string baseUrl,
     ILogger logger) : IModuleRepository
 {
-    public async Task<ModuleList> ListModulesAsync(ModuleSearchRequest request)
+    public async Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         await using var connection = new SqliteConnection(connectionString);
         await connection.OpenAsync();
         var (whereClause, parameters) = BuildListFilter(request);
@@ -114,8 +115,10 @@ public sealed class SqliteModuleRepository(
         return rows;
     }
 
-    public async Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version)
+    public async Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         await using var connection = new SqliteConnection(connectionString);
         await connection.OpenAsync();
 
@@ -135,7 +138,7 @@ public sealed class SqliteModuleRepository(
         if (!await reader.ReadAsync()) return null;
 
         var publishedAtIso = reader.GetString(6);
-        var versions = await GetVersionsInternal(connection, moduleNamespace, name, provider);
+        var versions = await GetVersionsInternal(connection, moduleNamespace, name, provider, cancellationToken);
 
         return new TerraformModule
         {
@@ -157,12 +160,14 @@ public sealed class SqliteModuleRepository(
         };
     }
 
-    public async Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider)
+    public async Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         await using var connection = new SqliteConnection(connectionString);
         await connection.OpenAsync();
 
-        var versions = await GetVersionsInternal(connection, moduleNamespace, name, provider);
+        var versions = await GetVersionsInternal(connection, moduleNamespace, name, provider, cancellationToken);
         return new ModuleVersions
         {
             Modules = new List<ModuleVersionInfo>
@@ -176,8 +181,9 @@ public sealed class SqliteModuleRepository(
     }
 
     public async Task<ModuleStorage?> GetModuleStorageAsync(string moduleNamespace, string name, string provider,
-        string version)
+        string version, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         await using var connection = new SqliteConnection(connectionString);
         await connection.OpenAsync();
 
@@ -640,7 +646,7 @@ public sealed class SqliteModuleRepository(
         }
     }
     private static async Task<List<string>> GetVersionsInternal(SqliteConnection connection, string moduleNamespace,
-        string name, string provider)
+        string name, string provider, CancellationToken cancellationToken)
     {
         var versions = new List<string>();
         await using var cmd = connection.CreateCommand();
@@ -649,8 +655,8 @@ public sealed class SqliteModuleRepository(
         cmd.Parameters.AddWithValue("$ns", moduleNamespace);
         cmd.Parameters.AddWithValue("$name", name);
         cmd.Parameters.AddWithValue("$prov", provider);
-        await using var r = await cmd.ExecuteReaderAsync();
-        while (await r.ReadAsync()) versions.Add(r.GetString(0));
+        await using var r = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await r.ReadAsync(cancellationToken)) versions.Add(r.GetString(0));
         return versions.OrderByDescending(version => version, SemVerVersionComparer.Instance).ToList();
     }
 

--- a/TerraformRegistry/Services/SqliteDatabaseService.cs
+++ b/TerraformRegistry/Services/SqliteDatabaseService.cs
@@ -77,17 +77,20 @@ public class SqliteDatabaseService : IDatabaseService, IModulePublicationReposit
     public Task<int> CountPendingExtractionJobsAsync(CancellationToken cancellationToken = default) =>
         _publications.CountPendingExtractionJobsAsync(cancellationToken);
 
-    public Task<ModuleList> ListModulesAsync(ModuleSearchRequest request) =>
-        _modules.ListModulesAsync(request);
+    public Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default) =>
+        _modules.ListModulesAsync(request, cancellationToken);
 
-    public Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version) =>
-        _modules.GetModuleAsync(moduleNamespace, name, provider, version);
+    public Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default) =>
+        _modules.GetModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
 
-    public Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider) =>
-        _modules.GetModuleVersionsAsync(moduleNamespace, name, provider);
+    public Task<ModuleVersions> GetModuleVersionsAsync(string moduleNamespace, string name, string provider,
+        CancellationToken cancellationToken = default) =>
+        _modules.GetModuleVersionsAsync(moduleNamespace, name, provider, cancellationToken);
 
-    public Task<ModuleStorage?> GetModuleStorageAsync(string moduleNamespace, string name, string provider, string version) =>
-        _modules.GetModuleStorageAsync(moduleNamespace, name, provider, version);
+    public Task<ModuleStorage?> GetModuleStorageAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default) =>
+        _modules.GetModuleStorageAsync(moduleNamespace, name, provider, version, cancellationToken);
 
     public Task<bool> AddModuleAsync(ModuleStorage moduleStorage) =>
         _modules.AddModuleAsync(moduleStorage);

--- a/TerraformRegistry/Services/SqliteDatabaseService.cs
+++ b/TerraformRegistry/Services/SqliteDatabaseService.cs
@@ -116,8 +116,8 @@ public class SqliteDatabaseService : IDatabaseService, IModulePublicationReposit
     public Task<bool> RestoreModuleAsync(string moduleNamespace, string name, string provider, string version) =>
         _modules.RestoreModuleAsync(moduleNamespace, name, provider, version);
 
-    public Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request) =>
-        _modules.ListDeletedModulesAsync(request);
+    public Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default) =>
+        _modules.ListDeletedModulesAsync(request, cancellationToken);
 
     public Task<ModuleStorage?> GetModuleStorageIncludingDeletedAsync(
         string moduleNamespace,
@@ -149,8 +149,9 @@ public class SqliteDatabaseService : IDatabaseService, IModulePublicationReposit
         string moduleNamespace,
         string name,
         string provider,
-        string version) =>
-        _moduleExtractions.GetModuleLlmContextAsync(moduleNamespace, name, provider, version);
+        string version,
+        CancellationToken cancellationToken = default) =>
+        _moduleExtractions.GetModuleLlmContextAsync(moduleNamespace, name, provider, version, cancellationToken);
 
     public Task UpsertModuleLlmContextAsync(
         string moduleNamespace,


### PR DESCRIPTION
## Summary\n- pass request cancellation from module read handlers through module service and repository boundaries\n- carry cancellation through local, S3, and Azure download lookups without swallowing cancellation\n- add focused handler, database delegation, S3 boundary, and cancellation regression tests\n\n## Verification\n- dockerized .NET 10.0.301 focused tests: 22 passed\n\nStacked on #111; do not merge until the parent PR is merged.