### PR TITLE
test: add fault and load certification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,6 +261,29 @@ jobs:
       - name: Run transactional publication fault gate
         run: bash scripts/remediation/gates/publication-fault-gate.sh
 
+  fault-load-certification:
+    name: Fault and load certification
+    if: github.event_name == 'pull_request' && github.head_ref == 'test/fault-load-certification'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Verify fault and load certification gate structure
+        run: bash scripts/remediation/gates/test-fault-load-certification.sh
+
+      - name: Run fault and load certification
+        run: bash scripts/remediation/gates/fault-load-certification.sh
+
   docker:
     name: Docker build and scan
     needs:

--- a/scripts/remediation/gates/fault-load-certification.sh
+++ b/scripts/remediation/gates/fault-load-certification.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deterministic, bounded release-certification evidence. The suites cover the
+# migration state matrix, publication/storage faults, bounded extraction,
+# mirror contention and lease loss, authorization, cancellation propagation,
+# and the 100,000-version pagination evidence fixture. They use disposable
+# SQLite/Testcontainer fixtures and SDK mocks where a cloud control plane is
+# unavailable; the separate emulator and Terraform jobs retain real backend
+# coverage without making this gate depend on cloud credentials.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+ASPNETCORE_ENVIRONMENT=Test dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj \
+  --configuration Release \
+  --filter 'FullyQualifiedName~MigrationAcceptanceMatrixTests|FullyQualifiedName~DbUpPostgresqlMigrationTests|FullyQualifiedName~LocalModuleServiceTests|FullyQualifiedName~AzureBlobModuleServiceUploadTests|FullyQualifiedName~S3ModuleServiceUploadTests|FullyQualifiedName~S3ModuleServicePurgeAndHealthTests|FullyQualifiedName~ModuleExtractionQueueRuntimeTests|FullyQualifiedName~ArchiveWorkspaceFactoryTests|FullyQualifiedName~ModulePublishCoordinatorTests|FullyQualifiedName~ModuleMirrorServiceTests|FullyQualifiedName~ProviderMirrorServiceTests|FullyQualifiedName~MirrorLeaseHeartbeatTests|FullyQualifiedName~MirrorDownloadAdmissionTests|FullyQualifiedName~NamespaceAuthorizationServiceTests|FullyQualifiedName~RbacTests|FullyQualifiedName~ApiKeyExpirationTests|FullyQualifiedName~ArtifactDownloadTokenServiceTests|FullyQualifiedName~TerraformLoginAuthorizationTests|FullyQualifiedName~LlmHandlersCancellationTests|FullyQualifiedName~ModuleHandlersPaginationTests|FullyQualifiedName~S3ModuleServiceDelegationTests|FullyQualifiedName~SqlitePaginationScaleEvidenceTests' \
+  --blame-hang \
+  --blame-hang-timeout 5m
+
+printf 'Fault and load certification gate passed.\n'

--- a/scripts/remediation/gates/test-fault-load-certification.sh
+++ b/scripts/remediation/gates/test-fault-load-certification.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+GATE="$ROOT/scripts/remediation/gates/fault-load-certification.sh"
+WORKFLOW="$ROOT/.github/workflows/ci.yaml"
+
+test -x "$GATE"
+
+# Each selected suite is executable evidence for one release-certification area.
+for suite in \
+  MigrationAcceptanceMatrixTests \
+  DbUpPostgresqlMigrationTests \
+  LocalModuleServiceTests \
+  AzureBlobModuleServiceUploadTests \
+  S3ModuleServiceUploadTests \
+  ModuleExtractionQueueRuntimeTests \
+  ArchiveWorkspaceFactoryTests \
+  ModuleMirrorServiceTests \
+  ProviderMirrorServiceTests \
+  MirrorLeaseHeartbeatTests \
+  NamespaceAuthorizationServiceTests \
+  RbacTests \
+  ApiKeyExpirationTests \
+  ArtifactDownloadTokenServiceTests \
+  LlmHandlersCancellationTests \
+  SqlitePaginationScaleEvidenceTests; do
+  grep -Fq "$suite" "$GATE"
+done
+
+grep -Eq '^  fault-load-certification:' "$WORKFLOW"
+grep -Fq 'test/fault-load-certification' "$WORKFLOW"
+grep -Fq 'scripts/remediation/gates/fault-load-certification.sh' "$WORKFLOW"


### PR DESCRIPTION
## Summary
- adds a bounded, executable fault/load release-certification gate
- wires the gate into PR CI for this certification branch
- locks the selected suite coverage with a structural gate test

## Evidence
- `DOTNET_ROOT=$HOME/.cache/terraform-registry-dotnet PATH=$HOME/.cache/terraform-registry-dotnet:$PATH bash scripts/remediation/gates/fault-load-certification.sh`
- Passed: 190 tests (migration, storage/publication, extraction, mirror, authorization, cancellation, and 100k-version pagination).

## Limitations
- The gate uses disposable SQLite/PostgreSQL Testcontainer fixtures and SDK-level storage faults. Real Azurite/MinIO Terraform conformance remains covered by the existing storage-emulator CI job; managed-identity Azure requires the protected environment.