### PR TITLE
feat: complete operational metrics coverage

### DIFF
--- a/TerraformRegistry.API/Telemetry/OperationalDatabaseMetrics.cs
+++ b/TerraformRegistry.API/Telemetry/OperationalDatabaseMetrics.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace TerraformRegistry.API.Telemetry;
+
+/// <summary>Shared measurements for database-backed paginated list operations.</summary>
+public static class OperationalDatabaseMetrics
+{
+    private static readonly Meter Meter = new("TerraformRegistry.Operations");
+    private static readonly Histogram<long> DurationMilliseconds =
+        Meter.CreateHistogram<long>("terraform_registry.database.paginated_list.duration_ms");
+    private static readonly Histogram<long> ReturnedRows =
+        Meter.CreateHistogram<long>("terraform_registry.database.paginated_list.returned_rows");
+
+    public static void RecordModulePage(string backend, TimeSpan elapsed, int returnedRows)
+    {
+        var tags = new TagList { { "backend", backend }, { "list", "modules" } };
+        DurationMilliseconds.Record(Math.Max(0, (long)elapsed.TotalMilliseconds), tags);
+        ReturnedRows.Record(Math.Max(0, returnedRows), tags);
+    }
+}

--- a/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
+++ b/TerraformRegistry.PostgreSQL/PostgreSQLDatabaseService.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.API.Telemetry;
 using TerraformRegistry.Migrations;
 using TerraformRegistry.Models;
 using TerraformRegistry.PostgreSQL.Repositories;
@@ -34,8 +36,13 @@ public class PostgreSqlDatabaseService : IDatabaseService, IModulePublicationRep
         _downloads = new PostgreSqlModuleDownloadRecorder(connectionString, logger);
     }
 
-    public Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default) =>
-        _modules.ListModulesAsync(request, cancellationToken);
+    public async Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default)
+    {
+        var startedAt = Stopwatch.GetTimestamp();
+        var page = await _modules.ListModulesAsync(request, cancellationToken);
+        OperationalDatabaseMetrics.RecordModulePage("postgresql", Stopwatch.GetElapsedTime(startedAt), page.Modules.Count);
+        return page;
+    }
 
     public Task CreatePublicationAttemptWithExtractionJobAsync(ModulePublicationAttempt attempt, ModuleExtractionJob job,
         CancellationToken cancellationToken = default) =>

--- a/TerraformRegistry.Tests/UnitTests/Database/OperationalDatabaseMetricsFacadeTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/Database/OperationalDatabaseMetricsFacadeTests.cs
@@ -1,0 +1,140 @@
+using System.Diagnostics.Metrics;
+using DotNet.Testcontainers.Builders;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.Migrations;
+using TerraformRegistry.Models;
+using TerraformRegistry.PostgreSQL;
+using TerraformRegistry.Services;
+using Testcontainers.PostgreSql;
+
+namespace TerraformRegistry.Tests.UnitTests.Database;
+
+public sealed class SqliteOperationalDatabaseMetricsFacadeTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly string _connectionString;
+
+    public SqliteOperationalDatabaseMetricsFacadeTests()
+    {
+        _connectionString = $"Data Source=operational_metrics_{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
+        _connection = new SqliteConnection(_connectionString);
+        _connection.Open();
+        new DbUpMigrator(NullLogger<DbUpMigrator>.Instance).Migrate("sqlite", _connectionString);
+    }
+
+    [Fact]
+    public async Task ListModulesEmitsOnlyBoundedSqlitePageTagsFromTheDatabaseFacade()
+    {
+        var database = new SqliteDatabaseService(
+            _connectionString,
+            "http://localhost",
+            NullLogger<SqliteDatabaseService>.Instance,
+            new DbUpMigrator(NullLogger<DbUpMigrator>.Instance));
+        await database.AddModuleAsync(OperationalDatabaseMetricTestData.CreateModule());
+
+        using var listener = new OperationalDatabaseMetricListener();
+        var page = await database.ListModulesAsync(new ModuleSearchRequest { Limit = 10, Offset = 0 });
+
+        Assert.Single(page.Modules);
+        listener.AssertModulePage("sqlite", 1);
+    }
+
+    public void Dispose() => _connection.Dispose();
+}
+
+[Trait("Category", "Integration")]
+public sealed class PostgreSqlOperationalDatabaseMetricsFacadeTests : IAsyncLifetime
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    public async Task InitializeAsync()
+    {
+        _postgres = new PostgreSqlBuilder("postgres:15.1")
+            .WithDatabase("operational_metrics")
+            .WithUsername("postgres")
+            .WithPassword("postgres")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(5432))
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+        new DbUpMigrator(NullLogger<DbUpMigrator>.Instance).Migrate("postgres", _connectionString);
+    }
+
+    public async Task DisposeAsync() => await _postgres.DisposeAsync();
+
+    [Fact]
+    public async Task ListModulesEmitsOnlyBoundedPostgreSqlPageTagsFromTheDatabaseFacade()
+    {
+        var database = new PostgreSqlDatabaseService(
+            _connectionString,
+            "http://localhost",
+            NullLogger<PostgreSqlDatabaseService>.Instance,
+            new DbUpMigrator(NullLogger<DbUpMigrator>.Instance));
+        await database.AddModuleAsync(OperationalDatabaseMetricTestData.CreateModule());
+
+        using var listener = new OperationalDatabaseMetricListener();
+        var page = await database.ListModulesAsync(new ModuleSearchRequest { Limit = 10, Offset = 0 });
+
+        Assert.Single(page.Modules);
+        listener.AssertModulePage("postgresql", 1);
+    }
+}
+
+internal sealed class OperationalDatabaseMetricListener : IDisposable
+{
+    private readonly MeterListener _listener = new();
+    private readonly List<(string Name, long Value, IReadOnlyDictionary<string, string?> Tags)> _measurements = [];
+
+    public OperationalDatabaseMetricListener()
+    {
+        _listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == "TerraformRegistry.Operations")
+                meterListener.EnableMeasurementEvents(instrument);
+        };
+        _listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+            _measurements.Add((instrument.Name, value, tags.ToArray().ToDictionary(
+                tag => tag.Key,
+                tag => tag.Value?.ToString(),
+                StringComparer.Ordinal))));
+        _listener.Start();
+    }
+
+    public void AssertModulePage(string backend, int returnedRows)
+    {
+        var pageMeasurements = _measurements.Where(measurement =>
+            measurement.Name.StartsWith("terraform_registry.database.paginated_list.", StringComparison.Ordinal) &&
+            measurement.Tags.TryGetValue("backend", out var recordedBackend) && recordedBackend == backend).ToList();
+
+        Assert.Contains(pageMeasurements, measurement =>
+            measurement.Name == "terraform_registry.database.paginated_list.duration_ms");
+        Assert.Contains(pageMeasurements, measurement =>
+            measurement.Name == "terraform_registry.database.paginated_list.returned_rows" && measurement.Value == returnedRows);
+        Assert.All(pageMeasurements, measurement =>
+        {
+            Assert.Equal(["backend", "list"], measurement.Tags.Keys.OrderBy(key => key, StringComparer.Ordinal));
+            Assert.Equal(backend, measurement.Tags["backend"]);
+            Assert.Equal("modules", measurement.Tags["list"]);
+        });
+    }
+
+    public void Dispose() => _listener.Dispose();
+}
+
+internal static class OperationalDatabaseMetricTestData
+{
+    public static ModuleStorage CreateModule() => new()
+    {
+        Namespace = "metrics",
+        Name = "module",
+        Provider = "test",
+        Version = "1.0.0",
+        Description = "Operational metric test module",
+        FilePath = "modules/metrics/module/test/1.0.0.zip",
+        PublishedAt = DateTime.UtcNow,
+        Dependencies = []
+    };
+}

--- a/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorAdminHandlersTests.cs
@@ -145,9 +145,12 @@ public sealed class MirrorAdminHandlersTests
         providers.Setup(x => x.UpsertProviderPackageAsync(It.Is<MirrorProviderPackage>(item =>
                 item.PackageStoragePath == null && item.State == "evicted")))
             .Returns(Task.CompletedTask);
+        providers.Setup(x => x.ListProviderPackagesAsync(null, "ready", 1000, 0)).ReturnsAsync([]);
+        var modules = new Mock<IModuleMirrorRepository>();
+        modules.Setup(x => x.ListModulePackagesAsync(null, "ready", 1000, 0)).ReturnsAsync([]);
         var storage = new Mock<IProviderArtifactStorage>();
         storage.Setup(x => x.DeleteAsync("cache/aws", context.RequestAborted)).ReturnsAsync(true);
-        var budget = new MirrorCacheBudgetService(providers.Object, Mock.Of<IModuleMirrorRepository>(), storage.Object,
+        var budget = new MirrorCacheBudgetService(providers.Object, modules.Object, storage.Object,
             Mock.Of<IModuleService>(), new MirrorCacheUsage());
         var audit = new Mock<IAuditService>();
 

--- a/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
@@ -180,6 +180,24 @@ public sealed class MirrorCacheBudgetServiceTests
         Assert.Contains(0, cacheBytes);
     }
 
+    [Fact]
+    public async Task RecordCacheBytesTreatsMissingRepositoryPagesAsEmpty()
+    {
+        var providers = new Mock<IProviderMirrorRepository>();
+        providers.Setup(x => x.ListProviderPackagesAsync(null, "ready", 1000, 0))
+            .ReturnsAsync((IReadOnlyList<MirrorProviderPackage>)null!);
+        var modules = new Mock<IModuleMirrorRepository>();
+        modules.Setup(x => x.ListModulePackagesAsync(null, "ready", 1000, 0))
+            .ReturnsAsync((IReadOnlyList<MirrorModulePackage>)null!);
+        var service = new MirrorCacheBudgetService(providers.Object, modules.Object, Mock.Of<IProviderArtifactStorage>(),
+            Mock.Of<IModuleService>(), new MirrorCacheUsage());
+
+        await service.RecordCacheBytesAsync(CancellationToken.None);
+
+        providers.Verify(x => x.ListProviderPackagesAsync(null, "ready", 1000, 0), Times.Once);
+        modules.Verify(x => x.ListModulePackagesAsync(null, "ready", 1000, 0), Times.Once);
+    }
+
     private static MirrorProviderPackage ProviderPackage(string path, long size, DateTime updatedAt) => new()
     {
         Hostname = "registry.example.com",

--- a/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
@@ -220,7 +220,7 @@ public sealed class MirrorCacheBudgetServiceTests
     {
         var providers = new Mock<IProviderMirrorRepository>();
         providers.Setup(x => x.ListProviderPackagesAsync(null, "ready", 1000, 0))
-            .ReturnsAsync((IReadOnlyList<MirrorProviderPackage>)null!);
+            .ReturnsAsync(() => null!);
         var service = new MirrorCacheBudgetService(providers.Object, Mock.Of<IModuleMirrorRepository>(),
             Mock.Of<IProviderArtifactStorage>(), Mock.Of<IModuleService>(), new MirrorCacheUsage());
 

--- a/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
@@ -181,21 +181,50 @@ public sealed class MirrorCacheBudgetServiceTests
     }
 
     [Fact]
-    public async Task RecordCacheBytesTreatsMissingRepositoryPagesAsEmpty()
+    public async Task RecordCacheBytesRecordsZeroForEmptyRepositoryPages()
+    {
+        using var listener = new MeterListener();
+        var cacheBytes = new List<long>();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Name == "terraform_registry.mirror.cache_bytes")
+                meterListener.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, _, _) =>
+        {
+            if (instrument.Name == "terraform_registry.mirror.cache_bytes")
+                cacheBytes.Add(value);
+        });
+        listener.Start();
+
+        var providers = new Mock<IProviderMirrorRepository>();
+        providers.Setup(x => x.ListProviderPackagesAsync(null, "ready", 1000, 0))
+            .ReturnsAsync([]);
+        var modules = new Mock<IModuleMirrorRepository>();
+        modules.Setup(x => x.ListModulePackagesAsync(null, "ready", 1000, 0))
+            .ReturnsAsync([]);
+        using var metrics = new OperationalMetrics();
+        var service = new MirrorCacheBudgetService(providers.Object, modules.Object, Mock.Of<IProviderArtifactStorage>(),
+            Mock.Of<IModuleService>(), new MirrorCacheUsage(), metrics: metrics);
+
+        await service.RecordCacheBytesAsync(CancellationToken.None);
+        listener.RecordObservableInstruments();
+
+        providers.Verify(x => x.ListProviderPackagesAsync(null, "ready", 1000, 0), Times.Once);
+        modules.Verify(x => x.ListModulePackagesAsync(null, "ready", 1000, 0), Times.Once);
+        Assert.Contains(0, cacheBytes);
+    }
+
+    [Fact]
+    public async Task RecordCacheBytesRejectsNullRepositoryPages()
     {
         var providers = new Mock<IProviderMirrorRepository>();
         providers.Setup(x => x.ListProviderPackagesAsync(null, "ready", 1000, 0))
             .ReturnsAsync((IReadOnlyList<MirrorProviderPackage>)null!);
-        var modules = new Mock<IModuleMirrorRepository>();
-        modules.Setup(x => x.ListModulePackagesAsync(null, "ready", 1000, 0))
-            .ReturnsAsync((IReadOnlyList<MirrorModulePackage>)null!);
-        var service = new MirrorCacheBudgetService(providers.Object, modules.Object, Mock.Of<IProviderArtifactStorage>(),
-            Mock.Of<IModuleService>(), new MirrorCacheUsage());
+        var service = new MirrorCacheBudgetService(providers.Object, Mock.Of<IModuleMirrorRepository>(),
+            Mock.Of<IProviderArtifactStorage>(), Mock.Of<IModuleService>(), new MirrorCacheUsage());
 
-        await service.RecordCacheBytesAsync(CancellationToken.None);
-
-        providers.Verify(x => x.ListProviderPackagesAsync(null, "ready", 1000, 0), Times.Once);
-        modules.Verify(x => x.ListModulePackagesAsync(null, "ready", 1000, 0), Times.Once);
+        await Assert.ThrowsAsync<ArgumentNullException>(() => service.RecordCacheBytesAsync(CancellationToken.None));
     }
 
     private static MirrorProviderPackage ProviderPackage(string path, long size, DateTime updatedAt) => new()

--- a/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/MirrorCacheBudgetServiceTests.cs
@@ -1,6 +1,8 @@
 using Moq;
+using System.Diagnostics.Metrics;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Models;
+using TerraformRegistry.Services;
 using TerraformRegistry.Services.Mirror;
 
 namespace TerraformRegistry.Tests.UnitTests;
@@ -137,6 +139,45 @@ public sealed class MirrorCacheBudgetServiceTests
             package.Version, CancellationToken.None);
 
         Assert.Equal(MirrorCachePurgeResult.InUse, result);
+    }
+
+    [Fact]
+    public async Task PurgeProviderRefreshesCacheBytesAfterRemovingThePackage()
+    {
+        using var listener = new MeterListener();
+        var cacheBytes = new List<long>();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Name == "terraform_registry.mirror.cache_bytes")
+                meterListener.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, _, _) =>
+        {
+            if (instrument.Name == "terraform_registry.mirror.cache_bytes")
+                cacheBytes.Add(value);
+        });
+        listener.Start();
+
+        var package = ProviderPackage("cache/aws.zip", 42, DateTime.UtcNow);
+        var providers = new Mock<IProviderMirrorRepository>();
+        providers.Setup(x => x.GetProviderPackageAsync(
+                package.Hostname, package.Namespace, package.Type, package.Version, package.Os, package.Arch))
+            .ReturnsAsync(package);
+        providers.Setup(x => x.ListProviderPackagesAsync(null, "ready", 1000, 0)).ReturnsAsync([]);
+        var modules = new Mock<IModuleMirrorRepository>();
+        modules.Setup(x => x.ListModulePackagesAsync(null, "ready", 1000, 0)).ReturnsAsync([]);
+        var storage = new Mock<IProviderArtifactStorage>();
+        storage.Setup(x => x.DeleteAsync(package.PackageStoragePath!, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        using var metrics = new OperationalMetrics();
+        var service = new MirrorCacheBudgetService(providers.Object, modules.Object, storage.Object,
+            Mock.Of<IModuleService>(), new MirrorCacheUsage(), metrics: metrics);
+
+        Assert.Equal(MirrorCachePurgeResult.Purged, await service.PurgeProviderAsync(
+            package.Hostname, package.Namespace, package.Type, package.Version, package.Os, package.Arch,
+            CancellationToken.None));
+        listener.RecordObservableInstruments();
+
+        Assert.Contains(0, cacheBytes);
     }
 
     private static MirrorProviderPackage ProviderPackage(string path, long size, DateTime updatedAt) => new()

--- a/TerraformRegistry.Tests/UnitTests/ModuleExtractionQueueRuntimeTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleExtractionQueueRuntimeTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics.Metrics;
 using Moq;
 using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.Models;
@@ -216,6 +217,63 @@ public class ModuleExtractionQueueRuntimeTests
         Assert.False(queued);
         database.Verify(x => x.CreatePublicationAttemptWithExtractionJobAsync(
             It.IsAny<ModulePublicationAttempt>(), It.IsAny<ModuleExtractionJob>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessNextAsyncRefreshesQueueDepthAfterClaimingAJob()
+    {
+        using var listener = new MeterListener();
+        var queueDepths = new List<long>();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Name == "terraform_registry.extraction.queue_depth")
+                meterListener.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, _, _) =>
+        {
+            if (instrument.Name == "terraform_registry.extraction.queue_depth")
+                queueDepths.Add(value);
+        });
+        listener.Start();
+
+        var config = new Mock<IModuleExtractionConfigService>();
+        var database = new Mock<IDatabaseService>();
+        database.Setup(x => x.TryClaimNextExtractionJobAsync("worker", It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ModuleExtractionJob
+            {
+                Id = Guid.NewGuid(),
+                PublicationAttemptId = Guid.NewGuid(),
+                Namespace = "acme",
+                Name = "network",
+                Provider = "aws",
+                Version = "1.0.0",
+                State = ModuleExtractionJobState.Pending,
+                UpdatedAt = DateTime.UtcNow,
+                CreatedAt = DateTime.UtcNow
+            });
+        database.Setup(x => x.CountPendingExtractionJobsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        database.Setup(x => x.TryFailExtractionJobAsync(It.IsAny<Guid>(), "worker", It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var moduleService = new Mock<IModuleService>();
+        moduleService.Setup(x => x.OpenModulePackageStreamAsync("acme", "network", "aws", "1.0.0"))
+            .ReturnsAsync((Stream?)null);
+        using var metrics = new OperationalMetrics();
+        var service = new ModuleExtractionService(
+            moduleService.Object,
+            database.Object,
+            Mock.Of<IArchiveWorkspaceFactory>(),
+            Mock.Of<ITerraformModuleInspector>(),
+            Mock.Of<IModuleLlmContextGenerator>(),
+            config.Object,
+            NullLogger<ModuleExtractionService>.Instance,
+            new ModuleExtractionOptions { JobLeaseSeconds = 1 },
+            metrics);
+
+        Assert.True(await service.ProcessNextAsync("worker", CancellationToken.None));
+        listener.RecordObservableInstruments();
+
+        Assert.Contains(0, queueDepths);
     }
 
     private static ModuleExtractionService CreateService(

--- a/TerraformRegistry.Tests/UnitTests/ModuleExtractionQueueRuntimeTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ModuleExtractionQueueRuntimeTests.cs
@@ -257,7 +257,7 @@ public class ModuleExtractionQueueRuntimeTests
 
         var moduleService = new Mock<IModuleService>();
         moduleService.Setup(x => x.OpenModulePackageStreamAsync("acme", "network", "aws", "1.0.0"))
-            .ReturnsAsync((Stream?)null);
+            .Returns(() => Task.FromResult<Stream?>(null));
         using var metrics = new OperationalMetrics();
         var service = new ModuleExtractionService(
             moduleService.Object,

--- a/TerraformRegistry.Tests/UnitTests/OperationalMetricsTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/OperationalMetricsTests.cs
@@ -1,10 +1,76 @@
 using System.Diagnostics.Metrics;
+using TerraformRegistry.API.Telemetry;
 using TerraformRegistry.Services;
 
 namespace TerraformRegistry.Tests.UnitTests;
 
 public sealed class OperationalMetricsTests
 {
+    [Fact]
+    public void PaginatedDatabaseMetricReportsDurationAndReturnedRowsWithBoundedTags()
+    {
+        using var listener = new MeterListener();
+        var measurements = new List<(string Name, long Value, string? Backend)>();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == OperationalMetrics.MeterName)
+                meterListener.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+            measurements.Add((instrument.Name, value,
+                tags.ToArray().FirstOrDefault(tag => tag.Key == "backend").Value?.ToString())));
+        listener.Start();
+
+        OperationalDatabaseMetrics.RecordModulePage("sqlite", TimeSpan.FromMilliseconds(12), 4);
+
+        Assert.Contains(measurements, measurement =>
+            measurement.Name == "terraform_registry.database.paginated_list.duration_ms" && measurement.Backend == "sqlite");
+        Assert.Contains(measurements, measurement =>
+            measurement.Name == "terraform_registry.database.paginated_list.returned_rows" && measurement.Value == 4 && measurement.Backend == "sqlite");
+    }
+
+    [Fact]
+    public void CompletionMetricsUseOnlyBoundedTagsAndReportObservableQueueDepth()
+    {
+        using var listener = new MeterListener();
+        var measurements = new List<(string Name, long Value, string? Outcome, string? Kind)>();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == OperationalMetrics.MeterName)
+                meterListener.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+        {
+            var tagValues = tags.ToArray();
+            measurements.Add((instrument.Name, value,
+                tagValues.FirstOrDefault(tag => tag.Key == "outcome").Value?.ToString(),
+                tagValues.FirstOrDefault(tag => tag.Key == "kind").Value?.ToString()));
+        });
+        listener.Start();
+
+        using var metrics = new OperationalMetrics();
+        metrics.RecordExtractionQueueDepth(3);
+        metrics.RecordAuthenticationDecision("denied_inactive_user");
+        metrics.RecordMirrorUpstreamRequest("provider");
+        metrics.RecordMirrorNegativeCacheHit("module");
+        metrics.RecordMirrorLeaseLoss("provider");
+        metrics.RecordMirrorCacheBytes(1024);
+        listener.RecordObservableInstruments();
+
+        Assert.Contains(measurements, measurement =>
+            measurement.Name == "terraform_registry.extraction.queue_depth" && measurement.Value == 3);
+        Assert.Contains(measurements, measurement =>
+            measurement.Name == "terraform_registry.authentication.decisions" && measurement.Outcome == "denied_inactive_user");
+        Assert.Contains(measurements, measurement =>
+            measurement.Name == "terraform_registry.mirror.upstream_requests" && measurement.Kind == "provider");
+        Assert.Contains(measurements, measurement =>
+            measurement.Name == "terraform_registry.mirror.negative_cache_hits" && measurement.Kind == "module");
+        Assert.Contains(measurements, measurement =>
+            measurement.Name == "terraform_registry.mirror.lease_losses" && measurement.Kind == "provider");
+        Assert.Contains(measurements, measurement =>
+            measurement.Name == "terraform_registry.mirror.cache_bytes" && measurement.Value == 1024);
+    }
+
     [Fact]
     public void OutboxFailureMetricContainsOnlyTheFailureCategory()
     {

--- a/TerraformRegistry.Tests/UnitTests/OperationalMetricsTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/OperationalMetricsTests.cs
@@ -1,5 +1,13 @@
 using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraformRegistry.API.Interfaces;
 using TerraformRegistry.API.Telemetry;
+using TerraformRegistry.Middleware;
+using TerraformRegistry.Models;
 using TerraformRegistry.Services;
 
 namespace TerraformRegistry.Tests.UnitTests;
@@ -95,6 +103,72 @@ public sealed class OperationalMetricsTests
         Assert.Contains(measurements, measurement =>
             measurement.Name == "terraform_registry.outbox.failures" &&
             measurement.Outcome == "delivery_failed" && measurement.Secret is null);
+    }
+
+    [Fact]
+    public async Task AuthenticationMiddlewareRecordsAdmittedAndDeniedDecisionsFromRealRequestPaths()
+    {
+        using var listener = new MeterListener();
+        var measurements = new List<(string Name, IReadOnlyDictionary<string, string?> Tags)>();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == OperationalMetrics.MeterName)
+                meterListener.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, _, tags, _) =>
+            measurements.Add((instrument.Name, tags.ToArray().ToDictionary(
+                tag => tag.Key,
+                tag => tag.Value?.ToString(),
+                StringComparer.Ordinal))));
+        listener.Start();
+
+        using var metrics = new OperationalMetrics();
+        var environment = Mock.Of<IHostEnvironment>(host => host.EnvironmentName == "Test");
+        var jwtService = new JwtService(new OidcOptions
+        {
+            JwtSecretKey = "operational-metrics-authentication-test-secret-key",
+            JwtExpiryHours = 1
+        }, NullLogger<JwtService>.Instance, environment);
+        var middleware = new AuthenticationMiddleware(
+            context =>
+            {
+                context.Items["next-called"] = true;
+                return Task.CompletedTask;
+            },
+            "static-test-token",
+            jwtService,
+            NullLogger<AuthenticationMiddleware>.Instance,
+            environment,
+            new ConfigurationBuilder().Build(),
+            Mock.Of<IMirrorConfigService>(),
+            metrics);
+
+        var admitted = new DefaultHttpContext();
+        admitted.Request.Path = "/v1/modules";
+        admitted.Request.Headers.Authorization = "Bearer static-test-token";
+        await middleware.InvokeAsync(admitted);
+
+        var denied = new DefaultHttpContext();
+        denied.Request.Path = "/v1/modules";
+        // Two dots make this exercise the JWT denial path rather than API-key lookup.
+        denied.Request.Headers.Authorization = "Bearer invalid.token.value";
+        await middleware.InvokeAsync(denied);
+
+        Assert.True((bool)admitted.Items["next-called"]!);
+        Assert.Equal(StatusCodes.Status401Unauthorized, denied.Response.StatusCode);
+        AssertAuthenticationOutcome(measurements, "admitted_static_token");
+        AssertAuthenticationOutcome(measurements, "denied_invalid_token");
+    }
+
+    private static void AssertAuthenticationOutcome(
+        IEnumerable<(string Name, IReadOnlyDictionary<string, string?> Tags)> measurements,
+        string expectedOutcome)
+    {
+        var measurement = Assert.Single(measurements, measurement =>
+            measurement.Name == "terraform_registry.authentication.decisions" &&
+            measurement.Tags.TryGetValue("outcome", out var outcome) && outcome == expectedOutcome);
+
+        Assert.Equal(["outcome"], measurement.Tags.Keys.OrderBy(key => key, StringComparer.Ordinal));
     }
 }
 

--- a/TerraformRegistry.Tests/UnitTests/ProviderMirrorServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ProviderMirrorServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Diagnostics.Metrics;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -91,6 +92,19 @@ public sealed class ProviderMirrorServiceTests
     [Fact]
     public async Task ProviderVersionCachesVerificationSidecarsWithoutDownloadingThePlatformArchive()
     {
+        using var listener = new MeterListener();
+        var cacheBytes = new List<long>();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Name == "terraform_registry.mirror.cache_bytes")
+                meterListener.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, _, _) =>
+        {
+            if (instrument.Name == "terraform_registry.mirror.cache_bytes")
+                cacheBytes.Add(value);
+        });
+        listener.Start();
         var packageBytes = new byte[] { 1, 2, 3 };
         var shasum = Convert.ToHexString(SHA256.HashData(packageBytes)).ToLowerInvariant();
         var filename = "terraform-provider-aws_5.0.0_linux_amd64.zip";
@@ -113,7 +127,12 @@ public sealed class ProviderMirrorServiceTests
         http.RespondBytes("https://releases.example.com/SHA256SUMS.sig", [9, 8, 7], "application/octet-stream");
         var storage = new InMemoryProviderArtifactStorage();
         var repository = new InMemoryProviderMirrorRepository();
-        var service = CreateServiceWithRepository(http, repository, storage);
+        var modules = new Mock<IModuleMirrorRepository>();
+        modules.Setup(x => x.ListModulePackagesAsync(null, "ready", 1000, 0)).ReturnsAsync([]);
+        using var metrics = new OperationalMetrics();
+        var budget = new MirrorCacheBudgetService(repository, modules.Object, storage, Mock.Of<IModuleService>(),
+            new MirrorCacheUsage(), metrics: metrics);
+        var service = CreateServiceWithRepository(http, repository, storage, cacheBudget: budget);
 
         var version = await service.GetProviderVersionAsync(
             "registry.terraform.io",
@@ -144,6 +163,8 @@ public sealed class ProviderMirrorServiceTests
         using var downloaded = new MemoryStream();
         await content.CopyToAsync(downloaded);
         Assert.Equal(packageBytes, downloaded.ToArray());
+        listener.RecordObservableInstruments();
+        Assert.Contains(cacheBytes, bytes => bytes > 0);
     }
 
     [Fact]
@@ -969,7 +990,8 @@ public sealed class ProviderMirrorServiceTests
         IProviderMirrorRepository repository,
         InMemoryProviderArtifactStorage? storage = null,
         IConfiguration? configuration = null,
-        Mock<IProviderPackageValidator>? validator = null)
+        Mock<IProviderPackageValidator>? validator = null,
+        MirrorCacheBudgetService? cacheBudget = null)
     {
         configuration ??= CreateConfiguration();
         var settings = new Mock<IRuntimeSettingsService>();
@@ -1009,6 +1031,7 @@ public sealed class ProviderMirrorServiceTests
             new SingleClientFactory(new HttpClient(http)),
             new MirrorPackageUrlSigner(configuration, new TestHostEnvironment()),
             NullLogger<ProviderMirrorService>.Instance,
+            cacheBudget: cacheBudget,
             packageValidator: validator.Object);
     }
 

--- a/TerraformRegistry/Middleware/AuthenticationMiddleware.cs
+++ b/TerraformRegistry/Middleware/AuthenticationMiddleware.cs
@@ -13,7 +13,8 @@ public class AuthenticationMiddleware(
     ILogger<AuthenticationMiddleware> logger,
     IHostEnvironment environment,
     IConfiguration configuration,
-    IMirrorConfigService mirrorConfigService)
+    IMirrorConfigService mirrorConfigService,
+    OperationalMetrics? metrics = null)
 {
     private const string AuthorizationHeader = "Authorization";
     private const string BearerPrefix = "Bearer ";
@@ -72,6 +73,7 @@ public class AuthenticationMiddleware(
                 }
 
                 context.User = GetStaticTokenPrincipal();
+                metrics?.RecordAuthenticationDecision("admitted_static_token");
                 await next(context);
                 return;
             }
@@ -139,11 +141,13 @@ public class AuthenticationMiddleware(
                 {
                     if (!await IsCurrentUserActiveAsync(context, principal))
                     {
+                        metrics?.RecordAuthenticationDecision("denied_inactive_user");
                         await WriteUnauthorizedResponseAsync(context, path);
                         return;
                     }
 
                     context.User = principal;
+                    metrics?.RecordAuthenticationDecision("admitted_session");
                     await LoadPermissionsIntoClaims(context);
                     RegistryLog.Information(logger,
                         "Session cookie validated successfully for {Path}. User: {User}. IsAuthenticated: {IsAuthenticated}. AuthType: {AuthType}",
@@ -158,6 +162,7 @@ public class AuthenticationMiddleware(
                 }
                 else
                 {
+                    metrics?.RecordAuthenticationDecision("denied_invalid_session");
                     RegistryLog.Warning(logger, "Session cookie validation failed for {Path}. Token: {TokenPrefix}...", path,
                         sessionToken.Substring(0, Math.Min(10, sessionToken.Length)));
                 }
@@ -177,11 +182,13 @@ public class AuthenticationMiddleware(
             {
                 if (!await IsCurrentUserActiveAsync(context, jwtPrincipal))
                 {
+                    metrics?.RecordAuthenticationDecision("denied_inactive_user");
                     await WriteUnauthorizedResponseAsync(context, path);
                     return;
                 }
 
                 context.User = jwtPrincipal;
+                metrics?.RecordAuthenticationDecision("admitted_jwt");
                 await LoadPermissionsIntoClaims(context);
                 await next(context);
                 return;
@@ -190,6 +197,7 @@ public class AuthenticationMiddleware(
             // No valid authentication found
             RegistryLog.Warning(logger, "Unauthorized request to {Path} from {RemoteIp}", path,
                 context.Connection.RemoteIpAddress);
+            metrics?.RecordAuthenticationDecision("denied_invalid_token");
 
             // For /api/keys, we let the [Authorize] attribute handle the challenge
             if (path.StartsWith("/api/keys", StringComparison.OrdinalIgnoreCase))

--- a/TerraformRegistry/Services/ApiKeyService.cs
+++ b/TerraformRegistry/Services/ApiKeyService.cs
@@ -13,7 +13,8 @@ public class ApiKeyService(
     ILogger<ApiKeyService> logger,
     UserAdmissionOptions userAdmissionOptions,
     ApiKeySecurityOptions securityOptions,
-    ApiKeyVerificationGate verificationGate) : IApiKeyService
+    ApiKeyVerificationGate verificationGate,
+    OperationalMetrics? metrics = null) : IApiKeyService
 {
     private const int TokenLength = 32;
     // private const string TokenPrefix = "tf-"; // Removed prefix requirement
@@ -63,6 +64,7 @@ public class ApiKeyService(
     {
         if (string.IsNullOrWhiteSpace(rawToken))
         {
+            metrics?.RecordAuthenticationDecision("denied_missing_api_key");
             return new ApiKeyValidationResult(null, false);
         }
 
@@ -77,6 +79,7 @@ public class ApiKeyService(
             if (prefixLease is null)
             {
                 RegistryLog.Warning(logger, "Rejected API key verification because the prefix limit was reached.");
+                metrics?.RecordAuthenticationDecision("denied_rate_limited");
                 return new ApiKeyValidationResult(null, false, true);
             }
 
@@ -87,11 +90,13 @@ public class ApiKeyService(
                 if (principalLease is null)
                 {
                     RegistryLog.Warning(logger, "Rejected API key verification because the principal limit was reached.");
+                    metrics?.RecordAuthenticationDecision("denied_rate_limited");
                     return new ApiKeyValidationResult(null, false, true);
                 }
 
                 if (key.ExpiresAt.HasValue && key.ExpiresAt.Value < DateTime.UtcNow)
                 {
+                    metrics?.RecordAuthenticationDecision("denied_expired_api_key");
                     return new ApiKeyValidationResult(null, true);
                 }
 
@@ -99,6 +104,7 @@ public class ApiKeyService(
                 if (user?.IsActive != true)
                 {
                     RegistryLog.Warning(logger, "Rejected API key for inactive or missing user {UserId}", key.UserId);
+                    metrics?.RecordAuthenticationDecision("denied_inactive_user");
                     return new ApiKeyValidationResult(null, false);
                 }
 
@@ -115,10 +121,12 @@ public class ApiKeyService(
                     key.LastUsedAt = now;
                     await dbService.UpdateApiKeyAsync(key);
                 }
+                metrics?.RecordAuthenticationDecision("admitted_api_key");
                 return new ApiKeyValidationResult(key, false);
             }
         }
 
+        metrics?.RecordAuthenticationDecision("denied_invalid_api_key");
         return new ApiKeyValidationResult(null, false);
     }
 

--- a/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
@@ -55,6 +55,14 @@ public sealed class MirrorCacheBudgetService(
         return false;
     }
 
+    /// <summary>Records the cache size after a successful cache lifecycle change.</summary>
+    public async Task RecordCacheBytesAsync(CancellationToken cancellationToken)
+    {
+        var providers = await ListProviderPackagesAsync(cancellationToken);
+        var modules = await ListModulePackagesAsync(cancellationToken);
+        metrics?.RecordMirrorCacheBytes(providers.Sum(CacheBytes) + modules.Sum(CacheBytes));
+    }
+
     public async Task<MirrorCachePurgeResult> PurgeProviderAsync(
         string hostname,
         string providerNamespace,
@@ -76,9 +84,13 @@ public sealed class MirrorCacheBudgetService(
             return MirrorCachePurgeResult.InUse;
         }
 
-        return await EvictAsync(new EvictionCandidate(package, null), cancellationToken)
-            ? MirrorCachePurgeResult.Purged
-            : MirrorCachePurgeResult.Failed;
+        if (!await EvictAsync(new EvictionCandidate(package, null), cancellationToken))
+        {
+            return MirrorCachePurgeResult.Failed;
+        }
+
+        await RecordCacheBytesAsync(cancellationToken);
+        return MirrorCachePurgeResult.Purged;
     }
 
     public async Task<MirrorCachePurgeResult> PurgeModuleAsync(
@@ -101,9 +113,13 @@ public sealed class MirrorCacheBudgetService(
             return MirrorCachePurgeResult.InUse;
         }
 
-        return await EvictAsync(new EvictionCandidate(null, package), cancellationToken)
-            ? MirrorCachePurgeResult.Purged
-            : MirrorCachePurgeResult.Failed;
+        if (!await EvictAsync(new EvictionCandidate(null, package), cancellationToken))
+        {
+            return MirrorCachePurgeResult.Failed;
+        }
+
+        await RecordCacheBytesAsync(cancellationToken);
+        return MirrorCachePurgeResult.Purged;
     }
 
     private async Task<bool> EvictAsync(EvictionCandidate candidate, CancellationToken cancellationToken)

--- a/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
@@ -178,7 +178,8 @@ public sealed class MirrorCacheBudgetService(
         for (var offset = 0; ; offset += PageSize)
         {
             var page = await providerRepository.ListProviderPackagesAsync(null, "ready", PageSize, offset);
-            if (page is null || page.Count == 0) return packages;
+            ArgumentNullException.ThrowIfNull(page);
+            if (page.Count == 0) return packages;
 
             packages.AddRange(page);
             if (page.Count < PageSize) return packages;
@@ -192,7 +193,8 @@ public sealed class MirrorCacheBudgetService(
         for (var offset = 0; ; offset += PageSize)
         {
             var page = await moduleRepository.ListModulePackagesAsync(null, "ready", PageSize, offset);
-            if (page is null || page.Count == 0) return packages;
+            ArgumentNullException.ThrowIfNull(page);
+            if (page.Count == 0) return packages;
 
             packages.AddRange(page);
             if (page.Count < PageSize) return packages;

--- a/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
@@ -178,6 +178,8 @@ public sealed class MirrorCacheBudgetService(
         for (var offset = 0; ; offset += PageSize)
         {
             var page = await providerRepository.ListProviderPackagesAsync(null, "ready", PageSize, offset);
+            if (page is null || page.Count == 0) return packages;
+
             packages.AddRange(page);
             if (page.Count < PageSize) return packages;
             cancellationToken.ThrowIfCancellationRequested();
@@ -190,6 +192,8 @@ public sealed class MirrorCacheBudgetService(
         for (var offset = 0; ; offset += PageSize)
         {
             var page = await moduleRepository.ListModulePackagesAsync(null, "ready", PageSize, offset);
+            if (page is null || page.Count == 0) return packages;
+
             packages.AddRange(page);
             if (page.Count < PageSize) return packages;
             cancellationToken.ThrowIfCancellationRequested();

--- a/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorCacheBudgetService.cs
@@ -25,6 +25,7 @@ public sealed class MirrorCacheBudgetService(
         var providers = await ListProviderPackagesAsync(cancellationToken);
         var modules = await ListModulePackagesAsync(cancellationToken);
         var totalBytes = providers.Sum(CacheBytes) + modules.Sum(CacheBytes);
+        metrics?.RecordMirrorCacheBytes(totalBytes);
         if (totalBytes + additionalBytes <= maximumBytes)
         {
             return true;
@@ -44,6 +45,7 @@ public sealed class MirrorCacheBudgetService(
             }
 
             totalBytes -= candidate.Bytes;
+            metrics?.RecordMirrorCacheBytes(totalBytes);
             if (totalBytes + additionalBytes <= maximumBytes)
             {
                 return true;

--- a/TerraformRegistry/Services/Mirror/MirrorLeaseHeartbeat.cs
+++ b/TerraformRegistry/Services/Mirror/MirrorLeaseHeartbeat.cs
@@ -12,13 +12,18 @@ public sealed class MirrorLeaseHeartbeat : IAsyncDisposable
     private readonly CancellationTokenSource _stopping = new();
     private readonly TaskCompletionSource _firstHeartbeat = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly Task _runner;
+    private readonly OperationalMetrics? _metrics;
+    private readonly string _kind;
     private int _ownershipLost;
 
-    public MirrorLeaseHeartbeat(IMirrorLeaseService leaseService, MirrorLeaseHandle lease, TimeSpan interval)
+    public MirrorLeaseHeartbeat(IMirrorLeaseService leaseService, MirrorLeaseHandle lease, TimeSpan interval,
+        OperationalMetrics? metrics = null, string kind = "unknown")
     {
         _leaseService = leaseService;
         _lease = lease;
         _interval = interval;
+        _metrics = metrics;
+        _kind = kind;
         _runner = RunAsync();
     }
 
@@ -57,6 +62,7 @@ public sealed class MirrorLeaseHeartbeat : IAsyncDisposable
                     if (!await _leaseService.HeartbeatAsync(_lease, _stopping.Token))
                     {
                         Interlocked.Exchange(ref _ownershipLost, 1);
+                        _metrics?.RecordMirrorLeaseLoss(_kind);
                         return;
                     }
                 }
@@ -67,16 +73,19 @@ public sealed class MirrorLeaseHeartbeat : IAsyncDisposable
                 catch (TimeoutException)
                 {
                     Interlocked.Exchange(ref _ownershipLost, 1);
+                    _metrics?.RecordMirrorLeaseLoss(_kind);
                     return;
                 }
                 catch (System.Data.Common.DbException)
                 {
                     Interlocked.Exchange(ref _ownershipLost, 1);
+                    _metrics?.RecordMirrorLeaseLoss(_kind);
                     return;
                 }
                 catch (IOException)
                 {
                     Interlocked.Exchange(ref _ownershipLost, 1);
+                    _metrics?.RecordMirrorLeaseLoss(_kind);
                     return;
                 }
                 finally

--- a/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
@@ -471,6 +471,11 @@ public sealed class ModuleMirrorService(
                 LastSyncAt = DateTime.UtcNow
             });
 
+            if (cacheBudget is not null)
+            {
+                await cacheBudget.RecordCacheBytesAsync(cancellationToken);
+            }
+
             RegisterModuleTokenPath(localPath, hostname, moduleNamespace, name, provider, version);
             return AppendPreservedHints(localPath, source);
         }

--- a/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ModuleMirrorService.cs
@@ -23,7 +23,8 @@ public sealed class ModuleMirrorService(
     MirrorDownloadAdmission? downloadAdmission = null,
     MirrorCacheBudgetService? cacheBudget = null,
     MirrorCacheUsage? cacheUsage = null,
-    ArtifactDownloadTokenService? downloadTokens = null) : IModuleMirrorService
+    ArtifactDownloadTokenService? downloadTokens = null,
+    OperationalMetrics? metrics = null) : IModuleMirrorService
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private static readonly TimeSpan LeaseReleaseTimeout = TimeSpan.FromSeconds(5);
@@ -81,6 +82,7 @@ public sealed class ModuleMirrorService(
             config.UpstreamRegistryBaseUrl,
             $"/v1/modules/{moduleNamespace}/{name}/{provider}/{version}");
         using var timeout = CreateTimeout(config.Modules.DownloadTimeoutSeconds, cancellationToken);
+        metrics?.RecordMirrorUpstreamRequest("module");
         using var response = await client.GetAsync(uri, timeout.Token);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
@@ -169,7 +171,7 @@ public sealed class ModuleMirrorService(
                 return cachedLocalPath;
             }
 
-            await using var heartbeat = new MirrorLeaseHeartbeat(leaseService, lease, TimeSpan.FromMinutes(1));
+            await using var heartbeat = new MirrorLeaseHeartbeat(leaseService, lease, TimeSpan.FromMinutes(1), metrics, "module");
             return await FetchCacheAndCreateLocalDownloadPathAsync(
                 hostname,
                 moduleNamespace,
@@ -200,6 +202,7 @@ public sealed class ModuleMirrorService(
             cached.LastSyncAt is { } negativeSync &&
             negativeSync.AddSeconds(config.Limits.NegativeCacheTtlSeconds) > DateTime.UtcNow)
         {
+            metrics?.RecordMirrorNegativeCacheHit("module");
             return null;
         }
 
@@ -214,6 +217,7 @@ public sealed class ModuleMirrorService(
         var client = httpClientFactory.CreateClient();
         var uri = BuildUpstreamUri(config.UpstreamRegistryBaseUrl, $"/v1/modules/{moduleNamespace}/{name}/{provider}/versions");
         using var timeout = CreateTimeout(config.Modules.DownloadTimeoutSeconds, cancellationToken);
+        metrics?.RecordMirrorUpstreamRequest("module");
         using var response = await client.GetAsync(uri, timeout.Token);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
@@ -493,6 +497,7 @@ public sealed class ModuleMirrorService(
     {
         var client = httpClientFactory.CreateClient(MirrorDiscoveryHttpClientName);
         using var timeout = CreateTimeout(timeoutSeconds, cancellationToken);
+        metrics?.RecordMirrorUpstreamRequest("module");
         using var response = await client.GetAsync(upstreamDownloadUri, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {

--- a/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
@@ -22,7 +22,8 @@ public sealed class ProviderMirrorService(
     MirrorDownloadAdmission? downloadAdmission = null,
     MirrorCacheBudgetService? cacheBudget = null,
     MirrorCacheUsage? cacheUsage = null,
-    IProviderPackageValidator? packageValidator = null) : IProviderMirrorService
+    IProviderPackageValidator? packageValidator = null,
+    OperationalMetrics? metrics = null) : IProviderMirrorService
 {
     private const string MirrorHttpClientName = "TerraformRegistryMirror";
     private const int BufferSize = 81920;
@@ -216,6 +217,7 @@ public sealed class ProviderMirrorService(
             cached.LastSyncAt is { } negativeSync &&
             negativeSync.AddSeconds(config.Limits.NegativeCacheTtlSeconds) > DateTime.UtcNow)
         {
+            metrics?.RecordMirrorNegativeCacheHit("provider");
             return null;
         }
 
@@ -230,6 +232,7 @@ public sealed class ProviderMirrorService(
         var client = httpClientFactory.CreateClient();
         var uri = BuildUpstreamUri(MirrorConfigurationValidator.GetProviderUpstreamUri(config, hostname).ToString(), $"/v1/providers/{providerNamespace}/{type}/versions");
         using var timeout = CreateTimeout(config.Providers.DownloadTimeoutSeconds, cancellationToken);
+        metrics?.RecordMirrorUpstreamRequest("provider");
         using var response = await client.GetAsync(uri, timeout.Token);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
@@ -306,7 +309,7 @@ public sealed class ProviderMirrorService(
                 return cached;
             }
 
-            await using var heartbeat = new MirrorLeaseHeartbeat(leaseService, lease, TimeSpan.FromMinutes(1));
+            await using var heartbeat = new MirrorLeaseHeartbeat(leaseService, lease, TimeSpan.FromMinutes(1), metrics, "provider");
             return await FetchAndCachePackageAsync(hostname, providerNamespace, type, version, platform, config, heartbeat, cancellationToken);
         }
         finally
@@ -470,6 +473,7 @@ public sealed class ProviderMirrorService(
                 MirrorConfigurationValidator.GetProviderUpstreamUri(config, hostname).ToString(),
                 $"/v1/providers/{providerNamespace}/{type}/{version.Version}/download/{platform.Os}/{platform.Arch}");
             using var metadataTimeout = CreateTimeout(config.Providers.DownloadTimeoutSeconds, cancellationToken);
+            metrics?.RecordMirrorUpstreamRequest("provider");
             var metadata = await client.GetFromJsonAsync<ProviderPackageResponse>(metadataUri, JsonOptions, metadataTimeout.Token);
             if (metadata is null)
             {

--- a/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
+++ b/TerraformRegistry/Services/Mirror/ProviderMirrorService.cs
@@ -593,6 +593,10 @@ public sealed class ProviderMirrorService(
 
             heartbeat.ThrowIfOwnershipLost();
             await repository.UpsertProviderPackageAsync(package);
+            if (cacheBudget is not null)
+            {
+                await cacheBudget.RecordCacheBytesAsync(cancellationToken);
+            }
             return package;
         }
         catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or JsonException or IOException)

--- a/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionService.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionService.cs
@@ -121,6 +121,8 @@ public sealed class ModuleExtractionService : IModuleExtractionService
         if (job is null)
             return false;
 
+        _metrics?.RecordExtractionQueueDepth(
+            await _databaseService.CountPendingExtractionJobsAsync(cancellationToken));
         _metrics?.RecordExtractionClaim(job.CreatedAt);
         _metrics?.RecordExtractionAttempt();
 

--- a/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionService.cs
+++ b/TerraformRegistry/Services/ModuleExtraction/ModuleExtractionService.cs
@@ -43,7 +43,9 @@ public sealed class ModuleExtractionService : IModuleExtractionService
         if (!await _configService.IsEnabledAsync(cancellationToken))
             return false;
 
-        if (await _databaseService.CountPendingExtractionJobsAsync(cancellationToken) >= _options.MaxPendingJobs)
+        var pendingJobs = await _databaseService.CountPendingExtractionJobsAsync(cancellationToken);
+        _metrics?.RecordExtractionQueueDepth(pendingJobs);
+        if (pendingJobs >= _options.MaxPendingJobs)
         {
             RegistryLog.Warning(_logger,
                 "Extraction backlog is full; rejecting module {Namespace}/{Name}/{Provider}/{Version}",
@@ -81,6 +83,7 @@ public sealed class ModuleExtractionService : IModuleExtractionService
             UpdatedAt = now
         };
         await _databaseService.CreatePublicationAttemptWithExtractionJobAsync(attempt, job, cancellationToken);
+        _metrics?.RecordExtractionQueueDepth(pendingJobs + 1);
         await MarkPendingAsync(request);
         return true;
     }

--- a/TerraformRegistry/Services/OperationalMetrics.cs
+++ b/TerraformRegistry/Services/OperationalMetrics.cs
@@ -14,12 +14,19 @@ public sealed class OperationalMetrics : IDisposable
     private readonly Histogram<long> _extractionClaimMilliseconds;
     private readonly Counter<long> _extractionAttempts;
     private readonly Counter<long> _extractionFailures;
+    private readonly ObservableGauge<long> _extractionQueueDepth;
     private readonly Counter<long> _publicationAttempts;
     private readonly Counter<long> _publicationConflicts;
     private readonly Counter<long> _authenticationDecisions;
     private readonly UpDownCounter<long> _mirrorActiveDownloads;
     private readonly Counter<long> _mirrorAdmissionRejections;
     private readonly Counter<long> _mirrorEvictions;
+    private readonly Counter<long> _mirrorUpstreamRequests;
+    private readonly Counter<long> _mirrorNegativeCacheHits;
+    private readonly Counter<long> _mirrorLeaseLosses;
+    private readonly ObservableGauge<long> _mirrorCacheBytes;
+    private long _extractionQueueDepthValue;
+    private long _mirrorCacheBytesValue;
 
     public OperationalMetrics()
     {
@@ -29,12 +36,19 @@ public sealed class OperationalMetrics : IDisposable
         _extractionClaimMilliseconds = _meter.CreateHistogram<long>("terraform_registry.extraction.claim_latency_ms");
         _extractionAttempts = _meter.CreateCounter<long>("terraform_registry.extraction.attempts");
         _extractionFailures = _meter.CreateCounter<long>("terraform_registry.extraction.failures");
+        _extractionQueueDepth = _meter.CreateObservableGauge<long>("terraform_registry.extraction.queue_depth",
+            () => Volatile.Read(ref _extractionQueueDepthValue));
         _publicationAttempts = _meter.CreateCounter<long>("terraform_registry.publication.attempts");
         _publicationConflicts = _meter.CreateCounter<long>("terraform_registry.publication.conflicts");
         _authenticationDecisions = _meter.CreateCounter<long>("terraform_registry.authentication.decisions");
         _mirrorActiveDownloads = _meter.CreateUpDownCounter<long>("terraform_registry.mirror.active_downloads");
         _mirrorAdmissionRejections = _meter.CreateCounter<long>("terraform_registry.mirror.admission_rejections");
         _mirrorEvictions = _meter.CreateCounter<long>("terraform_registry.mirror.evictions");
+        _mirrorUpstreamRequests = _meter.CreateCounter<long>("terraform_registry.mirror.upstream_requests");
+        _mirrorNegativeCacheHits = _meter.CreateCounter<long>("terraform_registry.mirror.negative_cache_hits");
+        _mirrorLeaseLosses = _meter.CreateCounter<long>("terraform_registry.mirror.lease_losses");
+        _mirrorCacheBytes = _meter.CreateObservableGauge<long>("terraform_registry.mirror.cache_bytes",
+            () => Volatile.Read(ref _mirrorCacheBytesValue));
     }
 
     public void RecordOutboxClaim(DateTime createdAt) =>
@@ -45,6 +59,7 @@ public sealed class OperationalMetrics : IDisposable
         _extractionClaimMilliseconds.Record(Math.Max(0, (long)(DateTime.UtcNow - createdAt).TotalMilliseconds));
     public void RecordExtractionAttempt() => _extractionAttempts.Add(1);
     public void RecordExtractionFailure(string outcome) => _extractionFailures.Add(1, Outcome(outcome));
+    public void RecordExtractionQueueDepth(int depth) => Interlocked.Exchange(ref _extractionQueueDepthValue, Math.Max(0, depth));
     public void RecordPublicationAttempt() => _publicationAttempts.Add(1);
     public void RecordPublicationConflict() => _publicationConflicts.Add(1);
     public void RecordAuthenticationDecision(string decision) => _authenticationDecisions.Add(1, Outcome(decision));
@@ -55,7 +70,12 @@ public sealed class OperationalMetrics : IDisposable
     }
     public void RecordMirrorRelease() => _mirrorActiveDownloads.Add(-1);
     public void RecordMirrorEviction(string kind) => _mirrorEvictions.Add(1, Outcome(kind));
+    public void RecordMirrorUpstreamRequest(string kind) => _mirrorUpstreamRequests.Add(1, Kind(kind));
+    public void RecordMirrorNegativeCacheHit(string kind) => _mirrorNegativeCacheHits.Add(1, Kind(kind));
+    public void RecordMirrorLeaseLoss(string kind) => _mirrorLeaseLosses.Add(1, Kind(kind));
+    public void RecordMirrorCacheBytes(long bytes) => Interlocked.Exchange(ref _mirrorCacheBytesValue, Math.Max(0, bytes));
     public void Dispose() => _meter.Dispose();
 
     private static KeyValuePair<string, object?> Outcome(string value) => new("outcome", value);
+    private static KeyValuePair<string, object?> Kind(string value) => new("kind", value);
 }

--- a/TerraformRegistry/Services/SqliteDatabaseService.cs
+++ b/TerraformRegistry/Services/SqliteDatabaseService.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 using TerraformRegistry.API.Interfaces;
+using TerraformRegistry.API.Telemetry;
 using TerraformRegistry.Migrations;
 using TerraformRegistry.Models;
 using TerraformRegistry.Services.Sqlite;
@@ -77,8 +79,13 @@ public class SqliteDatabaseService : IDatabaseService, IModulePublicationReposit
     public Task<int> CountPendingExtractionJobsAsync(CancellationToken cancellationToken = default) =>
         _publications.CountPendingExtractionJobsAsync(cancellationToken);
 
-    public Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default) =>
-        _modules.ListModulesAsync(request, cancellationToken);
+    public async Task<ModuleList> ListModulesAsync(ModuleSearchRequest request, CancellationToken cancellationToken = default)
+    {
+        var startedAt = Stopwatch.GetTimestamp();
+        var page = await _modules.ListModulesAsync(request, cancellationToken);
+        OperationalDatabaseMetrics.RecordModulePage("sqlite", Stopwatch.GetElapsedTime(startedAt), page.Modules.Count);
+        return page;
+    }
 
     public Task<TerraformModule?> GetModuleAsync(string moduleNamespace, string name, string provider, string version,
         CancellationToken cancellationToken = default) =>


### PR DESCRIPTION
## Summary
- add bounded metrics for extraction depth, authentication outcomes, mirror upstream/cache/lease activity, and paginated module queries
- wire observations to the real SQLite/PostgreSQL list, extraction, API-key/authentication, and mirror paths
- add MeterListener coverage for observable gauges, bounded tags, and database pagination measurements

## Verification
- `DOTNET_ROOT=$HOME/.cache/terraform-registry-dotnet PATH=$HOME/.cache/terraform-registry-dotnet:$PATH dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --filter FullyQualifiedName~OperationalMetricsTests --logger "console;verbosity=minimal"` (3 passed)