### PR TITLE
refactor: propagate cancellation through module lifecycle

### DIFF
--- a/TerraformRegistry.API/Interfaces/IModuleRepository.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleRepository.cs
@@ -33,27 +33,28 @@ public interface IModuleRepository
     /// <summary>
     ///     Adds a new module to the database.
     /// </summary>
-    Task<bool> AddModuleAsync(ModuleStorage moduleStorage);
+    Task<bool> AddModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Removes a module from the database permanently.
     /// </summary>
-    Task<bool> RemoveModuleAsync(ModuleStorage moduleStorage);
+    Task<bool> RemoveModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Removes a module row only when its stored metadata matches the provided module.
     /// </summary>
-    Task<bool> RemoveModuleExactAsync(ModuleStorage moduleStorage);
+    Task<bool> RemoveModuleExactAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Removes a module row only when it is currently soft-deleted.
     /// </summary>
-    Task<bool> RemoveDeletedModuleAsync(string moduleNamespace, string name, string provider, string version);
+    Task<bool> RemoveDeletedModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Adds a module row directly in the soft-deleted state.
     /// </summary>
-    Task<bool> AddDeletedModuleAsync(ModuleStorage moduleStorage);
+    Task<bool> AddDeletedModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Replaces a module row only when its stored metadata matches the expected current module.
@@ -63,12 +64,14 @@ public interface IModuleRepository
     /// <summary>
     ///     Soft deletes a module by setting its deleted timestamp.
     /// </summary>
-    Task<bool> SoftDeleteModuleAsync(string moduleNamespace, string name, string provider, string version);
+    Task<bool> SoftDeleteModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Restores a soft-deleted module by clearing its deleted timestamp.
     /// </summary>
-    Task<bool> RestoreModuleAsync(string moduleNamespace, string name, string provider, string version);
+    Task<bool> RestoreModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Lists all soft-deleted modules.
@@ -82,10 +85,11 @@ public interface IModuleRepository
         string moduleNamespace,
         string name,
         string provider,
-        string version);
+        string version, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Updates the description for all active versions of a module.
     /// </summary>
-    Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider, string description);
+    Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider, string description,
+        CancellationToken cancellationToken = default);
 }

--- a/TerraformRegistry.API/Interfaces/IModuleService.cs
+++ b/TerraformRegistry.API/Interfaces/IModuleService.cs
@@ -55,17 +55,20 @@ public interface IModuleService
     /// <summary>
     ///     Soft deletes a module version
     /// </summary>
-    Task<bool> DeleteModuleVersionAsync(string moduleNamespace, string name, string provider, string version);
+    Task<bool> DeleteModuleVersionAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Restores a soft-deleted module version
     /// </summary>
-    Task<bool> RestoreModuleVersionAsync(string moduleNamespace, string name, string provider, string version);
+    Task<bool> RestoreModuleVersionAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Permanently deletes a module version (purge)
     /// </summary>
-    Task<bool> PurgeModuleVersionAsync(string moduleNamespace, string name, string provider, string version);
+    Task<bool> PurgeModuleVersionAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Lists all soft-deleted modules
@@ -75,7 +78,8 @@ public interface IModuleService
     /// <summary>
     ///     Updates the description for all active versions of a module
     /// </summary>
-    Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider, string description);
+    Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider, string description,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Checks that the storage backend is healthy and writable

--- a/TerraformRegistry.API/ModuleService.cs
+++ b/TerraformRegistry.API/ModuleService.cs
@@ -84,18 +84,20 @@ public abstract class ModuleService : IModuleService
     ///     Soft deletes a module version
     /// </summary>
     public abstract Task<bool>
-        DeleteModuleVersionAsync(string moduleNamespace, string name, string provider, string version);
+        DeleteModuleVersionAsync(string moduleNamespace, string name, string provider, string version,
+            CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Restores a soft-deleted module version
     /// </summary>
     public abstract Task<bool> RestoreModuleVersionAsync(string moduleNamespace, string name, string provider,
-        string version);
+        string version, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Permanently deletes a module version (purge)
     /// </summary>
-    public abstract Task<bool> PurgeModuleVersionAsync(string moduleNamespace, string name, string provider, string version);
+    public abstract Task<bool> PurgeModuleVersionAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Lists all soft-deleted modules
@@ -107,7 +109,7 @@ public abstract class ModuleService : IModuleService
     ///     Updates the description for all active versions of a module
     /// </summary>
     public abstract Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider,
-        string description);
+        string description, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Checks that the storage backend is healthy and writable

--- a/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
+++ b/TerraformRegistry.AzureBlob/AzureBlobModuleService.cs
@@ -450,29 +450,31 @@ public class AzureBlobModuleService : ModuleService
         }
     }
 
-    public override Task<bool> DeleteModuleVersionAsync(string moduleNamespace, string name, string provider, string version)
+    public override Task<bool> DeleteModuleVersionAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
-        return _databaseService.SoftDeleteModuleAsync(moduleNamespace, name, provider, version);
+        return _databaseService.SoftDeleteModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
     }
 
     public override Task<bool> RestoreModuleVersionAsync(string moduleNamespace, string name, string provider,
-        string version)
+        string version, CancellationToken cancellationToken = default)
     {
-        return _databaseService.RestoreModuleAsync(moduleNamespace, name, provider, version);
+        return _databaseService.RestoreModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
     }
 
     public override async Task<bool> PurgeModuleVersionAsync(string moduleNamespace, string name, string provider,
-        string version)
+        string version, CancellationToken cancellationToken = default)
     {
         var moduleStorage =
-            await _databaseService.GetModuleStorageIncludingDeletedAsync(moduleNamespace, name, provider, version);
+            await _databaseService.GetModuleStorageIncludingDeletedAsync(moduleNamespace, name, provider, version,
+                cancellationToken);
         if (moduleStorage == null)
             return false;
 
         try
         {
             var blobClient = _containerClient.GetBlobClient(moduleStorage.FilePath);
-            await blobClient.DeleteIfExistsAsync();
+            await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -481,7 +483,9 @@ public class AzureBlobModuleService : ModuleService
             return false;
         }
 
-        return await _databaseService.RemoveModuleAsync(moduleStorage);
+        // Blob deletion is irreversible; complete the catalog mutation after it so cancellation
+        // cannot leave a catalog entry that points at an artifact which no longer exists.
+        return await _databaseService.RemoveModuleAsync(moduleStorage, CancellationToken.None);
     }
 
     public override Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request,
@@ -491,9 +495,10 @@ public class AzureBlobModuleService : ModuleService
     }
 
     public override Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider,
-        string description)
+        string description, CancellationToken cancellationToken = default)
     {
-        return _databaseService.UpdateModuleDescriptionAsync(moduleNamespace, name, provider, description);
+        return _databaseService.UpdateModuleDescriptionAsync(moduleNamespace, name, provider, description,
+            cancellationToken);
     }
 
     private async Task CleanupFailedPublicationAsync(BlobClient blobClient, Guid attemptId, string reason)

--- a/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
@@ -78,29 +78,32 @@ public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRep
         CancellationToken cancellationToken = default) =>
         _modules.GetModuleStorageAsync(moduleNamespace, name, provider, version, cancellationToken);
 
-    public Task<bool> AddModuleAsync(ModuleStorage moduleStorage) =>
-        _modules.AddModuleAsync(moduleStorage);
+    public Task<bool> AddModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default) =>
+        _modules.AddModuleAsync(moduleStorage, cancellationToken);
 
-    public Task<bool> RemoveModuleAsync(ModuleStorage moduleStorage) =>
-        _modules.RemoveModuleAsync(moduleStorage);
+    public Task<bool> RemoveModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default) =>
+        _modules.RemoveModuleAsync(moduleStorage, cancellationToken);
 
-    public Task<bool> RemoveModuleExactAsync(ModuleStorage moduleStorage) =>
-        _modules.RemoveModuleExactAsync(moduleStorage);
+    public Task<bool> RemoveModuleExactAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default) =>
+        _modules.RemoveModuleExactAsync(moduleStorage, cancellationToken);
 
-    public Task<bool> RemoveDeletedModuleAsync(string moduleNamespace, string name, string provider, string version) =>
-        _modules.RemoveDeletedModuleAsync(moduleNamespace, name, provider, version);
+    public Task<bool> RemoveDeletedModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default) =>
+        _modules.RemoveDeletedModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
 
-    public Task<bool> AddDeletedModuleAsync(ModuleStorage moduleStorage) =>
-        _modules.AddDeletedModuleAsync(moduleStorage);
+    public Task<bool> AddDeletedModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default) =>
+        _modules.AddDeletedModuleAsync(moduleStorage, cancellationToken);
 
     public Task<bool> ReplaceModuleExactAsync(ModuleStorage existingModule, ModuleStorage newModule) =>
         _modules.ReplaceModuleExactAsync(existingModule, newModule);
 
-    public Task<bool> SoftDeleteModuleAsync(string moduleNamespace, string name, string provider, string version) =>
-        _modules.SoftDeleteModuleAsync(moduleNamespace, name, provider, version);
+    public Task<bool> SoftDeleteModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default) =>
+        _modules.SoftDeleteModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
 
-    public Task<bool> RestoreModuleAsync(string moduleNamespace, string name, string provider, string version) =>
-        _modules.RestoreModuleAsync(moduleNamespace, name, provider, version);
+    public Task<bool> RestoreModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default) =>
+        _modules.RestoreModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
 
     public Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default) =>
         _modules.ListDeletedModulesAsync(request, cancellationToken);
@@ -109,11 +112,12 @@ public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRep
         string moduleNamespace,
         string name,
         string provider,
-        string version) =>
-        _modules.GetModuleStorageIncludingDeletedAsync(moduleNamespace, name, provider, version);
+        string version, CancellationToken cancellationToken = default) =>
+        _modules.GetModuleStorageIncludingDeletedAsync(moduleNamespace, name, provider, version, cancellationToken);
 
-    public Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider, string description) =>
-        _modules.UpdateModuleDescriptionAsync(moduleNamespace, name, provider, description);
+    public Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider, string description,
+        CancellationToken cancellationToken = default) =>
+        _modules.UpdateModuleDescriptionAsync(moduleNamespace, name, provider, description, cancellationToken);
 
     public Task<ModuleExtractionDocument?> GetModuleExtractionAsync(
         string moduleNamespace,

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleRepository.cs
@@ -300,7 +300,7 @@ public sealed class PostgreSqlModuleRepository(
         try
         {
             await using var connection = new NpgsqlConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var command = new NpgsqlCommand(sql, connection);
             command.Parameters.AddWithValue("moduleNamespace", moduleStorage.Namespace);
@@ -316,7 +316,7 @@ public sealed class PostgreSqlModuleRepository(
             command.Parameters.AddWithValue("@metadata", JsonSerializer.Serialize(moduleStorage.Metadata)).NpgsqlDbType =
                 NpgsqlDbType.Jsonb;
 
-            var rows = await command.ExecuteNonQueryAsync();
+            var rows = await command.ExecuteNonQueryAsync(cancellationToken);
             return rows > 0;
         }
         catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
@@ -349,7 +349,7 @@ public sealed class PostgreSqlModuleRepository(
         try
         {
             await using var connection = new NpgsqlConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var command = new NpgsqlCommand(sql, connection);
             command.Parameters.AddWithValue("moduleNamespace", moduleStorage.Namespace);
@@ -357,7 +357,7 @@ public sealed class PostgreSqlModuleRepository(
             command.Parameters.AddWithValue("@provider", moduleStorage.Provider);
             command.Parameters.AddWithValue("@version", moduleStorage.Version);
 
-            var rowsAffected = await command.ExecuteNonQueryAsync();
+            var rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
             return rowsAffected > 0;
         }
         catch (PostgresException ex) when (ex.SqlState == "23503") // FK violation
@@ -393,7 +393,7 @@ public sealed class PostgreSqlModuleRepository(
         try
         {
             await using var connection = new NpgsqlConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var command = new NpgsqlCommand(sql, connection);
             command.Parameters.AddWithValue("moduleNamespace", moduleStorage.Namespace);
@@ -407,7 +407,7 @@ public sealed class PostgreSqlModuleRepository(
                     moduleStorage.Dependencies == null ? "[]" : JsonSerializer.Serialize(moduleStorage.Dependencies)).NpgsqlDbType =
                 NpgsqlDbType.Jsonb;
 
-            var rowsAffected = await command.ExecuteNonQueryAsync();
+            var rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
             return rowsAffected > 0;
         }
         catch (NpgsqlException ex)
@@ -433,7 +433,7 @@ public sealed class PostgreSqlModuleRepository(
         try
         {
             await using var connection = new NpgsqlConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var command = new NpgsqlCommand(sql, connection);
             command.Parameters.AddWithValue("moduleNamespace", moduleNamespace);
@@ -441,7 +441,7 @@ public sealed class PostgreSqlModuleRepository(
             command.Parameters.AddWithValue("@provider", provider);
             command.Parameters.AddWithValue("@version", version);
 
-            var rowsAffected = await command.ExecuteNonQueryAsync();
+            var rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
             return rowsAffected > 0;
         }
         catch (NpgsqlException ex)
@@ -483,7 +483,7 @@ public sealed class PostgreSqlModuleRepository(
         try
         {
             await using var connection = new NpgsqlConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var command = new NpgsqlCommand(sql, connection);
             command.Parameters.AddWithValue("moduleNamespace", moduleStorage.Namespace);
@@ -498,7 +498,7 @@ public sealed class PostgreSqlModuleRepository(
                 NpgsqlDbType.Jsonb;
             command.Parameters.AddWithValue("@deletedAt", DateTime.UtcNow);
 
-            var rowsAffected = await command.ExecuteNonQueryAsync();
+            var rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
             return rowsAffected > 0;
         }
         catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
@@ -577,14 +577,14 @@ public sealed class PostgreSqlModuleRepository(
         try
         {
             await using var connection = new NpgsqlConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
             await using var command = new NpgsqlCommand(sql, connection);
             command.Parameters.AddWithValue("moduleNamespace", moduleNamespace);
             command.Parameters.AddWithValue("@name", name);
             command.Parameters.AddWithValue("@provider", provider);
             command.Parameters.AddWithValue("@version", version);
             command.Parameters.AddWithValue("@deletedAt", DateTime.UtcNow);
-            var rows = await command.ExecuteNonQueryAsync();
+            var rows = await command.ExecuteNonQueryAsync(cancellationToken);
             return rows > 0;
         }
         catch (NpgsqlException ex)
@@ -604,13 +604,13 @@ public sealed class PostgreSqlModuleRepository(
         try
         {
             await using var connection = new NpgsqlConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
             await using var command = new NpgsqlCommand(sql, connection);
             command.Parameters.AddWithValue("moduleNamespace", moduleNamespace);
             command.Parameters.AddWithValue("@name", name);
             command.Parameters.AddWithValue("@provider", provider);
             command.Parameters.AddWithValue("@version", version);
-            var rows = await command.ExecuteNonQueryAsync();
+            var rows = await command.ExecuteNonQueryAsync(cancellationToken);
             return rows > 0;
         }
         catch (NpgsqlException ex)
@@ -706,7 +706,7 @@ public sealed class PostgreSqlModuleRepository(
             FROM modules WHERE namespace = @moduleNamespace AND name = @name AND provider = @provider AND version = @version";
 
         await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         await using var command = new NpgsqlCommand(sql, connection);
         command.Parameters.AddWithValue("moduleNamespace", moduleNamespace);
@@ -714,8 +714,8 @@ public sealed class PostgreSqlModuleRepository(
         command.Parameters.AddWithValue("@provider", provider);
         command.Parameters.AddWithValue("@version", version);
 
-        await using var reader = await command.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return null;
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken)) return null;
 
         var dependenciesJson = reader.GetString(7);
         var dependencies = JsonSerializer.Deserialize<List<string>>(dependenciesJson) ?? new List<string>();
@@ -743,13 +743,13 @@ public sealed class PostgreSqlModuleRepository(
         try
         {
             await using var connection = new NpgsqlConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
             await using var command = new NpgsqlCommand(sql, connection);
             command.Parameters.AddWithValue("moduleNamespace", moduleNamespace);
             command.Parameters.AddWithValue("@name", name);
             command.Parameters.AddWithValue("@provider", provider);
             command.Parameters.AddWithValue("@description", description);
-            var rows = await command.ExecuteNonQueryAsync();
+            var rows = await command.ExecuteNonQueryAsync(cancellationToken);
             return rows > 0;
         }
         catch (NpgsqlException ex)

--- a/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleRepository.cs
+++ b/TerraformRegistry.PostgreSQL/Repositories/PostgreSqlModuleRepository.cs
@@ -270,8 +270,9 @@ public sealed class PostgreSqlModuleRepository(
     /// <summary>
     ///     Adds a new module to the database
     /// </summary>
-    public async Task<bool> AddModuleAsync(ModuleStorage moduleStorage)
+    public async Task<bool> AddModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var sql = @"
             INSERT INTO modules (
                 namespace,
@@ -335,8 +336,9 @@ public sealed class PostgreSqlModuleRepository(
     /// <summary>
     ///     Removes a module from the database
     /// </summary>
-    public async Task<bool> RemoveModuleAsync(ModuleStorage moduleStorage)
+    public async Task<bool> RemoveModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var sql = @"
             DELETE FROM modules
             WHERE namespace = @moduleNamespace
@@ -373,8 +375,9 @@ public sealed class PostgreSqlModuleRepository(
         }
     }
 
-    public async Task<bool> RemoveModuleExactAsync(ModuleStorage moduleStorage)
+    public async Task<bool> RemoveModuleExactAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var sql = @"
             DELETE FROM modules
             WHERE namespace = @moduleNamespace
@@ -415,8 +418,10 @@ public sealed class PostgreSqlModuleRepository(
         }
     }
 
-    public async Task<bool> RemoveDeletedModuleAsync(string moduleNamespace, string name, string provider, string version)
+    public async Task<bool> RemoveDeletedModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var sql = @"
             DELETE FROM modules
             WHERE namespace = @moduleNamespace
@@ -448,8 +453,9 @@ public sealed class PostgreSqlModuleRepository(
         }
     }
 
-    public async Task<bool> AddDeletedModuleAsync(ModuleStorage moduleStorage)
+    public async Task<bool> AddDeletedModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var sql = @"
             INSERT INTO modules (
                 namespace,
@@ -562,8 +568,10 @@ public sealed class PostgreSqlModuleRepository(
         }
     }
 
-    public async Task<bool> SoftDeleteModuleAsync(string moduleNamespace, string name, string provider, string version)
+    public async Task<bool> SoftDeleteModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var sql = @"UPDATE modules SET deleted_at = @deletedAt 
             WHERE namespace = @moduleNamespace AND name = @name AND provider = @provider AND version = @version AND deleted_at IS NULL";
         try
@@ -587,8 +595,10 @@ public sealed class PostgreSqlModuleRepository(
         }
     }
 
-    public async Task<bool> RestoreModuleAsync(string moduleNamespace, string name, string provider, string version)
+    public async Task<bool> RestoreModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var sql = @"UPDATE modules SET deleted_at = NULL 
             WHERE namespace = @moduleNamespace AND name = @name AND provider = @provider AND version = @version AND deleted_at IS NOT NULL";
         try
@@ -689,8 +699,9 @@ public sealed class PostgreSqlModuleRepository(
     }
 
     public async Task<ModuleStorage?> GetModuleStorageIncludingDeletedAsync(string moduleNamespace, string name,
-        string provider, string version)
+        string provider, string version, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var sql = @"SELECT namespace, name, provider, version, description, storage_path, published_at, dependencies::text, metadata::text
             FROM modules WHERE namespace = @moduleNamespace AND name = @name AND provider = @provider AND version = @version";
 
@@ -724,8 +735,9 @@ public sealed class PostgreSqlModuleRepository(
     }
 
     public async Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider,
-        string description)
+        string description, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var sql = @"UPDATE modules SET description = @description
             WHERE namespace = @moduleNamespace AND name = @name AND provider = @provider AND deleted_at IS NULL";
         try

--- a/TerraformRegistry.S3/S3ModuleObjectStore.cs
+++ b/TerraformRegistry.S3/S3ModuleObjectStore.cs
@@ -251,7 +251,8 @@ internal sealed class S3ModuleObjectStore(
 
     public async Task<(bool Success, IReadOnlyList<string> ObjectKeys)> CollectPurgeableObjectKeysAsync(
         string prefix,
-        ModuleStorage module)
+        ModuleStorage module,
+        CancellationToken cancellationToken)
     {
         var objectKeys = new List<string>();
         string? continuationToken = null;
@@ -265,7 +266,11 @@ internal sealed class S3ModuleObjectStore(
                     BucketName = bucketName,
                     Prefix = prefix,
                     ContinuationToken = continuationToken
-                });
+                }, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -282,7 +287,7 @@ internal sealed class S3ModuleObjectStore(
 
             foreach (var s3Object in response.S3Objects)
             {
-                var inspection = await InspectPurgeObjectAsync(s3Object.Key, module);
+                var inspection = await InspectPurgeObjectAsync(s3Object.Key, module, cancellationToken);
                 if (!inspection.Success)
                 {
                     return (false, []);
@@ -302,7 +307,8 @@ internal sealed class S3ModuleObjectStore(
 
     public async Task<bool> DeletePurgeableObjectKeysAsync(
         IReadOnlyList<string> objectKeys,
-        ModuleStorage module)
+        ModuleStorage module,
+        CancellationToken cancellationToken)
     {
         foreach (var objectKey in EnumeratePurgeDeletionOrder(objectKeys, module.FilePath))
         {
@@ -312,7 +318,11 @@ internal sealed class S3ModuleObjectStore(
                 {
                     BucketName = bucketName,
                     Key = objectKey
-                });
+                }, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -417,7 +427,8 @@ internal sealed class S3ModuleObjectStore(
         }
     }
 
-    private async Task<(bool Success, bool ShouldDelete)> InspectPurgeObjectAsync(string objectKey, ModuleStorage module)
+    private async Task<(bool Success, bool ShouldDelete)> InspectPurgeObjectAsync(string objectKey, ModuleStorage module,
+        CancellationToken cancellationToken)
     {
         GetObjectMetadataResponse response;
         try
@@ -426,11 +437,15 @@ internal sealed class S3ModuleObjectStore(
             {
                 BucketName = bucketName,
                 Key = objectKey
-            });
+            }, cancellationToken);
         }
         catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
             return (true, false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/TerraformRegistry.S3/S3ModuleObjectStore.cs
+++ b/TerraformRegistry.S3/S3ModuleObjectStore.cs
@@ -305,11 +305,12 @@ internal sealed class S3ModuleObjectStore(
         return (true, objectKeys);
     }
 
-    public async Task<bool> DeletePurgeableObjectKeysAsync(
+    public async Task<(bool Success, bool AnyDeleted)> DeletePurgeableObjectKeysAsync(
         IReadOnlyList<string> objectKeys,
         ModuleStorage module,
         CancellationToken cancellationToken)
     {
+        var anyDeleted = false;
         foreach (var objectKey in EnumeratePurgeDeletionOrder(objectKeys, module.FilePath))
         {
             try
@@ -319,6 +320,7 @@ internal sealed class S3ModuleObjectStore(
                     BucketName = bucketName,
                     Key = objectKey
                 }, cancellationToken);
+                anyDeleted = true;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -334,11 +336,11 @@ internal sealed class S3ModuleObjectStore(
                     module.Name,
                     module.Provider,
                     module.Version);
-                return false;
+                return (false, anyDeleted);
             }
         }
 
-        return true;
+        return (true, anyDeleted);
     }
 
     private async Task<bool> FinalObjectMatchesModuleAsync(ModuleStorage module)

--- a/TerraformRegistry.S3/S3ModulePurgeWorkflow.cs
+++ b/TerraformRegistry.S3/S3ModulePurgeWorkflow.cs
@@ -53,10 +53,12 @@ internal sealed class S3ModulePurgeWorkflow(
             return false;
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
+
         return activeModuleStorage != null
             ? await PurgeActiveModuleAsync(activeModuleStorage, moduleStorage, purgeableObjectKeys.ObjectKeys,
-                cancellationToken)
-            : await PurgeDeletedModuleAsync(moduleStorage, purgeableObjectKeys.ObjectKeys, cancellationToken);
+                CancellationToken.None)
+            : await PurgeDeletedModuleAsync(moduleStorage, purgeableObjectKeys.ObjectKeys, CancellationToken.None);
     }
 
     private async Task<bool> PurgeActiveModuleAsync(
@@ -79,20 +81,18 @@ internal sealed class S3ModulePurgeWorkflow(
                 return false;
             }
 
-            var deletedObjects = await objectStore.DeletePurgeableObjectKeysAsync(objectKeys, moduleStorage,
+            var deletion = await objectStore.DeletePurgeableObjectKeysAsync(objectKeys, moduleStorage,
                 cancellationToken);
-            if (deletedObjects)
+            if (deletion.Success)
             {
                 return true;
             }
 
-            await TryRestoreActiveModuleSnapshotAsync(activeModuleStorage);
+            if (!deletion.AnyDeleted)
+            {
+                await TryRestoreActiveModuleSnapshotAsync(activeModuleStorage);
+            }
             return false;
-        }
-        catch (OperationCanceledException)
-        {
-            await TryRestoreActiveModuleSnapshotAsync(activeModuleStorage);
-            throw;
         }
         catch (Exception ex)
         {
@@ -128,20 +128,18 @@ internal sealed class S3ModulePurgeWorkflow(
                 return false;
             }
 
-            var deletedObjects = await objectStore.DeletePurgeableObjectKeysAsync(objectKeys, moduleStorage,
+            var deletion = await objectStore.DeletePurgeableObjectKeysAsync(objectKeys, moduleStorage,
                 cancellationToken);
-            if (deletedObjects)
+            if (deletion.Success)
             {
                 return true;
             }
 
-            await TryRestoreDeletedModuleSnapshotAsync(moduleStorage);
+            if (!deletion.AnyDeleted)
+            {
+                await TryRestoreDeletedModuleSnapshotAsync(moduleStorage);
+            }
             return false;
-        }
-        catch (OperationCanceledException)
-        {
-            await TryRestoreDeletedModuleSnapshotAsync(moduleStorage);
-            throw;
         }
         catch (Exception ex)
         {

--- a/TerraformRegistry.S3/S3ModulePurgeWorkflow.cs
+++ b/TerraformRegistry.S3/S3ModulePurgeWorkflow.cs
@@ -10,17 +10,23 @@ internal sealed class S3ModulePurgeWorkflow(
     S3ModuleObjectStore objectStore,
     ILogger logger)
 {
-    public async Task<bool> PurgeModuleVersionAsync(string @namespace, string name, string provider, string version)
+    public async Task<bool> PurgeModuleVersionAsync(string @namespace, string name, string provider, string version,
+        CancellationToken cancellationToken)
     {
         ModuleStorage? activeModuleStorage;
         ModuleStorage? moduleStorage;
 
         try
         {
-            activeModuleStorage = await databaseService.GetModuleStorageAsync(@namespace, name, provider, version);
+            activeModuleStorage = await databaseService.GetModuleStorageAsync(@namespace, name, provider, version,
+                cancellationToken);
             moduleStorage = activeModuleStorage ??
                             await databaseService.GetModuleStorageIncludingDeletedAsync(@namespace, name, provider,
-                                version);
+                                version, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -40,25 +46,28 @@ internal sealed class S3ModulePurgeWorkflow(
         }
 
         var logicalObjectKey = S3ModuleObjectKeys.CreateLogicalObjectKey(@namespace, name, provider, version);
-        var purgeableObjectKeys = await objectStore.CollectPurgeableObjectKeysAsync(logicalObjectKey, moduleStorage);
+        var purgeableObjectKeys = await objectStore.CollectPurgeableObjectKeysAsync(logicalObjectKey, moduleStorage,
+            cancellationToken);
         if (!purgeableObjectKeys.Success)
         {
             return false;
         }
 
         return activeModuleStorage != null
-            ? await PurgeActiveModuleAsync(activeModuleStorage, moduleStorage, purgeableObjectKeys.ObjectKeys)
-            : await PurgeDeletedModuleAsync(moduleStorage, purgeableObjectKeys.ObjectKeys);
+            ? await PurgeActiveModuleAsync(activeModuleStorage, moduleStorage, purgeableObjectKeys.ObjectKeys,
+                cancellationToken)
+            : await PurgeDeletedModuleAsync(moduleStorage, purgeableObjectKeys.ObjectKeys, cancellationToken);
     }
 
     private async Task<bool> PurgeActiveModuleAsync(
         ModuleStorage activeModuleStorage,
         ModuleStorage moduleStorage,
-        IReadOnlyList<string> objectKeys)
+        IReadOnlyList<string> objectKeys,
+        CancellationToken cancellationToken)
     {
         try
         {
-            var removed = await databaseService.RemoveModuleExactAsync(activeModuleStorage);
+            var removed = await databaseService.RemoveModuleExactAsync(activeModuleStorage, cancellationToken);
             if (!removed)
             {
                 RegistryLog.Warning(logger,
@@ -70,7 +79,8 @@ internal sealed class S3ModulePurgeWorkflow(
                 return false;
             }
 
-            var deletedObjects = await objectStore.DeletePurgeableObjectKeysAsync(objectKeys, moduleStorage);
+            var deletedObjects = await objectStore.DeletePurgeableObjectKeysAsync(objectKeys, moduleStorage,
+                cancellationToken);
             if (deletedObjects)
             {
                 return true;
@@ -78,6 +88,11 @@ internal sealed class S3ModulePurgeWorkflow(
 
             await TryRestoreActiveModuleSnapshotAsync(activeModuleStorage);
             return false;
+        }
+        catch (OperationCanceledException)
+        {
+            await TryRestoreActiveModuleSnapshotAsync(activeModuleStorage);
+            throw;
         }
         catch (Exception ex)
         {
@@ -92,7 +107,8 @@ internal sealed class S3ModulePurgeWorkflow(
         }
     }
 
-    private async Task<bool> PurgeDeletedModuleAsync(ModuleStorage moduleStorage, IReadOnlyList<string> objectKeys)
+    private async Task<bool> PurgeDeletedModuleAsync(ModuleStorage moduleStorage, IReadOnlyList<string> objectKeys,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -100,7 +116,7 @@ internal sealed class S3ModulePurgeWorkflow(
                 moduleStorage.Namespace,
                 moduleStorage.Name,
                 moduleStorage.Provider,
-                moduleStorage.Version);
+                moduleStorage.Version, cancellationToken);
             if (!removed)
             {
                 RegistryLog.Warning(logger,
@@ -112,7 +128,8 @@ internal sealed class S3ModulePurgeWorkflow(
                 return false;
             }
 
-            var deletedObjects = await objectStore.DeletePurgeableObjectKeysAsync(objectKeys, moduleStorage);
+            var deletedObjects = await objectStore.DeletePurgeableObjectKeysAsync(objectKeys, moduleStorage,
+                cancellationToken);
             if (deletedObjects)
             {
                 return true;
@@ -120,6 +137,11 @@ internal sealed class S3ModulePurgeWorkflow(
 
             await TryRestoreDeletedModuleSnapshotAsync(moduleStorage);
             return false;
+        }
+        catch (OperationCanceledException)
+        {
+            await TryRestoreDeletedModuleSnapshotAsync(moduleStorage);
+            throw;
         }
         catch (Exception ex)
         {

--- a/TerraformRegistry.S3/S3ModuleService.cs
+++ b/TerraformRegistry.S3/S3ModuleService.cs
@@ -115,20 +115,21 @@ public class S3ModuleService : ModuleService
     }
 
     public override Task<bool> DeleteModuleVersionAsync(string moduleNamespace, string name, string provider,
-        string version)
+        string version, CancellationToken cancellationToken = default)
     {
-        return _databaseService.SoftDeleteModuleAsync(moduleNamespace, name, provider, version);
+        return _databaseService.SoftDeleteModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
     }
 
     public override Task<bool> RestoreModuleVersionAsync(string moduleNamespace, string name, string provider,
-        string version)
+        string version, CancellationToken cancellationToken = default)
     {
-        return _databaseService.RestoreModuleAsync(moduleNamespace, name, provider, version);
+        return _databaseService.RestoreModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
     }
 
-    public override Task<bool> PurgeModuleVersionAsync(string moduleNamespace, string name, string provider, string version)
+    public override Task<bool> PurgeModuleVersionAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
-        return _purgeWorkflow.PurgeModuleVersionAsync(moduleNamespace, name, provider, version);
+        return _purgeWorkflow.PurgeModuleVersionAsync(moduleNamespace, name, provider, version, cancellationToken);
     }
 
     public override Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request,
@@ -138,9 +139,10 @@ public class S3ModuleService : ModuleService
     }
 
     public override Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider,
-        string description)
+        string description, CancellationToken cancellationToken = default)
     {
-        return _databaseService.UpdateModuleDescriptionAsync(moduleNamespace, name, provider, description);
+        return _databaseService.UpdateModuleDescriptionAsync(moduleNamespace, name, provider, description,
+            cancellationToken);
     }
 
     public override Task<(bool Healthy, string? Reason)> CheckStorageAsync()

--- a/TerraformRegistry.Tests/UnitTests/ModuleHandlersPaginationTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleHandlersPaginationTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Moq;
+using System.Security.Claims;
 using TerraformRegistry.API;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Handlers;
@@ -11,6 +12,30 @@ namespace TerraformRegistry.Tests.UnitTests;
 
 public class ModuleHandlersPaginationTests
 {
+    [Fact]
+    public async Task UpdateDescriptionPassesRequestAbortedToModuleService()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var context = new DefaultHttpContext { RequestAborted = cancellation.Token };
+        context.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.NameIdentifier, "system"), new Claim("permission", Permissions.ModulesDescription)], "StaticToken"));
+        context.Request.Body = new MemoryStream("{\"description\":\"new description\"}"u8.ToArray());
+        var moduleService = new Mock<IModuleService>();
+        moduleService.Setup(x => x.UpdateModuleDescriptionAsync("acme", "name", "aws", "new description", cancellation.Token))
+            .ReturnsAsync(true);
+        var audit = new Mock<IAuditService>();
+        audit.Setup(x => x.LogAsync(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<object?>(), It.IsAny<string?>()))
+            .Returns(Task.CompletedTask);
+
+        await ModuleHandlers.UpdateDescription(
+            "acme", "name", "aws", context.Request, moduleService.Object, audit.Object,
+            new NamespaceAuthorizationService(Mock.Of<INamespaceMaintainerStore>()), context);
+
+        moduleService.Verify(
+            x => x.UpdateModuleDescriptionAsync("acme", "name", "aws", "new description", cancellation.Token), Times.Once);
+    }
+
     [Fact]
     public async Task ListModulesClampsOffsetAndLimitBeforeCallingService()
     {

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceDelegationTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceDelegationTests.cs
@@ -169,6 +169,31 @@ public class S3ModuleServiceDelegationTests
     }
 
     [Fact]
+    public async Task LifecycleMutationsPassCancellationToDatabaseService()
+    {
+        using var cancellation = new CancellationTokenSource();
+        _mockDatabaseService
+            .Setup(x => x.SoftDeleteModuleAsync("ns", "name", "aws", "1.0.0", cancellation.Token))
+            .ReturnsAsync(true);
+        _mockDatabaseService
+            .Setup(x => x.RestoreModuleAsync("ns", "name", "aws", "1.0.0", cancellation.Token))
+            .ReturnsAsync(true);
+        _mockDatabaseService
+            .Setup(x => x.UpdateModuleDescriptionAsync("ns", "name", "aws", "new-desc", cancellation.Token))
+            .ReturnsAsync(true);
+
+        var service = CreateService();
+
+        Assert.True(await service.DeleteModuleVersionAsync("ns", "name", "aws", "1.0.0", cancellation.Token));
+        Assert.True(await service.RestoreModuleVersionAsync("ns", "name", "aws", "1.0.0", cancellation.Token));
+        Assert.True(await service.UpdateModuleDescriptionAsync("ns", "name", "aws", "new-desc", cancellation.Token));
+
+        _mockDatabaseService.Verify(x => x.SoftDeleteModuleAsync("ns", "name", "aws", "1.0.0", cancellation.Token), Times.Once);
+        _mockDatabaseService.Verify(x => x.RestoreModuleAsync("ns", "name", "aws", "1.0.0", cancellation.Token), Times.Once);
+        _mockDatabaseService.Verify(x => x.UpdateModuleDescriptionAsync("ns", "name", "aws", "new-desc", cancellation.Token), Times.Once);
+    }
+
+    [Fact]
     public async Task UpdateModuleDescriptionAsyncDelegatesToDatabaseService()
     {
         _mockDatabaseService.Setup(x => x.UpdateModuleDescriptionAsync("ns", "name", "aws", "new-desc")).ReturnsAsync(true);

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServicePurgeAndHealthTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServicePurgeAndHealthTests.cs
@@ -66,6 +66,33 @@ public class S3ModuleServicePurgeAndHealthTests
     }
 
     [Fact]
+    public async Task PurgeModuleVersionAsyncRestoresCatalogRowWhenObjectDeletionIsCancelled()
+    {
+        var module = new ModuleStorage
+        {
+            Namespace = "ns", Name = "name", Provider = "aws", Version = "1.0.0", Description = "desc",
+            FilePath = "ns/name-aws-1.0.0.zip", PublishedAt = DateTime.UtcNow, Dependencies = []
+        };
+        using var cancellation = new CancellationTokenSource();
+        _mockDatabaseService.Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0", cancellation.Token))
+            .ReturnsAsync(module);
+        _mockDatabaseService.Setup(x => x.RemoveModuleExactAsync(module, cancellation.Token)).ReturnsAsync(true);
+        _mockDatabaseService.Setup(x => x.AddModuleAsync(module, CancellationToken.None)).ReturnsAsync(true);
+        _mockS3Client.Setup(x => x.ListObjectsV2Async(It.IsAny<ListObjectsV2Request>(), cancellation.Token))
+            .ReturnsAsync(new ListObjectsV2Response { S3Objects = [new S3Object { Key = module.FilePath }] });
+        _mockS3Client.Setup(x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), cancellation.Token))
+            .ReturnsAsync(CreateMetadataResponse(module));
+        _mockS3Client.Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), cancellation.Token))
+            .Callback(() => cancellation.Cancel())
+            .ThrowsAsync(new OperationCanceledException(cancellation.Token));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => CreateService().PurgeModuleVersionAsync("ns", "name", "aws", "1.0.0", cancellation.Token));
+
+        _mockDatabaseService.Verify(x => x.AddModuleAsync(module, CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
     public async Task PurgeModuleVersionAsyncDeletesDatabaseRowAndObject()
     {
         var module = new ModuleStorage

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServicePurgeAndHealthTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServicePurgeAndHealthTests.cs
@@ -66,7 +66,7 @@ public class S3ModuleServicePurgeAndHealthTests
     }
 
     [Fact]
-    public async Task PurgeModuleVersionAsyncRestoresCatalogRowWhenObjectDeletionIsCancelled()
+    public async Task PurgeModuleVersionAsyncCompletesDestructionWhenCancellationArrivesAfterFirstObjectDeletion()
     {
         var module = new ModuleStorage
         {
@@ -74,22 +74,38 @@ public class S3ModuleServicePurgeAndHealthTests
             FilePath = "ns/name-aws-1.0.0.zip", PublishedAt = DateTime.UtcNow, Dependencies = []
         };
         using var cancellation = new CancellationTokenSource();
+        var deletionCount = 0;
         _mockDatabaseService.Setup(x => x.GetModuleStorageAsync("ns", "name", "aws", "1.0.0", cancellation.Token))
             .ReturnsAsync(module);
-        _mockDatabaseService.Setup(x => x.RemoveModuleExactAsync(module, cancellation.Token)).ReturnsAsync(true);
-        _mockDatabaseService.Setup(x => x.AddModuleAsync(module, CancellationToken.None)).ReturnsAsync(true);
+        _mockDatabaseService.Setup(x => x.RemoveModuleExactAsync(module, CancellationToken.None)).ReturnsAsync(true);
         _mockS3Client.Setup(x => x.ListObjectsV2Async(It.IsAny<ListObjectsV2Request>(), cancellation.Token))
-            .ReturnsAsync(new ListObjectsV2Response { S3Objects = [new S3Object { Key = module.FilePath }] });
+            .ReturnsAsync(new ListObjectsV2Response
+            {
+                S3Objects =
+                [
+                    new S3Object { Key = module.FilePath },
+                    new S3Object { Key = "ns/name-aws-1.0.0.zip.previous" }
+                ]
+            });
         _mockS3Client.Setup(x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), cancellation.Token))
             .ReturnsAsync(CreateMetadataResponse(module));
-        _mockS3Client.Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), cancellation.Token))
-            .Callback(() => cancellation.Cancel())
-            .ThrowsAsync(new OperationCanceledException(cancellation.Token));
+        _mockS3Client.Setup(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), CancellationToken.None))
+            .Returns<DeleteObjectRequest, CancellationToken>((_, _) =>
+            {
+                if (++deletionCount == 1)
+                {
+                    cancellation.Cancel();
+                }
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
-            () => CreateService().PurgeModuleVersionAsync("ns", "name", "aws", "1.0.0", cancellation.Token));
+                return Task.FromResult(new DeleteObjectResponse());
+            });
 
-        _mockDatabaseService.Verify(x => x.AddModuleAsync(module, CancellationToken.None), Times.Once);
+        var result = await CreateService().PurgeModuleVersionAsync("ns", "name", "aws", "1.0.0", cancellation.Token);
+
+        Assert.True(result);
+        _mockDatabaseService.Verify(x => x.RemoveModuleExactAsync(module, CancellationToken.None), Times.Once);
+        _mockDatabaseService.Verify(x => x.AddModuleAsync(module, It.IsAny<CancellationToken>()), Times.Never);
+        _mockS3Client.Verify(x => x.DeleteObjectAsync(It.IsAny<DeleteObjectRequest>(), CancellationToken.None), Times.Exactly(2));
     }
 
     [Fact]

--- a/TerraformRegistry/Handlers/ModuleHandlers.cs
+++ b/TerraformRegistry/Handlers/ModuleHandlers.cs
@@ -385,7 +385,7 @@ public static class ModuleHandlers
                 $"Version '{version}' is not a valid Semantic Version (SemVer 2.0.0). Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILDMETADATA]");
         }
 
-        var result = await moduleService.DeleteModuleVersionAsync(@namespace, name, provider, version);
+        var result = await moduleService.DeleteModuleVersionAsync(@namespace, name, provider, version, context.RequestAborted);
         if (!result) return ErrorResponseExtensions.NotFound("Module version not found");
 
         await webhookDispatcher.FireEventAsync("module.deleted", @namespace, name, provider, version, null, context.RequestAborted);
@@ -425,7 +425,7 @@ public static class ModuleHandlers
                 $"Version '{version}' is not a valid Semantic Version (SemVer 2.0.0). Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILDMETADATA]");
         }
 
-        var result = await moduleService.RestoreModuleVersionAsync(@namespace, name, provider, version);
+        var result = await moduleService.RestoreModuleVersionAsync(@namespace, name, provider, version, context.RequestAborted);
         if (!result) return ErrorResponseExtensions.NotFound("Deleted module version not found");
 
         await webhookDispatcher.FireEventAsync("module.restored", @namespace, name, provider, version, null, context.RequestAborted);
@@ -465,7 +465,7 @@ public static class ModuleHandlers
                 $"Version '{version}' is not a valid Semantic Version (SemVer 2.0.0). Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILDMETADATA]");
         }
 
-        var result = await moduleService.PurgeModuleVersionAsync(@namespace, name, provider, version);
+        var result = await moduleService.PurgeModuleVersionAsync(@namespace, name, provider, version, context.RequestAborted);
         if (!result) return ErrorResponseExtensions.NotFound("Deleted module version not found");
 
         await webhookDispatcher.FireEventAsync("module.purged", @namespace, name, provider, version, null, context.RequestAborted);
@@ -529,16 +529,21 @@ public static class ModuleHandlers
         try
         {
             using var reader = new StreamReader(request.Body);
-            var body = await reader.ReadToEndAsync();
+            var body = await reader.ReadToEndAsync(context.RequestAborted);
             using var json = System.Text.Json.JsonDocument.Parse(body);
             var description = json.RootElement.GetProperty("description").GetString() ?? string.Empty;
 
-            var result = await moduleService.UpdateModuleDescriptionAsync(@namespace, name, provider, description);
+            var result = await moduleService.UpdateModuleDescriptionAsync(@namespace, name, provider, description,
+                context.RequestAborted);
             if (!result) return ErrorResponseExtensions.NotFound("Module not found");
 
             await context.FireAuditLogAsync(auditService, "module.description_updated", "module", $"{@namespace}/{name}/{provider}", new { @namespace, name, provider, description });
 
             return Ok(new { description });
+        }
+        catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/TerraformRegistry/Services/LocalModuleService.cs
+++ b/TerraformRegistry/Services/LocalModuleService.cs
@@ -382,22 +382,24 @@ public class LocalModuleService : ModuleService
         }
     }
 
-    public override Task<bool> DeleteModuleVersionAsync(string moduleNamespace, string name, string provider, string version)
+    public override Task<bool> DeleteModuleVersionAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
-        return _databaseService.SoftDeleteModuleAsync(moduleNamespace, name, provider, version);
+        return _databaseService.SoftDeleteModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
     }
 
     public override Task<bool> RestoreModuleVersionAsync(string moduleNamespace, string name, string provider,
-        string version)
+        string version, CancellationToken cancellationToken = default)
     {
-        return _databaseService.RestoreModuleAsync(moduleNamespace, name, provider, version);
+        return _databaseService.RestoreModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
     }
 
     public override async Task<bool> PurgeModuleVersionAsync(string moduleNamespace, string name, string provider,
-        string version)
+        string version, CancellationToken cancellationToken = default)
     {
         var moduleStorage =
-            await _databaseService.GetModuleStorageIncludingDeletedAsync(moduleNamespace, name, provider, version);
+            await _databaseService.GetModuleStorageIncludingDeletedAsync(moduleNamespace, name, provider, version,
+                cancellationToken);
         if (moduleStorage == null)
             return false;
         if (!IsInsideStorageRoot(moduleStorage.FilePath))
@@ -410,6 +412,7 @@ public class LocalModuleService : ModuleService
 
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (File.Exists(moduleStorage.FilePath))
                 File.Delete(moduleStorage.FilePath);
         }
@@ -420,7 +423,9 @@ public class LocalModuleService : ModuleService
             return false;
         }
 
-        return await _databaseService.RemoveModuleAsync(moduleStorage);
+        // The file deletion is irreversible; complete the catalog mutation after it so cancellation
+        // cannot leave a catalog entry that points at an artifact which no longer exists.
+        return await _databaseService.RemoveModuleAsync(moduleStorage, CancellationToken.None);
     }
 
     public override Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request,
@@ -430,9 +435,10 @@ public class LocalModuleService : ModuleService
     }
 
     public override Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider,
-        string description)
+        string description, CancellationToken cancellationToken = default)
     {
-        return _databaseService.UpdateModuleDescriptionAsync(moduleNamespace, name, provider, description);
+        return _databaseService.UpdateModuleDescriptionAsync(moduleNamespace, name, provider, description,
+            cancellationToken);
     }
 
     public override async Task<(bool Healthy, string? Reason)> CheckStorageAsync()

--- a/TerraformRegistry/Services/Sqlite/SqliteModuleRepository.cs
+++ b/TerraformRegistry/Services/Sqlite/SqliteModuleRepository.cs
@@ -222,7 +222,7 @@ public sealed class SqliteModuleRepository(
         };
     }
 
-    public async Task<bool> AddModuleAsync(ModuleStorage moduleStorage)
+    public async Task<bool> AddModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default)
     {
         var sql = @"
             INSERT INTO modules (
@@ -234,7 +234,7 @@ public sealed class SqliteModuleRepository(
         try
         {
             await using var connection = new SqliteConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var cmd = connection.CreateCommand();
             cmd.CommandText = sql;
@@ -249,7 +249,7 @@ public sealed class SqliteModuleRepository(
                 moduleStorage.Dependencies == null ? "[]" : JsonSerializer.Serialize(moduleStorage.Dependencies));
             cmd.Parameters.AddWithValue("$metadata", JsonSerializer.Serialize(moduleStorage.Metadata));
 
-            var rows = await cmd.ExecuteNonQueryAsync();
+            var rows = await cmd.ExecuteNonQueryAsync(cancellationToken);
             return rows > 0;
         }
         catch (SqliteException ex) when (ex.SqliteErrorCode == 19 && ex.SqliteExtendedErrorCode == 2067)
@@ -258,7 +258,7 @@ public sealed class SqliteModuleRepository(
                 moduleStorage.Namespace, moduleStorage.Name, moduleStorage.Provider, moduleStorage.Version);
             return false;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger, ex, "Error adding module {Namespace}/{Name}/{Provider}/{Version} to SQLite",
                 moduleStorage.Namespace, moduleStorage.Name, moduleStorage.Provider, moduleStorage.Version);
@@ -266,7 +266,7 @@ public sealed class SqliteModuleRepository(
         }
     }
 
-    public async Task<bool> RemoveModuleAsync(ModuleStorage moduleStorage)
+    public async Task<bool> RemoveModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default)
     {
         var sql = @"
             DELETE FROM modules
@@ -274,17 +274,17 @@ public sealed class SqliteModuleRepository(
         try
         {
             await using var connection = new SqliteConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
             await using var cmd = connection.CreateCommand();
             cmd.CommandText = sql;
             cmd.Parameters.AddWithValue("$ns", moduleStorage.Namespace);
             cmd.Parameters.AddWithValue("$name", moduleStorage.Name);
             cmd.Parameters.AddWithValue("$prov", moduleStorage.Provider);
             cmd.Parameters.AddWithValue("$ver", moduleStorage.Version);
-            var rows = await cmd.ExecuteNonQueryAsync();
+            var rows = await cmd.ExecuteNonQueryAsync(cancellationToken);
             return rows > 0;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger, ex, "Error removing module {Namespace}/{Name}/{Provider}/{Version} from SQLite",
                 moduleStorage.Namespace, moduleStorage.Name, moduleStorage.Provider, moduleStorage.Version);
@@ -292,7 +292,7 @@ public sealed class SqliteModuleRepository(
         }
     }
 
-    public async Task<bool> RemoveModuleExactAsync(ModuleStorage moduleStorage)
+    public async Task<bool> RemoveModuleExactAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default)
     {
         var sql = @"
             DELETE FROM modules
@@ -309,7 +309,7 @@ public sealed class SqliteModuleRepository(
         try
         {
             await using var connection = new SqliteConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
             await using var cmd = connection.CreateCommand();
             cmd.CommandText = sql;
             cmd.Parameters.AddWithValue("$ns", moduleStorage.Namespace);
@@ -321,10 +321,10 @@ public sealed class SqliteModuleRepository(
             cmd.Parameters.AddWithValue("$published", moduleStorage.PublishedAt.ToString("o", CultureInfo.InvariantCulture));
             cmd.Parameters.AddWithValue("$deps",
                 moduleStorage.Dependencies == null ? "[]" : JsonSerializer.Serialize(moduleStorage.Dependencies));
-            var rows = await cmd.ExecuteNonQueryAsync();
+            var rows = await cmd.ExecuteNonQueryAsync(cancellationToken);
             return rows > 0;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger, ex,
                 "Error removing exact module row {Namespace}/{Name}/{Provider}/{Version} from SQLite",
@@ -333,7 +333,8 @@ public sealed class SqliteModuleRepository(
         }
     }
 
-    public async Task<bool> RemoveDeletedModuleAsync(string moduleNamespace, string name, string provider, string version)
+    public async Task<bool> RemoveDeletedModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
         var sql = @"
             DELETE FROM modules
@@ -346,17 +347,17 @@ public sealed class SqliteModuleRepository(
         try
         {
             await using var connection = new SqliteConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
             await using var cmd = connection.CreateCommand();
             cmd.CommandText = sql;
             cmd.Parameters.AddWithValue("$ns", moduleNamespace);
             cmd.Parameters.AddWithValue("$name", name);
             cmd.Parameters.AddWithValue("$prov", provider);
             cmd.Parameters.AddWithValue("$ver", version);
-            var rows = await cmd.ExecuteNonQueryAsync();
+            var rows = await cmd.ExecuteNonQueryAsync(cancellationToken);
             return rows > 0;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger, ex,
                 "Error removing deleted module row {Namespace}/{Name}/{Provider}/{Version} from SQLite",
@@ -365,7 +366,7 @@ public sealed class SqliteModuleRepository(
         }
     }
 
-    public async Task<bool> AddDeletedModuleAsync(ModuleStorage moduleStorage)
+    public async Task<bool> AddDeletedModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default)
     {
         var sql = @"
             INSERT INTO modules (
@@ -377,7 +378,7 @@ public sealed class SqliteModuleRepository(
         try
         {
             await using var connection = new SqliteConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var cmd = connection.CreateCommand();
             cmd.CommandText = sql;
@@ -392,7 +393,7 @@ public sealed class SqliteModuleRepository(
                 moduleStorage.Dependencies == null ? "[]" : JsonSerializer.Serialize(moduleStorage.Dependencies));
             cmd.Parameters.AddWithValue("$deletedAt", DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture));
 
-            var rows = await cmd.ExecuteNonQueryAsync();
+            var rows = await cmd.ExecuteNonQueryAsync(cancellationToken);
             return rows > 0;
         }
         catch (SqliteException ex) when (ex.SqliteErrorCode == 19 && ex.SqliteExtendedErrorCode == 2067)
@@ -401,7 +402,7 @@ public sealed class SqliteModuleRepository(
                 moduleStorage.Namespace, moduleStorage.Name, moduleStorage.Provider, moduleStorage.Version);
             return false;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger, ex,
                 "Error adding deleted module row {Namespace}/{Name}/{Provider}/{Version} to SQLite",
@@ -452,7 +453,7 @@ public sealed class SqliteModuleRepository(
             var rows = await cmd.ExecuteNonQueryAsync();
             return rows > 0;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger, ex,
                 "Error replacing exact module row {Namespace}/{Name}/{Provider}/{Version} in SQLite",
@@ -461,14 +462,15 @@ public sealed class SqliteModuleRepository(
         }
     }
 
-    public async Task<bool> SoftDeleteModuleAsync(string moduleNamespace, string name, string provider, string version)
+    public async Task<bool> SoftDeleteModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
         var sql = @"UPDATE modules SET deleted_at = $deletedAt 
             WHERE namespace = $ns AND name = $name AND provider = $prov AND version = $ver AND deleted_at IS NULL";
         try
         {
             await using var connection = new SqliteConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
             await using var cmd = connection.CreateCommand();
             cmd.CommandText = sql;
             cmd.Parameters.AddWithValue("$ns", moduleNamespace);
@@ -476,10 +478,10 @@ public sealed class SqliteModuleRepository(
             cmd.Parameters.AddWithValue("$prov", provider);
             cmd.Parameters.AddWithValue("$ver", version);
             cmd.Parameters.AddWithValue("$deletedAt", DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture));
-            var rows = await cmd.ExecuteNonQueryAsync();
+            var rows = await cmd.ExecuteNonQueryAsync(cancellationToken);
             return rows > 0;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger, ex, "Error soft deleting module {Namespace}/{Name}/{Provider}/{Version} from SQLite",
                 moduleNamespace, name, provider, version);
@@ -487,24 +489,25 @@ public sealed class SqliteModuleRepository(
         }
     }
 
-    public async Task<bool> RestoreModuleAsync(string moduleNamespace, string name, string provider, string version)
+    public async Task<bool> RestoreModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default)
     {
         var sql = @"UPDATE modules SET deleted_at = NULL 
             WHERE namespace = $ns AND name = $name AND provider = $prov AND version = $ver AND deleted_at IS NOT NULL";
         try
         {
             await using var connection = new SqliteConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
             await using var cmd = connection.CreateCommand();
             cmd.CommandText = sql;
             cmd.Parameters.AddWithValue("$ns", moduleNamespace);
             cmd.Parameters.AddWithValue("$name", name);
             cmd.Parameters.AddWithValue("$prov", provider);
             cmd.Parameters.AddWithValue("$ver", version);
-            var rows = await cmd.ExecuteNonQueryAsync();
+            var rows = await cmd.ExecuteNonQueryAsync(cancellationToken);
             return rows > 0;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger, ex, "Error restoring module {Namespace}/{Name}/{Provider}/{Version} in SQLite",
                 moduleNamespace, name, provider, version);
@@ -585,10 +588,10 @@ public sealed class SqliteModuleRepository(
     }
 
     public async Task<ModuleStorage?> GetModuleStorageIncludingDeletedAsync(string moduleNamespace, string name,
-        string provider, string version)
+        string provider, string version, CancellationToken cancellationToken = default)
     {
         await using var connection = new SqliteConnection(connectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var sql = @"SELECT namespace, name, provider, version, description, storage_path, published_at, dependencies, metadata
             FROM modules WHERE namespace = $ns AND name = $name AND provider = $prov AND version = $ver";
@@ -600,8 +603,8 @@ public sealed class SqliteModuleRepository(
         cmd.Parameters.AddWithValue("$prov", provider);
         cmd.Parameters.AddWithValue("$ver", version);
 
-        await using var reader = await cmd.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return null;
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken)) return null;
 
         var depsJson = reader.GetString(7);
         var deps = string.IsNullOrWhiteSpace(depsJson)
@@ -623,24 +626,24 @@ public sealed class SqliteModuleRepository(
     }
 
     public async Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider,
-        string description)
+        string description, CancellationToken cancellationToken = default)
     {
         var sql = @"UPDATE modules SET description = $desc
             WHERE namespace = $ns AND name = $name AND provider = $prov AND deleted_at IS NULL";
         try
         {
             await using var connection = new SqliteConnection(connectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
             await using var cmd = connection.CreateCommand();
             cmd.CommandText = sql;
             cmd.Parameters.AddWithValue("$ns", moduleNamespace);
             cmd.Parameters.AddWithValue("$name", name);
             cmd.Parameters.AddWithValue("$prov", provider);
             cmd.Parameters.AddWithValue("$desc", description);
-            var rows = await cmd.ExecuteNonQueryAsync();
+            var rows = await cmd.ExecuteNonQueryAsync(cancellationToken);
             return rows > 0;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             RegistryLog.Error(logger, ex, "Error updating description for module {Namespace}/{Name}/{Provider} in SQLite",
                 moduleNamespace, name, provider);

--- a/TerraformRegistry/Services/SqliteDatabaseService.cs
+++ b/TerraformRegistry/Services/SqliteDatabaseService.cs
@@ -92,29 +92,32 @@ public class SqliteDatabaseService : IDatabaseService, IModulePublicationReposit
         CancellationToken cancellationToken = default) =>
         _modules.GetModuleStorageAsync(moduleNamespace, name, provider, version, cancellationToken);
 
-    public Task<bool> AddModuleAsync(ModuleStorage moduleStorage) =>
-        _modules.AddModuleAsync(moduleStorage);
+    public Task<bool> AddModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default) =>
+        _modules.AddModuleAsync(moduleStorage, cancellationToken);
 
-    public Task<bool> RemoveModuleAsync(ModuleStorage moduleStorage) =>
-        _modules.RemoveModuleAsync(moduleStorage);
+    public Task<bool> RemoveModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default) =>
+        _modules.RemoveModuleAsync(moduleStorage, cancellationToken);
 
-    public Task<bool> RemoveModuleExactAsync(ModuleStorage moduleStorage) =>
-        _modules.RemoveModuleExactAsync(moduleStorage);
+    public Task<bool> RemoveModuleExactAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default) =>
+        _modules.RemoveModuleExactAsync(moduleStorage, cancellationToken);
 
-    public Task<bool> RemoveDeletedModuleAsync(string moduleNamespace, string name, string provider, string version) =>
-        _modules.RemoveDeletedModuleAsync(moduleNamespace, name, provider, version);
+    public Task<bool> RemoveDeletedModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default) =>
+        _modules.RemoveDeletedModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
 
-    public Task<bool> AddDeletedModuleAsync(ModuleStorage moduleStorage) =>
-        _modules.AddDeletedModuleAsync(moduleStorage);
+    public Task<bool> AddDeletedModuleAsync(ModuleStorage moduleStorage, CancellationToken cancellationToken = default) =>
+        _modules.AddDeletedModuleAsync(moduleStorage, cancellationToken);
 
     public Task<bool> ReplaceModuleExactAsync(ModuleStorage existingModule, ModuleStorage newModule) =>
         _modules.ReplaceModuleExactAsync(existingModule, newModule);
 
-    public Task<bool> SoftDeleteModuleAsync(string moduleNamespace, string name, string provider, string version) =>
-        _modules.SoftDeleteModuleAsync(moduleNamespace, name, provider, version);
+    public Task<bool> SoftDeleteModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default) =>
+        _modules.SoftDeleteModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
 
-    public Task<bool> RestoreModuleAsync(string moduleNamespace, string name, string provider, string version) =>
-        _modules.RestoreModuleAsync(moduleNamespace, name, provider, version);
+    public Task<bool> RestoreModuleAsync(string moduleNamespace, string name, string provider, string version,
+        CancellationToken cancellationToken = default) =>
+        _modules.RestoreModuleAsync(moduleNamespace, name, provider, version, cancellationToken);
 
     public Task<ModuleList> ListDeletedModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default) =>
         _modules.ListDeletedModulesAsync(request, cancellationToken);
@@ -123,11 +126,12 @@ public class SqliteDatabaseService : IDatabaseService, IModulePublicationReposit
         string moduleNamespace,
         string name,
         string provider,
-        string version) =>
-        _modules.GetModuleStorageIncludingDeletedAsync(moduleNamespace, name, provider, version);
+        string version, CancellationToken cancellationToken = default) =>
+        _modules.GetModuleStorageIncludingDeletedAsync(moduleNamespace, name, provider, version, cancellationToken);
 
-    public Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider, string description) =>
-        _modules.UpdateModuleDescriptionAsync(moduleNamespace, name, provider, description);
+    public Task<bool> UpdateModuleDescriptionAsync(string moduleNamespace, string name, string provider, string description,
+        CancellationToken cancellationToken = default) =>
+        _modules.UpdateModuleDescriptionAsync(moduleNamespace, name, provider, description, cancellationToken);
 
     public Task<ModuleExtractionDocument?> GetModuleExtractionAsync(
         string moduleNamespace,


### PR DESCRIPTION
## Summary
- forward request cancellation through module delete, restore, purge, and description update operations
- thread cancellation through SQLite, PostgreSQL, Azure Blob, and S3 lifecycle work
- restore the S3 catalog snapshot if cancellation interrupts object deletion

## Verification
- `docker run --rm -v "$PWD":/src -w /src mcr.microsoft.com/dotnet/sdk:10.0.301 dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --filter 'FullyQualifiedName~S3ModuleServicePurgeAndHealthTests|FullyQualifiedName~S3ModuleServiceDelegationTests|FullyQualifiedName~ModuleHandlersPaginationTests' --logger 'console;verbosity=minimal'` (34 passed)