### PR TITLE
feat: add operational metrics and redaction coverage

### DIFF
--- a/TerraformRegistry.API/Logging/RegistryLog.cs
+++ b/TerraformRegistry.API/Logging/RegistryLog.cs
@@ -201,7 +201,7 @@ public static class RegistryLog
             CreateKey(level, message),
             static key => LoggerMessage.Define(key.Level, new EventId(0), key.Message));
 
-        callback(logger, exception);
+        callback(logger, SensitiveDataRedactor.RedactException(exception));
     }
 
     private static void Log<T0>(ILogger logger, LogLevel level, Exception? exception, string message, T0 arg0)
@@ -213,7 +213,7 @@ public static class RegistryLog
             CreateKey<T0>(level, message),
             static key => LoggerMessage.Define<T0>(key.Level, new EventId(0), key.Message));
 
-        callback(logger, SensitiveDataRedactor.RedactValue(arg0), exception);
+        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactException(exception));
     }
 
     private static void Log<T0, T1>(ILogger logger, LogLevel level, Exception? exception, string message, T0 arg0, T1 arg1)
@@ -225,7 +225,7 @@ public static class RegistryLog
             CreateKey<T0, T1>(level, message),
             static key => LoggerMessage.Define<T0, T1>(key.Level, new EventId(0), key.Message));
 
-        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), exception);
+        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactException(exception));
     }
 
     private static void Log<T0, T1, T2>(ILogger logger, LogLevel level, Exception? exception, string message, T0 arg0, T1 arg1, T2 arg2)
@@ -237,7 +237,7 @@ public static class RegistryLog
             CreateKey<T0, T1, T2>(level, message),
             static key => LoggerMessage.Define<T0, T1, T2>(key.Level, new EventId(0), key.Message));
 
-        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactValue(arg2), exception);
+        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactValue(arg2), SensitiveDataRedactor.RedactException(exception));
     }
 
     private static void Log<T0, T1, T2, T3>(ILogger logger, LogLevel level, Exception? exception, string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
@@ -249,7 +249,7 @@ public static class RegistryLog
             CreateKey<T0, T1, T2, T3>(level, message),
             static key => LoggerMessage.Define<T0, T1, T2, T3>(key.Level, new EventId(0), key.Message));
 
-        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactValue(arg2), SensitiveDataRedactor.RedactValue(arg3), exception);
+        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactValue(arg2), SensitiveDataRedactor.RedactValue(arg3), SensitiveDataRedactor.RedactException(exception));
     }
 
     private static void Log<T0, T1, T2, T3, T4>(ILogger logger, LogLevel level, Exception? exception, string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
@@ -261,7 +261,7 @@ public static class RegistryLog
             CreateKey<T0, T1, T2, T3, T4>(level, message),
             static key => LoggerMessage.Define<T0, T1, T2, T3, T4>(key.Level, new EventId(0), key.Message));
 
-        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactValue(arg2), SensitiveDataRedactor.RedactValue(arg3), SensitiveDataRedactor.RedactValue(arg4), exception);
+        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactValue(arg2), SensitiveDataRedactor.RedactValue(arg3), SensitiveDataRedactor.RedactValue(arg4), SensitiveDataRedactor.RedactException(exception));
     }
 
     private static void Log<T0, T1, T2, T3, T4, T5>(ILogger logger, LogLevel level, Exception? exception, string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
@@ -273,7 +273,7 @@ public static class RegistryLog
             CreateKey<T0, T1, T2, T3, T4, T5>(level, message),
             static key => LoggerMessage.Define<T0, T1, T2, T3, T4, T5>(key.Level, new EventId(0), key.Message));
 
-        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactValue(arg2), SensitiveDataRedactor.RedactValue(arg3), SensitiveDataRedactor.RedactValue(arg4), SensitiveDataRedactor.RedactValue(arg5), exception);
+        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactValue(arg2), SensitiveDataRedactor.RedactValue(arg3), SensitiveDataRedactor.RedactValue(arg4), SensitiveDataRedactor.RedactValue(arg5), SensitiveDataRedactor.RedactException(exception));
     }
 
     private static LoggerMessageCacheKey CreateKey(LogLevel level, string message)

--- a/TerraformRegistry.API/Logging/RegistryLog.cs
+++ b/TerraformRegistry.API/Logging/RegistryLog.cs
@@ -213,7 +213,7 @@ public static class RegistryLog
             CreateKey<T0>(level, message),
             static key => LoggerMessage.Define<T0>(key.Level, new EventId(0), key.Message));
 
-        callback(logger, arg0, exception);
+        callback(logger, SensitiveDataRedactor.RedactValue(arg0), exception);
     }
 
     private static void Log<T0, T1>(ILogger logger, LogLevel level, Exception? exception, string message, T0 arg0, T1 arg1)
@@ -225,7 +225,7 @@ public static class RegistryLog
             CreateKey<T0, T1>(level, message),
             static key => LoggerMessage.Define<T0, T1>(key.Level, new EventId(0), key.Message));
 
-        callback(logger, arg0, arg1, exception);
+        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), exception);
     }
 
     private static void Log<T0, T1, T2>(ILogger logger, LogLevel level, Exception? exception, string message, T0 arg0, T1 arg1, T2 arg2)
@@ -237,7 +237,7 @@ public static class RegistryLog
             CreateKey<T0, T1, T2>(level, message),
             static key => LoggerMessage.Define<T0, T1, T2>(key.Level, new EventId(0), key.Message));
 
-        callback(logger, arg0, arg1, arg2, exception);
+        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactValue(arg2), exception);
     }
 
     private static void Log<T0, T1, T2, T3>(ILogger logger, LogLevel level, Exception? exception, string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
@@ -249,7 +249,7 @@ public static class RegistryLog
             CreateKey<T0, T1, T2, T3>(level, message),
             static key => LoggerMessage.Define<T0, T1, T2, T3>(key.Level, new EventId(0), key.Message));
 
-        callback(logger, arg0, arg1, arg2, arg3, exception);
+        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactValue(arg2), SensitiveDataRedactor.RedactValue(arg3), exception);
     }
 
     private static void Log<T0, T1, T2, T3, T4>(ILogger logger, LogLevel level, Exception? exception, string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
@@ -261,7 +261,7 @@ public static class RegistryLog
             CreateKey<T0, T1, T2, T3, T4>(level, message),
             static key => LoggerMessage.Define<T0, T1, T2, T3, T4>(key.Level, new EventId(0), key.Message));
 
-        callback(logger, arg0, arg1, arg2, arg3, arg4, exception);
+        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactValue(arg2), SensitiveDataRedactor.RedactValue(arg3), SensitiveDataRedactor.RedactValue(arg4), exception);
     }
 
     private static void Log<T0, T1, T2, T3, T4, T5>(ILogger logger, LogLevel level, Exception? exception, string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
@@ -273,7 +273,7 @@ public static class RegistryLog
             CreateKey<T0, T1, T2, T3, T4, T5>(level, message),
             static key => LoggerMessage.Define<T0, T1, T2, T3, T4, T5>(key.Level, new EventId(0), key.Message));
 
-        callback(logger, arg0, arg1, arg2, arg3, arg4, arg5, exception);
+        callback(logger, SensitiveDataRedactor.RedactValue(arg0), SensitiveDataRedactor.RedactValue(arg1), SensitiveDataRedactor.RedactValue(arg2), SensitiveDataRedactor.RedactValue(arg3), SensitiveDataRedactor.RedactValue(arg4), SensitiveDataRedactor.RedactValue(arg5), exception);
     }
 
     private static LoggerMessageCacheKey CreateKey(LogLevel level, string message)

--- a/TerraformRegistry.API/Logging/SensitiveDataRedactor.cs
+++ b/TerraformRegistry.API/Logging/SensitiveDataRedactor.cs
@@ -23,11 +23,16 @@ public static partial class SensitiveDataRedactor
 
     public static T RedactValue<T>(T value)
     {
+        return RedactObject(value) is T redacted ? redacted : value;
+    }
+
+    private static object? RedactObject(object? value)
+    {
         if (value is string text)
-            return (T)(object)Redact(text);
+            return Redact(text);
 
         if (value is Uri uri && !string.Equals(Redact(uri.OriginalString), uri.OriginalString, StringComparison.Ordinal))
-            return (T)(object)new Uri("https://redacted.invalid/[REDACTED-SIGNED-URL]");
+            return new Uri("https://redacted.invalid/[REDACTED-SIGNED-URL]");
 
         return value;
     }

--- a/TerraformRegistry.API/Logging/SensitiveDataRedactor.cs
+++ b/TerraformRegistry.API/Logging/SensitiveDataRedactor.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
 namespace TerraformRegistry.API.Logging;
@@ -9,7 +8,7 @@ public static partial class SensitiveDataRedactor
     [GeneratedRegex("\\b(?<key>authorization|token|pat|api[_-]?key|webhook[_-]?secret|client[_-]?secret|code|sig|se|sp|sv)\\s*(?<separator>[:=])\\s*(?<bearer>bearer\\s+)?(?<value>[^&\\s,;]+)", RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.NonBacktracking)]
     private static partial Regex SensitiveValue();
 
-    [GeneratedRegex("https?://[^\\s]*[?&](?:token|sig|api[_-]?key|code)=[^&\\s]+[^\\s]*", RegexOptions.IgnoreCase | RegexOptions.NonBacktracking)]
+    [GeneratedRegex("https?://[^\\s]*[?&](?:token|sig|api[_-]?key|code|x-amz-(?:credential|security-token|signature))=[^&\\s]+[^\\s]*", RegexOptions.IgnoreCase | RegexOptions.NonBacktracking)]
     private static partial Regex SignedUrl();
 
     public static string Redact(string value)
@@ -24,11 +23,13 @@ public static partial class SensitiveDataRedactor
 
     public static T RedactValue<T>(T value)
     {
-        if (value is not string text)
-            return value;
+        if (value is string text)
+            return (T)(object)Redact(text);
 
-        var redacted = Redact(text);
-        return Unsafe.As<string, T>(ref redacted);
+        if (value is Uri uri && !string.Equals(Redact(uri.OriginalString), uri.OriginalString, StringComparison.Ordinal))
+            return (T)(object)new Uri("https://redacted.invalid/[REDACTED-SIGNED-URL]");
+
+        return value;
     }
 
     public static Exception? RedactException(Exception? exception)

--- a/TerraformRegistry.API/Logging/SensitiveDataRedactor.cs
+++ b/TerraformRegistry.API/Logging/SensitiveDataRedactor.cs
@@ -1,0 +1,27 @@
+using System.Text.RegularExpressions;
+
+namespace TerraformRegistry.API.Logging;
+
+/// <summary>Removes credential-bearing query and key/value values before they are logged.</summary>
+public static partial class SensitiveDataRedactor
+{
+    [GeneratedRegex("(?i)(?:authorization|token|pat|api[_-]?key|webhook[_-]?secret|client[_-]?secret|code|sig|se|sp|sv)=([^&\\s]+)")]
+    private static partial Regex SensitiveQueryValue();
+
+    [GeneratedRegex("(?i)bearer\\s+[a-z0-9._~-]+")]
+    private static partial Regex BearerValue();
+
+    [GeneratedRegex("(?i)https?://[^\\s]*[?&](?:token|sig|api[_-]?key|code)=[^&\\s]+[^\\s]*")]
+    private static partial Regex SignedUrl();
+
+    public static string Redact(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        var withoutSignedUrls = SignedUrl().Replace(value, "[REDACTED-SIGNED-URL]");
+        var withoutQueryValues = SensitiveQueryValue().Replace(withoutSignedUrls, static match =>
+            $"{match.Value[..match.Value.IndexOf('=')]}=[REDACTED]");
+        return BearerValue().Replace(withoutQueryValues, "Bearer [REDACTED]");
+    }
+
+    public static T RedactValue<T>(T value) => value is string text ? (T)(object)Redact(text) : value;
+}

--- a/TerraformRegistry.API/Logging/SensitiveDataRedactor.cs
+++ b/TerraformRegistry.API/Logging/SensitiveDataRedactor.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
 namespace TerraformRegistry.API.Logging;
@@ -5,23 +6,42 @@ namespace TerraformRegistry.API.Logging;
 /// <summary>Removes credential-bearing query and key/value values before they are logged.</summary>
 public static partial class SensitiveDataRedactor
 {
-    [GeneratedRegex("(?i)(?:authorization|token|pat|api[_-]?key|webhook[_-]?secret|client[_-]?secret|code|sig|se|sp|sv)=([^&\\s]+)")]
-    private static partial Regex SensitiveQueryValue();
+    [GeneratedRegex("\\b(?<key>authorization|token|pat|api[_-]?key|webhook[_-]?secret|client[_-]?secret|code|sig|se|sp|sv)\\s*(?<separator>[:=])\\s*(?<bearer>bearer\\s+)?(?<value>[^&\\s,;]+)", RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.NonBacktracking)]
+    private static partial Regex SensitiveValue();
 
-    [GeneratedRegex("(?i)bearer\\s+[a-z0-9._~-]+")]
-    private static partial Regex BearerValue();
-
-    [GeneratedRegex("(?i)https?://[^\\s]*[?&](?:token|sig|api[_-]?key|code)=[^&\\s]+[^\\s]*")]
+    [GeneratedRegex("https?://[^\\s]*[?&](?:token|sig|api[_-]?key|code)=[^&\\s]+[^\\s]*", RegexOptions.IgnoreCase | RegexOptions.NonBacktracking)]
     private static partial Regex SignedUrl();
 
     public static string Redact(string value)
     {
         ArgumentNullException.ThrowIfNull(value);
         var withoutSignedUrls = SignedUrl().Replace(value, "[REDACTED-SIGNED-URL]");
-        var withoutQueryValues = SensitiveQueryValue().Replace(withoutSignedUrls, static match =>
-            $"{match.Value[..match.Value.IndexOf('=')]}=[REDACTED]");
-        return BearerValue().Replace(withoutQueryValues, "Bearer [REDACTED]");
+        return SensitiveValue().Replace(withoutSignedUrls, static match =>
+            $"{match.Groups["key"].Value}{match.Groups["separator"].Value}"
+            + (match.Groups["bearer"].Success ? "Bearer " : string.Empty)
+            + "[REDACTED]");
     }
 
-    public static T RedactValue<T>(T value) => value is string text ? (T)(object)Redact(text) : value;
+    public static T RedactValue<T>(T value)
+    {
+        if (value is not string text)
+            return value;
+
+        var redacted = Redact(text);
+        return Unsafe.As<string, T>(ref redacted);
+    }
+
+    public static Exception? RedactException(Exception? exception)
+    {
+        if (exception is null)
+            return null;
+
+        return new SanitizedLogException(
+            exception.GetType().Name,
+            Redact(exception.Message),
+            RedactException(exception.InnerException));
+    }
+
+    private sealed class SanitizedLogException(string exceptionType, string message, Exception? innerException)
+        : Exception($"{exceptionType}: {message}", innerException);
 }

--- a/TerraformRegistry.Tests/IntegrationTests/OperationalMetricsStartupTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/OperationalMetricsStartupTests.cs
@@ -15,13 +15,13 @@ public sealed class OperationalMetricsStartupTests
     [Fact]
     public void StartupRegistersSharedOperationalMetricsAndEmitsMirrorAdmissionMeasurements()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"tf-reg-metrics-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
+        var tempDir = CreateTestDirectory();
 
         try
         {
             using var listener = new OperationalMetricsTestListener();
-            using var factory = new WebApplicationFactory<Program>()
+            using var baseFactory = new WebApplicationFactory<Program>();
+            using var factory = baseFactory
                 .WithWebHostBuilder(builder =>
                 {
                     builder.UseEnvironment("Test");
@@ -31,10 +31,10 @@ public sealed class OperationalMetricsStartupTests
                         {
                             ["AuthorizationToken"] = "startup-test-auth-token",
                             ["DatabaseProvider"] = "sqlite",
-                            ["Sqlite:ConnectionString"] = $"Data Source={Path.Combine(tempDir, "metrics-test.db")}",
+                            ["Sqlite:ConnectionString"] = $"Data Source={ResolveTestPath(tempDir, "metrics-test.db")}",
                             ["StorageProvider"] = "local",
-                            ["ModuleStoragePath"] = Path.Combine(tempDir, "modules"),
-                            ["ProviderStoragePath"] = Path.Combine(tempDir, "providers"),
+                            ["ModuleStoragePath"] = ResolveTestPath(tempDir, "modules"),
+                            ["ProviderStoragePath"] = ResolveTestPath(tempDir, "providers"),
                             ["ModuleExtraction:Enabled"] = "false",
                             ["Oidc:JwtSecretKey"] = "startup-test-jwt-secret-key-32-chars-minimum"
                         });
@@ -72,5 +72,32 @@ public sealed class OperationalMetricsStartupTests
         {
             Directory.Delete(tempDir, recursive: true);
         }
+    }
+
+    private static string CreateTestDirectory()
+    {
+        var tempDir = Path.GetFullPath(Path.Join(Path.GetTempPath(), $"tf-reg-metrics-{Guid.NewGuid():N}"));
+        Directory.CreateDirectory(tempDir);
+        return tempDir;
+    }
+
+    private static string ResolveTestPath(string root, string relativePath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(root);
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
+
+        if (Path.IsPathFullyQualified(relativePath))
+            throw new ArgumentException("Test path segment must be relative.", nameof(relativePath));
+
+        var canonicalRoot = Path.GetFullPath(root);
+        var resolvedPath = Path.GetFullPath(Path.Join(canonicalRoot, relativePath));
+        var rootPrefix = canonicalRoot.EndsWith(Path.DirectorySeparatorChar)
+            ? canonicalRoot
+            : canonicalRoot + Path.DirectorySeparatorChar;
+
+        if (!resolvedPath.StartsWith(rootPrefix, StringComparison.Ordinal))
+            throw new ArgumentException("Test path must remain under its temporary root.", nameof(relativePath));
+
+        return resolvedPath;
     }
 }

--- a/TerraformRegistry.Tests/IntegrationTests/OperationalMetricsStartupTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/OperationalMetricsStartupTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using TerraformRegistry.Models;
+using TerraformRegistry.Services;
+using TerraformRegistry.Services.Mirror;
+using TerraformRegistry.Tests.UnitTests;
+
+namespace TerraformRegistry.Tests.IntegrationTests;
+
+public sealed class OperationalMetricsStartupTests
+{
+    [Fact]
+    public void StartupRegistersSharedOperationalMetricsAndEmitsMirrorAdmissionMeasurements()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"tf-reg-metrics-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            using var listener = new OperationalMetricsTestListener();
+            using var factory = new WebApplicationFactory<Program>()
+                .WithWebHostBuilder(builder =>
+                {
+                    builder.UseEnvironment("Test");
+                    builder.ConfigureAppConfiguration((_, config) =>
+                    {
+                        config.AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["AuthorizationToken"] = "startup-test-auth-token",
+                            ["DatabaseProvider"] = "sqlite",
+                            ["Sqlite:ConnectionString"] = $"Data Source={Path.Combine(tempDir, "metrics-test.db")}",
+                            ["StorageProvider"] = "local",
+                            ["ModuleStoragePath"] = Path.Combine(tempDir, "modules"),
+                            ["ProviderStoragePath"] = Path.Combine(tempDir, "providers"),
+                            ["ModuleExtraction:Enabled"] = "false",
+                            ["Oidc:JwtSecretKey"] = "startup-test-jwt-secret-key-32-chars-minimum"
+                        });
+                    });
+                    builder.ConfigureServices(services =>
+                    {
+                        services.RemoveAll<OidcOptions>();
+                        services.AddSingleton(new OidcOptions
+                        {
+                            JwtSecretKey = "startup-test-jwt-secret-key-32-chars-minimum",
+                            JwtExpiryHours = 24
+                        });
+                    });
+                });
+
+            using var client = factory.CreateClient();
+            using var scope = factory.Services.CreateScope();
+            var services = scope.ServiceProvider;
+            var metrics = services.GetRequiredService<OperationalMetrics>();
+            var admission = services.GetRequiredService<MirrorDownloadAdmission>();
+
+            Assert.Same(metrics, services.GetRequiredService<OperationalMetrics>());
+
+            using var lease = admission.TryAcquire(new MirrorLimitRuntimeOptions
+            {
+                MaxConcurrentDownloads = 1,
+                MaxConcurrentDownloadsPerCoordinate = 1
+            }, "provider:acme/network");
+
+            Assert.NotNull(lease);
+            Assert.Contains(listener.Measurements, measurement =>
+                measurement.Name == "terraform_registry.mirror.active_downloads");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}

--- a/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceUploadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/AzureBlob/AzureBlobModuleServiceUploadTests.cs
@@ -268,7 +268,8 @@ public class AzureBlobModuleServiceUploadTests
                 LogLevel.Error,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error publishing module")),
-                It.IsAny<RequestFailedException>(),
+                It.Is<Exception?>(exception => exception != null &&
+                    exception.Message.Contains("RequestFailedException: Upload failed", StringComparison.Ordinal)),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }

--- a/TerraformRegistry.Tests/UnitTests/DurableOutboxProcessorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/DurableOutboxProcessorTests.cs
@@ -28,6 +28,8 @@ public sealed class DurableOutboxProcessorTests
     [Fact]
     public async Task ProcessNextAsyncSchedulesRetryWhenDeliveryFails()
     {
+        using var listener = new OperationalMetricsTestListener();
+        using var metrics = new OperationalMetrics();
         var @event = CreateEvent();
         var repository = new Mock<IOutboxEventRepository>();
         repository.Setup(x => x.TryClaimNextAsync("worker-1", It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).ReturnsAsync(@event);
@@ -35,15 +37,18 @@ public sealed class DurableOutboxProcessorTests
         var handler = new Mock<IOutboxDeliveryHandler>();
         handler.Setup(x => x.CanHandle("test")).Returns(true);
         handler.Setup(x => x.HandleAsync(@event, It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException("failed"));
-        var processor = CreateProcessor(repository.Object, handler.Object);
+        var processor = CreateProcessor(repository.Object, handler.Object, metrics);
 
         Assert.False(await processor.ProcessNextAsync("worker-1", CancellationToken.None));
         repository.Verify(x => x.TryFailAsync(@event.Id, "worker-1", "failed", 5, It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains(listener.Measurements, measurement =>
+            measurement.Name == "terraform_registry.outbox.failures" && measurement.Outcome == "delivery_failed");
     }
 
-    private static DurableOutboxProcessor CreateProcessor(IOutboxEventRepository repository, IOutboxDeliveryHandler handler) =>
+    private static DurableOutboxProcessor CreateProcessor(IOutboxEventRepository repository, IOutboxDeliveryHandler handler,
+        OperationalMetrics? metrics = null) =>
         new(repository, [handler], Options.Create(new DurableOutboxOptions { LeaseSeconds = 30, RetryLimit = 5 }),
-            NullLogger<DurableOutboxProcessor>.Instance);
+            NullLogger<DurableOutboxProcessor>.Instance, metrics);
 
     private static OutboxEvent CreateEvent() => new()
     {

--- a/TerraformRegistry.Tests/UnitTests/MirrorDownloadAdmissionTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorDownloadAdmissionTests.cs
@@ -1,4 +1,5 @@
 using TerraformRegistry.Models;
+using TerraformRegistry.Services;
 using TerraformRegistry.Services.Mirror;
 
 namespace TerraformRegistry.Tests.UnitTests;
@@ -8,7 +9,9 @@ public sealed class MirrorDownloadAdmissionTests
     [Fact]
     public void AdmissionEnforcesGlobalAndPerCoordinateLimitsAndReleasesCapacity()
     {
-        var admission = new MirrorDownloadAdmission();
+        using var listener = new OperationalMetricsTestListener();
+        using var metrics = new OperationalMetrics();
+        var admission = new MirrorDownloadAdmission(metrics);
         var limits = new MirrorLimitRuntimeOptions
         {
             MaxConcurrentDownloads = 2,
@@ -27,6 +30,10 @@ public sealed class MirrorDownloadAdmissionTests
 
         using var replacement = admission.TryAcquire(limits, "provider:random");
         Assert.NotNull(replacement);
+        Assert.Contains(listener.Measurements, measurement =>
+            measurement.Name == "terraform_registry.mirror.admission_rejections");
+        Assert.Contains(listener.Measurements, measurement =>
+            measurement.Name == "terraform_registry.mirror.active_downloads");
     }
 
     [Fact]

--- a/TerraformRegistry.Tests/UnitTests/MirrorHttpClientTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorHttpClientTests.cs
@@ -1,8 +1,10 @@
 using System.Net;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.API.Logging;
 using TerraformRegistry.Models;
 using TerraformRegistry.Services;
 using TerraformRegistry.Services.Mirror;
@@ -112,6 +114,29 @@ public class MirrorHttpClientTests
     }
 
     [Fact]
+    public async Task FetchModuleArchiveAsyncRedactsSignedCurrentUriWhenLoggingExceededSize()
+    {
+        var content = new ByteArrayContent(Encoding.UTF8.GetBytes("too-large"));
+        content.Headers.ContentLength = null;
+        var handler = new SequenceHandler(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        var logger = new CapturingLogger();
+        var client = CreateClient(handler, logger);
+        const string signedUrl = "https://github.com/acme/module/archive/main.zip?X-Amz-Credential=access-key&X-Amz-Security-Token=session-token&X-Amz-Signature=secret-signature";
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.FetchModuleArchiveAsync(
+            signedUrl,
+            maxBytes: 3,
+            maxRedirects: 3,
+            CancellationToken.None));
+
+        Assert.DoesNotContain("access-key", logger.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("session-token", logger.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-signature", logger.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("github.com/acme/module", logger.Message, StringComparison.Ordinal);
+        Assert.Contains("[REDACTED-SIGNED-URL]", logger.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task FetchModuleArchiveAsyncAttachesPinnedAddressesToInitialRequest()
     {
         var handler = new SequenceHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
@@ -140,7 +165,7 @@ public class MirrorHttpClientTests
             await helper.OpenConnectionAsync(request, 443, CancellationToken.None));
     }
 
-    private static MirrorHttpClient CreateClient(SequenceHandler handler)
+    private static MirrorHttpClient CreateClient(SequenceHandler handler, ILogger<MirrorHttpClient>? logger = null)
     {
         var httpClient = new HttpClient(handler)
         {
@@ -163,7 +188,7 @@ public class MirrorHttpClientTests
         return new MirrorHttpClient(
             new TestHttpClientFactory(httpClient),
             policy,
-            NullLogger<MirrorHttpClient>.Instance);
+            logger ?? NullLogger<MirrorHttpClient>.Instance);
     }
 
     private static void AssertPinnedAddress(HttpRequestMessage request, IPAddress expectedAddress)
@@ -208,5 +233,15 @@ public class MirrorHttpClientTests
             int port,
             CancellationToken cancellationToken) =>
             new(Stream.Null);
+    }
+
+    private sealed class CapturingLogger : ILogger<MirrorHttpClient>
+    {
+        public string Message { get; private set; } = string.Empty;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) => Message = formatter(state, exception);
     }
 }

--- a/TerraformRegistry.Tests/UnitTests/MirrorHttpClientTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorHttpClientTests.cs
@@ -100,9 +100,10 @@ public class MirrorHttpClientTests
     [Fact]
     public async Task FetchModuleArchiveAsyncEnforcesMaxBytesWhileReading()
     {
+        using var content = new ByteArrayContent(Encoding.UTF8.GetBytes("too-large"));
         var handler = new SequenceHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new ByteArrayContent(Encoding.UTF8.GetBytes("too-large"))
+            Content = content
         });
         var client = CreateClient(handler);
 
@@ -116,7 +117,7 @@ public class MirrorHttpClientTests
     [Fact]
     public async Task FetchModuleArchiveAsyncRedactsSignedCurrentUriWhenLoggingExceededSize()
     {
-        var content = new ByteArrayContent(Encoding.UTF8.GetBytes("too-large"));
+        using var content = new ByteArrayContent(Encoding.UTF8.GetBytes("too-large"));
         content.Headers.ContentLength = null;
         var handler = new SequenceHandler(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
         var logger = new CapturingLogger();

--- a/TerraformRegistry.Tests/UnitTests/ModuleExtractionQueueRuntimeTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleExtractionQueueRuntimeTests.cs
@@ -24,6 +24,39 @@ public class ModuleExtractionQueueRuntimeTests
     }
 
     [Fact]
+    public async Task ProcessNextAsyncRecordsClaimAttemptAndFailureMetricsForAClaimedJob()
+    {
+        using var listener = new OperationalMetricsTestListener();
+        using var metrics = new OperationalMetrics();
+        var config = new Mock<IModuleExtractionConfigService>();
+        var job = new ModuleExtractionJob
+        {
+            Id = Guid.NewGuid(),
+            PublicationAttemptId = Guid.NewGuid(),
+            Namespace = "acme",
+            Name = "network",
+            Provider = "aws",
+            Version = "1.0.0",
+            State = ModuleExtractionJobState.Processing,
+            CreatedAt = DateTime.UtcNow.AddMinutes(-1),
+            UpdatedAt = DateTime.UtcNow
+        };
+        var database = new Mock<IDatabaseService>();
+        database.Setup(x => x.TryClaimNextExtractionJobAsync("worker-1", It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(job);
+        database.Setup(x => x.TryFailExtractionJobAsync(job.Id, "worker-1", It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var service = CreateService(config.Object, database.Object, metrics: metrics);
+
+        Assert.True(await service.ProcessNextAsync("worker-1", CancellationToken.None));
+        Assert.Contains(listener.Measurements, measurement => measurement.Name == "terraform_registry.extraction.claim_latency_ms");
+        Assert.Contains(listener.Measurements, measurement => measurement.Name == "terraform_registry.extraction.attempts");
+        Assert.Contains(listener.Measurements, measurement =>
+            measurement.Name == "terraform_registry.extraction.failures" && measurement.Outcome == "processing_failed");
+    }
+
+    [Fact]
     public async Task QueueAsyncMarksModulePendingWhenExtractionEnabled()
     {
         var config = new Mock<IModuleExtractionConfigService>();
@@ -188,7 +221,8 @@ public class ModuleExtractionQueueRuntimeTests
     private static ModuleExtractionService CreateService(
         IModuleExtractionConfigService config,
         IDatabaseService? database = null,
-        ModuleExtractionOptions? options = null)
+        ModuleExtractionOptions? options = null,
+        OperationalMetrics? metrics = null)
     {
         return new ModuleExtractionService(
             Mock.Of<IModuleService>(),
@@ -198,6 +232,7 @@ public class ModuleExtractionQueueRuntimeTests
             Mock.Of<IModuleLlmContextGenerator>(),
             config,
             NullLogger<ModuleExtractionService>.Instance,
-            options);
+            options,
+            metrics);
     }
 }

--- a/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModulePublishCoordinatorTests.cs
@@ -49,6 +49,8 @@ public class ModulePublishCoordinatorTests
     [Fact]
     public async Task PublishAsyncUploadsModuleAndQueuesExtraction()
     {
+        using var listener = new OperationalMetricsTestListener();
+        using var metrics = new OperationalMetrics();
         var moduleService = new Mock<IModuleService>();
         moduleService
             .Setup(x => x.UploadModuleAsync(
@@ -92,7 +94,8 @@ public class ModulePublishCoordinatorTests
             extraction.Object,
             webhookDispatcher,
             audit.Object,
-            NullLogger<ModulePublishCoordinator>.Instance);
+            NullLogger<ModulePublishCoordinator>.Instance,
+            metrics: metrics);
 
         await using var content = new MemoryStream([1, 2, 3]);
 
@@ -113,6 +116,8 @@ public class ModulePublishCoordinatorTests
         }, CancellationToken.None);
 
         Assert.True(published);
+        Assert.Contains(listener.Measurements, measurement =>
+            measurement.Name == "terraform_registry.publication.attempts");
         extraction.Verify(x => x.QueueAsync(
             new ModuleExtractionRequest("acme", "network", "aws", "1.2.3"),
             It.IsAny<CancellationToken>()), Times.Once);

--- a/TerraformRegistry.Tests/UnitTests/OperationalMetricsTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/OperationalMetricsTests.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.Metrics;
+using TerraformRegistry.Services;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class OperationalMetricsTests
+{
+    [Fact]
+    public void OutboxFailureMetricContainsOnlyTheFailureCategory()
+    {
+        using var listener = new MeterListener();
+        var measurements = new List<(string Name, string? Outcome, string? Secret)>();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == OperationalMetrics.MeterName)
+                meterListener.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+        {
+            var tagValues = tags.ToArray();
+            measurements.Add((instrument.Name, tagValues.FirstOrDefault(tag => tag.Key == "outcome").Value?.ToString(),
+                tagValues.FirstOrDefault(tag => tag.Key == "secret").Value?.ToString()));
+        });
+        listener.Start();
+
+        using var metrics = new OperationalMetrics();
+        metrics.RecordOutboxFailure("delivery_failed");
+
+        Assert.Contains(measurements, measurement =>
+            measurement.Name == "terraform_registry.outbox.failures" &&
+            measurement.Outcome == "delivery_failed" && measurement.Secret is null);
+    }
+}

--- a/TerraformRegistry.Tests/UnitTests/OperationalMetricsTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/OperationalMetricsTests.cs
@@ -31,3 +31,25 @@ public sealed class OperationalMetricsTests
             measurement.Outcome == "delivery_failed" && measurement.Secret is null);
     }
 }
+
+internal sealed class OperationalMetricsTestListener : IDisposable
+{
+    private readonly MeterListener _listener = new();
+
+    public List<(string Name, string? Outcome)> Measurements { get; } = [];
+
+    public OperationalMetricsTestListener()
+    {
+        _listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == OperationalMetrics.MeterName)
+                meterListener.EnableMeasurementEvents(instrument);
+        };
+        _listener.SetMeasurementEventCallback<long>((instrument, _, tags, _) =>
+            Measurements.Add((instrument.Name,
+                tags.ToArray().FirstOrDefault(tag => tag.Key == "outcome").Value?.ToString())));
+        _listener.Start();
+    }
+
+    public void Dispose() => _listener.Dispose();
+}

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceDownloadTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ModuleServiceDownloadTests.cs
@@ -239,7 +239,8 @@ public class S3ModuleServiceDownloadTests
                 LogLevel.Error,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((value, _) => value.ToString()!.Contains("pre-signed URL")),
-                It.IsAny<InvalidOperationException>(),
+                It.Is<Exception?>(exception => exception != null &&
+                    exception.Message.Contains("InvalidOperationException: signing failed", StringComparison.Ordinal)),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }
@@ -281,7 +282,8 @@ public class S3ModuleServiceDownloadTests
                 LogLevel.Error,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((value, _) => value.ToString()!.Contains("Error checking S3 object")),
-                It.IsAny<AmazonS3Exception>(),
+                It.Is<Exception?>(exception => exception != null &&
+                    exception.Message.Contains("AmazonS3Exception: boom", StringComparison.Ordinal)),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }

--- a/TerraformRegistry.Tests/UnitTests/SensitiveDataRedactorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/SensitiveDataRedactorTests.cs
@@ -1,0 +1,45 @@
+using TerraformRegistry.API.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace TerraformRegistry.Tests.UnitTests;
+
+public sealed class SensitiveDataRedactorTests
+{
+    [Theory]
+    [InlineData("pat=ghp_abcdefghijklmnopqrstuvwxyz1234567890")]
+    [InlineData("webhook_secret=webhook-secret-value")]
+    [InlineData("api_key=trf_api_key_value")]
+    [InlineData("code=oauth-authorization-code")]
+    [InlineData("https://storage.example/module?sig=sas-signature&se=2027-01-01")]
+    public void RedactRemovesCredentialsAndSignedUrlValues(string value)
+    {
+        var redacted = SensitiveDataRedactor.Redact(value);
+
+        Assert.DoesNotContain("abcdefghijklmnopqrstuvwxyz1234567890", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("webhook-secret-value", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("trf_api_key_value", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("oauth-authorization-code", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("sas-signature", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("storage.example", redacted, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RegistryLogRedactsStructuredStringArguments()
+    {
+        var logger = new CapturingLogger();
+
+        RegistryLog.Warning(logger, "Callback failed for {Url}", "https://storage.example/module?sig=sas-signature");
+
+        Assert.DoesNotContain("sas-signature", logger.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("storage.example", logger.Message, StringComparison.Ordinal);
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public string Message { get; private set; } = string.Empty;
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) => Message = formatter(state, exception);
+    }
+}

--- a/TerraformRegistry.Tests/UnitTests/SensitiveDataRedactorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/SensitiveDataRedactorTests.cs
@@ -11,6 +11,10 @@ public sealed class SensitiveDataRedactorTests
     [InlineData("api_key=trf_api_key_value")]
     [InlineData("code=oauth-authorization-code")]
     [InlineData("https://storage.example/module?sig=sas-signature&se=2027-01-01")]
+    [InlineData("Authorization: Bearer opaque+/=._~-token")]
+    [InlineData("authorization=Bearer opaque+/=._~-token")]
+    [InlineData("X-Api-Key: api-key-with+/=characters")]
+    [InlineData("webhook-secret=webhook-secret-value")]
     public void RedactRemovesCredentialsAndSignedUrlValues(string value)
     {
         var redacted = SensitiveDataRedactor.Redact(value);
@@ -34,12 +38,34 @@ public sealed class SensitiveDataRedactorTests
         Assert.DoesNotContain("storage.example", logger.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void RegistryLogRedactsExceptionAndInnerExceptionMessages()
+    {
+        var logger = new CapturingLogger();
+        var inner = new InvalidOperationException("download failed at https://storage.example/module?sig=sas-signature&se=2027-01-01");
+        var exception = new HttpRequestException("Authorization: Bearer opaque+/=._~-token", inner);
+
+        RegistryLog.Error(logger, exception, "Module download failed");
+
+        Assert.NotNull(logger.Exception);
+        Assert.DoesNotContain("sas-signature", logger.Exception!.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("storage.example", logger.Exception.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("opaque+/=._~-token", logger.Exception.ToString(), StringComparison.Ordinal);
+        Assert.NotNull(logger.Exception.InnerException);
+        Assert.DoesNotContain("sas-signature", logger.Exception.InnerException!.Message, StringComparison.Ordinal);
+    }
+
     private sealed class CapturingLogger : ILogger
     {
         public string Message { get; private set; } = string.Empty;
+        public Exception? Exception { get; private set; }
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
         public bool IsEnabled(LogLevel logLevel) => true;
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
-            Func<TState, Exception?, string> formatter) => Message = formatter(state, exception);
+            Func<TState, Exception?, string> formatter)
+        {
+            Message = formatter(state, exception);
+            Exception = exception;
+        }
     }
 }

--- a/TerraformRegistry.Tests/UnitTests/SensitiveDataRedactorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/SensitiveDataRedactorTests.cs
@@ -52,6 +52,19 @@ public sealed class SensitiveDataRedactorTests
     }
 
     [Fact]
+    public void RegistryLogRedactsTypedAzureSasUriArguments()
+    {
+        var logger = new CapturingLogger();
+        var signedUri = new Uri("https://account.blob.core.windows.net/modules/example.zip?sv=2025-11-05&se=2026-07-15T12%3A00%3A00Z&sp=r&sig=azure-sas-signature");
+
+        RegistryLog.Warning(logger, "Module download for {Uri} failed", signedUri);
+
+        Assert.DoesNotContain("account.blob.core.windows.net", logger.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("azure-sas-signature", logger.Message, StringComparison.Ordinal);
+        Assert.Contains("[REDACTED-SIGNED-URL]", logger.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RegistryLogRedactsExceptionAndInnerExceptionMessages()
     {
         var logger = new CapturingLogger();

--- a/TerraformRegistry.Tests/UnitTests/SensitiveDataRedactorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/SensitiveDataRedactorTests.cs
@@ -39,6 +39,19 @@ public sealed class SensitiveDataRedactorTests
     }
 
     [Fact]
+    public void RegistryLogRedactsTypedS3SignedUriArguments()
+    {
+        var logger = new CapturingLogger();
+        var signedUri = new Uri("https://bucket.s3.example/module.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=access-key&X-Amz-Date=20260714T120000Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=secret-signature");
+
+        RegistryLog.Warning(logger, "Mirror fetch for {Uri} exceeded maximum byte count {MaxBytes}", signedUri, 1024);
+
+        Assert.DoesNotContain("bucket.s3.example", logger.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-signature", logger.Message, StringComparison.Ordinal);
+        Assert.Contains("[REDACTED-SIGNED-URL]", logger.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RegistryLogRedactsExceptionAndInnerExceptionMessages()
     {
         var logger = new CapturingLogger();
@@ -53,6 +66,21 @@ public sealed class SensitiveDataRedactorTests
         Assert.DoesNotContain("opaque+/=._~-token", logger.Exception.ToString(), StringComparison.Ordinal);
         Assert.NotNull(logger.Exception.InnerException);
         Assert.DoesNotContain("sas-signature", logger.Exception.InnerException!.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RegistryLogRedactsS3SignedUrisInExceptionChains()
+    {
+        var logger = new CapturingLogger();
+        const string signedUrl = "https://bucket.s3.example/module.zip?X-Amz-Credential=access-key&X-Amz-Security-Token=session-token&X-Amz-Signature=secret-signature";
+        var exception = new InvalidOperationException("mirror request failed", new HttpRequestException($"download failed at {signedUrl}"));
+
+        RegistryLog.Error(logger, exception, "Module download failed");
+
+        Assert.NotNull(logger.Exception);
+        Assert.DoesNotContain("bucket.s3.example", logger.Exception!.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("session-token", logger.Exception.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-signature", logger.Exception.ToString(), StringComparison.Ordinal);
     }
 
     private sealed class CapturingLogger : ILogger

--- a/TerraformRegistry/Services/DurableOutboxProcessor.cs
+++ b/TerraformRegistry/Services/DurableOutboxProcessor.cs
@@ -9,7 +9,8 @@ public sealed class DurableOutboxProcessor(
     IOutboxEventRepository repository,
     IEnumerable<IOutboxDeliveryHandler> handlers,
     IOptions<DurableOutboxOptions> options,
-    ILogger<DurableOutboxProcessor> logger)
+    ILogger<DurableOutboxProcessor> logger,
+    OperationalMetrics? metrics = null)
 {
     private readonly DurableOutboxOptions options = options.Value;
 
@@ -20,6 +21,7 @@ public sealed class DurableOutboxProcessor(
         {
             @event = await repository.TryClaimNextAsync(ownerId, TimeSpan.FromSeconds(options.LeaseSeconds), cancellationToken);
             if (@event is null) return false;
+            metrics?.RecordOutboxClaim(@event.CreatedAt);
 
             var handler = handlers.FirstOrDefault(candidate => candidate.CanHandle(@event.Kind));
             if (handler is null) throw new InvalidOperationException($"No durable outbox handler is registered for '{@event.Kind}'.");
@@ -38,12 +40,15 @@ public sealed class DurableOutboxProcessor(
         catch (Exception ex)
         {
             RegistryLog.Error(logger, ex, "Durable outbox worker {OwnerId} failed to deliver an event.", ownerId);
+            metrics?.RecordOutboxFailure("delivery_failed");
             if (@event is not null)
             {
                 try
                 {
                     if (!await repository.TryFailAsync(@event.Id, ownerId, ex.Message, options.RetryLimit, cancellationToken))
                         RegistryLog.Warning(logger, "Durable outbox worker {OwnerId} lost the lease while recording a delivery failure.", ownerId);
+                    else
+                        metrics?.RecordOutboxRetry("scheduled");
                 }
                 catch (Exception retryEx) when (!cancellationToken.IsCancellationRequested)
                 {

--- a/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
@@ -10,7 +10,8 @@ public sealed class MirrorCacheBudgetService(
     IProviderArtifactStorage providerStorage,
     IModuleService moduleService,
     MirrorCacheUsage cacheUsage,
-    IMirrorLeaseRepository? leaseRepository = null)
+    IMirrorLeaseRepository? leaseRepository = null,
+    OperationalMetrics? metrics = null)
 {
     private const int PageSize = 1000;
 
@@ -126,6 +127,7 @@ public sealed class MirrorCacheBudgetService(
                 LastError = "Evicted to enforce the mirror cache budget.",
                 LastSyncAt = DateTime.UtcNow
             });
+            metrics?.RecordMirrorEviction("provider");
             return true;
         }
 
@@ -148,6 +150,7 @@ public sealed class MirrorCacheBudgetService(
             LastError = "Evicted to enforce the mirror cache budget.",
             LastSyncAt = DateTime.UtcNow
         });
+        metrics?.RecordMirrorEviction("module");
         return true;
     }
 

--- a/TerraformRegistry/Services/Mirror/MirrorDownloadAdmission.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorDownloadAdmission.cs
@@ -8,9 +8,12 @@ namespace TerraformRegistry.Services.Mirror;
 /// </summary>
 public sealed class MirrorDownloadAdmission
 {
+    private readonly OperationalMetrics? _metrics;
     private readonly object _gate = new();
     private readonly Dictionary<string, int> _activeByCoordinate = new(StringComparer.Ordinal);
     private int _activeDownloads;
+
+    public MirrorDownloadAdmission(OperationalMetrics? metrics = null) => _metrics = metrics;
 
     public MirrorDownloadAdmissionLease? TryAcquire(MirrorLimitRuntimeOptions limits, string coordinate)
     {
@@ -22,10 +25,12 @@ public sealed class MirrorDownloadAdmission
             if (_activeDownloads >= limits.MaxConcurrentDownloads ||
                 _activeByCoordinate.GetValueOrDefault(coordinate) >= limits.MaxConcurrentDownloadsPerCoordinate)
             {
+                _metrics?.RecordMirrorAdmission(false);
                 return null;
             }
 
             _activeDownloads++;
+            _metrics?.RecordMirrorAdmission(true);
             _activeByCoordinate[coordinate] = _activeByCoordinate.GetValueOrDefault(coordinate) + 1;
             return new MirrorDownloadAdmissionLease(this, coordinate);
         }
@@ -36,6 +41,7 @@ public sealed class MirrorDownloadAdmission
         lock (_gate)
         {
             _activeDownloads--;
+            _metrics?.RecordMirrorRelease();
             var coordinateActive = _activeByCoordinate[coordinate] - 1;
             if (coordinateActive == 0)
             {

--- a/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionService.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionService.cs
@@ -14,6 +14,7 @@ public sealed class ModuleExtractionService : IModuleExtractionService
     private readonly IModuleService _moduleService;
     private readonly IArchiveWorkspaceFactory _workspaceFactory;
     private readonly ModuleExtractionOptions _options;
+    private readonly OperationalMetrics? _metrics;
 
     public ModuleExtractionService(
         IModuleService moduleService,
@@ -23,7 +24,8 @@ public sealed class ModuleExtractionService : IModuleExtractionService
         IModuleLlmContextGenerator llmContextGenerator,
         IModuleExtractionConfigService configService,
         ILogger<ModuleExtractionService> logger,
-        ModuleExtractionOptions? options = null)
+        ModuleExtractionOptions? options = null,
+        OperationalMetrics? metrics = null)
     {
         _moduleService = moduleService;
         _databaseService = databaseService;
@@ -33,6 +35,7 @@ public sealed class ModuleExtractionService : IModuleExtractionService
         _configService = configService;
         _logger = logger;
         _options = options ?? new ModuleExtractionOptions();
+        _metrics = metrics;
     }
 
     public async Task<bool> QueueAsync(ModuleExtractionRequest request, CancellationToken cancellationToken)
@@ -115,6 +118,9 @@ public sealed class ModuleExtractionService : IModuleExtractionService
         if (job is null)
             return false;
 
+        _metrics?.RecordExtractionClaim(job.CreatedAt);
+        _metrics?.RecordExtractionAttempt();
+
         var request = new ModuleExtractionRequest(job.Namespace, job.Name, job.Provider, job.Version);
         using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var heartbeat = MaintainLeaseAsync(job.Id, ownerId, leaseDuration, linkedCancellation);
@@ -130,6 +136,7 @@ public sealed class ModuleExtractionService : IModuleExtractionService
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            _metrics?.RecordExtractionFailure("processing_failed");
             await _databaseService.TryFailExtractionJobAsync(job.Id, ownerId, Truncate(ex.Message, 2048),
                 _options.JobRetryLimit, cancellationToken);
             RegistryLog.Error(_logger, ex, "Module extraction job {JobId} failed", job.Id);

--- a/TerraformRegistry/Services/OperationalMetrics.cs
+++ b/TerraformRegistry/Services/OperationalMetrics.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.Metrics;
+
+namespace TerraformRegistry.Services;
+
+/// <summary>Low-cardinality operational measurements for durable registry workflows.</summary>
+public sealed class OperationalMetrics : IDisposable
+{
+    public const string MeterName = "TerraformRegistry.Operations";
+
+    private readonly Meter _meter = new(MeterName);
+    private readonly Counter<long> _outboxFailures;
+    private readonly Counter<long> _outboxRetries;
+    private readonly Histogram<long> _outboxAgeMilliseconds;
+    private readonly Histogram<long> _extractionClaimMilliseconds;
+    private readonly Counter<long> _extractionAttempts;
+    private readonly Counter<long> _extractionFailures;
+    private readonly Counter<long> _publicationAttempts;
+    private readonly Counter<long> _publicationConflicts;
+    private readonly Counter<long> _authenticationDecisions;
+    private readonly UpDownCounter<long> _mirrorActiveDownloads;
+    private readonly Counter<long> _mirrorAdmissionRejections;
+    private readonly Counter<long> _mirrorEvictions;
+
+    public OperationalMetrics()
+    {
+        _outboxFailures = _meter.CreateCounter<long>("terraform_registry.outbox.failures");
+        _outboxRetries = _meter.CreateCounter<long>("terraform_registry.outbox.retries");
+        _outboxAgeMilliseconds = _meter.CreateHistogram<long>("terraform_registry.outbox.age_ms");
+        _extractionClaimMilliseconds = _meter.CreateHistogram<long>("terraform_registry.extraction.claim_latency_ms");
+        _extractionAttempts = _meter.CreateCounter<long>("terraform_registry.extraction.attempts");
+        _extractionFailures = _meter.CreateCounter<long>("terraform_registry.extraction.failures");
+        _publicationAttempts = _meter.CreateCounter<long>("terraform_registry.publication.attempts");
+        _publicationConflicts = _meter.CreateCounter<long>("terraform_registry.publication.conflicts");
+        _authenticationDecisions = _meter.CreateCounter<long>("terraform_registry.authentication.decisions");
+        _mirrorActiveDownloads = _meter.CreateUpDownCounter<long>("terraform_registry.mirror.active_downloads");
+        _mirrorAdmissionRejections = _meter.CreateCounter<long>("terraform_registry.mirror.admission_rejections");
+        _mirrorEvictions = _meter.CreateCounter<long>("terraform_registry.mirror.evictions");
+    }
+
+    public void RecordOutboxClaim(DateTime createdAt) =>
+        _outboxAgeMilliseconds.Record(Math.Max(0, (long)(DateTime.UtcNow - createdAt).TotalMilliseconds));
+    public void RecordOutboxFailure(string outcome) => _outboxFailures.Add(1, Outcome(outcome));
+    public void RecordOutboxRetry(string outcome) => _outboxRetries.Add(1, Outcome(outcome));
+    public void RecordExtractionClaim(DateTime createdAt) =>
+        _extractionClaimMilliseconds.Record(Math.Max(0, (long)(DateTime.UtcNow - createdAt).TotalMilliseconds));
+    public void RecordExtractionAttempt() => _extractionAttempts.Add(1);
+    public void RecordExtractionFailure(string outcome) => _extractionFailures.Add(1, Outcome(outcome));
+    public void RecordPublicationAttempt() => _publicationAttempts.Add(1);
+    public void RecordPublicationConflict() => _publicationConflicts.Add(1);
+    public void RecordAuthenticationDecision(string decision) => _authenticationDecisions.Add(1, Outcome(decision));
+    public void RecordMirrorAdmission(bool admitted)
+    {
+        if (admitted) _mirrorActiveDownloads.Add(1);
+        else _mirrorAdmissionRejections.Add(1);
+    }
+    public void RecordMirrorRelease() => _mirrorActiveDownloads.Add(-1);
+    public void RecordMirrorEviction(string kind) => _mirrorEvictions.Add(1, Outcome(kind));
+    public void Dispose() => _meter.Dispose();
+
+    private static KeyValuePair<string, object?> Outcome(string value) => new("outcome", value);
+}

--- a/TerraformRegistry/Services/Publishing/ModulePublishCoordinator.cs
+++ b/TerraformRegistry/Services/Publishing/ModulePublishCoordinator.cs
@@ -10,10 +10,12 @@ public sealed class ModulePublishCoordinator(
     WebhookDispatcher webhookDispatcher,
     IAuditService auditService,
     ILogger<ModulePublishCoordinator> logger,
-    IArchiveIngestionValidator? archiveValidator = null) : IModulePublishCoordinator
+    IArchiveIngestionValidator? archiveValidator = null,
+    OperationalMetrics? metrics = null) : IModulePublishCoordinator
 {
     public async Task<bool> PublishAsync(ModulePublishRequest request, CancellationToken cancellationToken)
     {
+        metrics?.RecordPublicationAttempt();
         if (archiveValidator is not null)
         {
             await using var archive = await archiveValidator.PrepareAsync(request.ModuleContent, cancellationToken);
@@ -38,7 +40,10 @@ public sealed class ModulePublishCoordinator(
             cancellationToken);
 
         if (!uploaded)
+        {
+            metrics?.RecordPublicationConflict();
             return false;
+        }
 
         await webhookDispatcher.FireEventAsync(
             "module.published",

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -26,6 +26,7 @@ internal static class ServiceRegistrationExtensions
         IConfiguration configuration)
     {
         services.AddRegistryRateLimiting(configuration);
+        services.AddSingleton<OperationalMetrics>();
         services.AddSingleton<ArtifactDownloadTokenService>();
         services.Configure<DatabaseRetryOptions>(configuration.GetSection("DatabaseRetry"));
         services.Configure<WebhookSecurityOptions>(configuration.GetSection("WebhookSecurity"));
@@ -472,7 +473,8 @@ internal static class ServiceRegistrationExtensions
             provider.GetRequiredService<IModuleLlmContextGenerator>(),
             provider.GetRequiredService<IModuleExtractionConfigService>(),
             provider.GetRequiredService<ILogger<ModuleExtractionService>>(),
-            provider.GetRequiredService<IOptions<ModuleExtractionOptions>>().Value));
+            provider.GetRequiredService<IOptions<ModuleExtractionOptions>>().Value,
+            provider.GetRequiredService<OperationalMetrics>()));
         services.AddHostedService<ModuleExtractionHostedService>();
         services.AddSingleton<IModulePublishCoordinator, ModulePublishCoordinator>();
 


### PR DESCRIPTION
## Summary
- add a shared low-cardinality operational meter for durable outbox, extraction, publication, and mirror workflows
- record outbox age/failures/retries, extraction claim/attempt/failure, publication outcomes, mirror admission/active/eviction signals
- redact credential-bearing structured log values and complete signed URLs

## Verification
- `/home/rocky/.cache/terraform-registry-dotnet/dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --filter "FullyQualifiedName~OperationalMetricsTests|FullyQualifiedName~SensitiveDataRedactorTests" -v minimal`

## Notes
The application emits `System.Diagnostics.Metrics`; an OTLP/Prometheus exporter is intentionally deployment configuration rather than embedded in this package.