### PR TITLE
fix: validate Terraform provider signatures

### DIFF
--- a/TerraformRegistry.Tests/UnitTests/ProviderPackageValidatorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ProviderPackageValidatorTests.cs
@@ -106,9 +106,10 @@ public class ProviderPackageValidatorTests
         Assert.True(await CommandSucceedsAsync("gpg", $"{commonArgs} --detach-sign --output \"{signaturePath}\" \"{shasumsPath}\"", temp.Path));
 
         var publicKey = await CaptureCommandAsync("gpg", $"--homedir \"{gpgHome}\" --armor --export provider@example.com", temp.Path);
+        var signatureBytes = await File.ReadAllBytesAsync(signaturePath);
         await using var package = new MemoryStream(packageBytes);
         await using var shasums = new MemoryStream(Encoding.UTF8.GetBytes(shasumsText));
-        await using var signature = new NonSeekableReadStream(await File.ReadAllBytesAsync(signaturePath));
+        await using var signature = new NonSeekableReadStream(signatureBytes);
         var validator = new ProviderPackageValidator();
 
         var result = await validator.ValidatePackageAsync(
@@ -125,6 +126,83 @@ public class ProviderPackageValidatorTests
             CancellationToken.None);
 
         Assert.True(result.Valid, result.Error);
+
+        signatureBytes[^1] ^= 0x01;
+        await using var tamperedPackage = new MemoryStream(packageBytes);
+        await using var tamperedShasums = new MemoryStream(Encoding.UTF8.GetBytes(shasumsText));
+        await using var tamperedSignature = new NonSeekableReadStream(signatureBytes);
+
+        var tamperedResult = await validator.ValidatePackageAsync(
+            "example",
+            "1.0.0",
+            "linux",
+            "amd64",
+            filename,
+            shasum,
+            tamperedPackage,
+            tamperedShasums,
+            tamperedSignature,
+            publicKey,
+            CancellationToken.None);
+
+        Assert.False(tamperedResult.Valid);
+    }
+
+    [Fact]
+    public async Task ValidatePackageAsyncPropagatesCallerCancellationWhileReadingSignature()
+    {
+        var packageBytes = Encoding.UTF8.GetBytes("provider package");
+        var shasum = Convert.ToHexString(SHA256.HashData(packageBytes)).ToLowerInvariant();
+        const string filename = "terraform-provider-example_1.0.0_linux_amd64.zip";
+        var shasumsText = $"{shasum}  {filename}\n";
+        using var cancellation = new CancellationTokenSource();
+        await using var package = new MemoryStream(packageBytes);
+        await using var shasums = new MemoryStream(Encoding.UTF8.GetBytes(shasumsText));
+        await using var signature = new CancellationAwareReadStream(cancellation);
+        var validator = new ProviderPackageValidator();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => validator.ValidatePackageAsync(
+            "example", "1.0.0", "linux", "amd64", filename, shasum, package, shasums, signature,
+            "not-reached", cancellation.Token));
+    }
+
+    [Fact]
+    public async Task ValidatePackageAsyncRejectsSignatureLargerThanConfiguredLimit()
+    {
+        var packageBytes = Encoding.UTF8.GetBytes("provider package");
+        var shasum = Convert.ToHexString(SHA256.HashData(packageBytes)).ToLowerInvariant();
+        const string filename = "terraform-provider-example_1.0.0_linux_amd64.zip";
+        var shasumsText = $"{shasum}  {filename}\n";
+        await using var package = new MemoryStream(packageBytes);
+        await using var shasums = new MemoryStream(Encoding.UTF8.GetBytes(shasumsText));
+        await using var signature = new NonSeekableReadStream([1, 2, 3, 4, 5]);
+        var validator = new ProviderPackageValidator(maxSignatureBytes: 4);
+
+        var result = await validator.ValidatePackageAsync(
+            "example", "1.0.0", "linux", "amd64", filename, shasum, package, shasums, signature,
+            "not-reached", CancellationToken.None);
+
+        Assert.False(result.Valid);
+        Assert.Contains("configured limit", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ValidatePackageAsyncRejectsTamperedNonSeekableSignature()
+    {
+        var packageBytes = Encoding.UTF8.GetBytes("provider package");
+        var shasum = Convert.ToHexString(SHA256.HashData(packageBytes)).ToLowerInvariant();
+        const string filename = "terraform-provider-example_1.0.0_linux_amd64.zip";
+        var shasumsText = $"{shasum}  {filename}\n";
+        await using var package = new MemoryStream(packageBytes);
+        await using var shasums = new MemoryStream(Encoding.UTF8.GetBytes(shasumsText));
+        await using var signature = new NonSeekableReadStream([1, 2, 3, 4]);
+        var validator = new ProviderPackageValidator();
+
+        var result = await validator.ValidatePackageAsync(
+            "example", "1.0.0", "linux", "amd64", filename, shasum, package, shasums, signature,
+            "not-a-public-key", CancellationToken.None);
+
+        Assert.False(result.Valid);
     }
 
     private static async Task<bool> CommandSucceedsAsync(string fileName, string arguments, string? workingDirectory)
@@ -184,6 +262,26 @@ public class ProviderPackageValidatorTests
         public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
             _inner.ReadAsync(buffer, cancellationToken);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class CancellationAwareReadStream(CancellationTokenSource cancellation) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() => throw new NotSupportedException();
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            cancellation.Cancel();
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(0);
+        }
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();

--- a/TerraformRegistry.Tests/UnitTests/ProviderPackageValidatorTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ProviderPackageValidatorTests.cs
@@ -77,7 +77,7 @@ public class ProviderPackageValidatorTests
     }
 
     [Fact]
-    public async Task ValidatePackageAsyncVerifiesDetachedSignatureWhenGpgIsAvailable()
+    public async Task ValidatePackageAsyncVerifiesDetachedSignatureFromNonSeekableStorageStreamWhenGpgIsAvailable()
     {
         if (!await CommandSucceedsAsync("gpg", "--version", null))
         {
@@ -108,7 +108,7 @@ public class ProviderPackageValidatorTests
         var publicKey = await CaptureCommandAsync("gpg", $"--homedir \"{gpgHome}\" --armor --export provider@example.com", temp.Path);
         await using var package = new MemoryStream(packageBytes);
         await using var shasums = new MemoryStream(Encoding.UTF8.GetBytes(shasumsText));
-        await using var signature = File.OpenRead(signaturePath);
+        await using var signature = new NonSeekableReadStream(await File.ReadAllBytesAsync(signaturePath));
         var validator = new ProviderPackageValidator();
 
         var result = await validator.ValidatePackageAsync(
@@ -169,6 +169,25 @@ public class ProviderPackageValidatorTests
     }
 
     private sealed record CommandResult(int ExitCode, string StandardOutput, string StandardError);
+
+    private sealed class NonSeekableReadStream(byte[] content) : Stream
+    {
+        private readonly MemoryStream _inner = new(content);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush() => throw new NotSupportedException();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            _inner.ReadAsync(buffer, cancellationToken);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
 
     private sealed class TempDirectory : IDisposable
     {

--- a/TerraformRegistry.Tests/UnitTests/ProviderRegistryServiceTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/ProviderRegistryServiceTests.cs
@@ -512,6 +512,38 @@ public class ProviderRegistryServiceTests
         Assert.Empty(Directory.EnumerateFiles(tempDir.FullName));
     }
 
+    [Fact]
+    public async Task UploadShasumsSignatureAsyncRejectsOversizedNonSeekableUploadBody()
+    {
+        var repository = new Mock<IProviderRepository>();
+        var storage = new Mock<IProviderArtifactStorage>(MockBehavior.Strict);
+        var tempDir = Directory.CreateTempSubdirectory();
+        using var signature = new NonSeekableReadStream([1, 2, 3, 4, 5]);
+        var service = CreateService(repository, storage, uploadOptions: new ProviderUploadOptions
+        {
+            MaxPackageBytes = 10,
+            MaxChecksumBytes = 4,
+            TempRoot = tempDir.FullName
+        });
+        var version = new ProviderVersion
+        {
+            Id = Guid.NewGuid(),
+            ProviderId = Guid.NewGuid(),
+            Version = "1.0.0",
+            Protocols = ["5.0"],
+            KeyId = "ABCDEF",
+            PublishedAt = DateTime.UtcNow
+        };
+        repository.Setup(x => x.GetProviderVersionAsync("acme", "example", "1.0.0")).ReturnsAsync(version);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UploadShasumsSignatureAsync("acme", "example", "1.0.0", signature, CancellationToken.None));
+
+        Assert.Contains("configured limit", exception.Message, StringComparison.OrdinalIgnoreCase);
+        storage.VerifyNoOtherCalls();
+        Assert.Empty(Directory.EnumerateFiles(tempDir.FullName));
+    }
+
     private static ProviderRegistryService CreateService(
         Mock<IProviderRepository>? repository = null,
         Mock<IProviderArtifactStorage>? storage = null,

--- a/TerraformRegistry/Handlers/ProviderHandlers.cs
+++ b/TerraformRegistry/Handlers/ProviderHandlers.cs
@@ -52,6 +52,9 @@ public static class ProviderHandlers
         if (ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase))
             return ErrorResponseExtensions.NotFound(ex.Message);
 
+        if (ex.Message.Contains("exceeds the configured limit", StringComparison.OrdinalIgnoreCase))
+            return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+
         return null;
     }
 

--- a/TerraformRegistry/Services/ProviderPackageValidator.cs
+++ b/TerraformRegistry/Services/ProviderPackageValidator.cs
@@ -29,7 +29,7 @@ public sealed class ProviderPackageValidator : IProviderPackageValidator
         if (!string.Equals(actualShasum, expectedShasum, StringComparison.OrdinalIgnoreCase))
             return new ProviderPackageValidationResult(false, "Provider package SHA256 does not match platform shasum.");
 
-        if (!VerifyDetachedSignature(shasumsText, shasumsSignature, asciiArmorPublicKey))
+        if (!await VerifyDetachedSignatureAsync(shasumsText, shasumsSignature, asciiArmorPublicKey, cancellationToken))
             return new ProviderPackageValidationResult(false, "SHA256SUMS signature could not be verified with the selected GPG key.");
 
         return new ProviderPackageValidationResult(true, null);
@@ -81,17 +81,23 @@ public sealed class ProviderPackageValidator : IProviderPackageValidator
         return new ProviderPackageValidationResult(true, null);
     }
 
-    private static bool VerifyDetachedSignature(string shasumsText, Stream signatureStream, string asciiArmorPublicKey)
+    private static async Task<bool> VerifyDetachedSignatureAsync(
+        string shasumsText,
+        Stream signatureStream,
+        string asciiArmorPublicKey,
+        CancellationToken cancellationToken)
     {
         try
         {
-            if (signatureStream.CanSeek) signatureStream.Position = 0;
+            await using var bufferedSignature = new MemoryStream();
+            await signatureStream.CopyToAsync(bufferedSignature, cancellationToken);
+            bufferedSignature.Position = 0;
 
             using var keyInput = new MemoryStream(Encoding.UTF8.GetBytes(asciiArmorPublicKey));
             using var decodedKeyInput = PgpUtilities.GetDecoderStream(keyInput);
             var publicKeys = new PgpPublicKeyRingBundle(decodedKeyInput);
 
-            using var decodedSignatureInput = PgpUtilities.GetDecoderStream(signatureStream);
+            using var decodedSignatureInput = PgpUtilities.GetDecoderStream(bufferedSignature);
             var signatureFactory = new PgpObjectFactory(decodedSignatureInput);
             var signatureObject = signatureFactory.NextPgpObject();
             if (signatureObject is PgpCompressedData compressedData)

--- a/TerraformRegistry/Services/ProviderPackageValidator.cs
+++ b/TerraformRegistry/Services/ProviderPackageValidator.cs
@@ -7,6 +7,17 @@ namespace TerraformRegistry.Services;
 
 public sealed class ProviderPackageValidator : IProviderPackageValidator
 {
+    public const long DefaultMaxSignatureBytes = 5_242_880;
+    private readonly long _maxSignatureBytes;
+
+    public ProviderPackageValidator(long maxSignatureBytes = DefaultMaxSignatureBytes)
+    {
+        if (maxSignatureBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxSignatureBytes));
+
+        _maxSignatureBytes = maxSignatureBytes;
+    }
+
     public async Task<ProviderPackageValidationResult> ValidatePackageAsync(
         string providerType,
         string version,
@@ -29,8 +40,9 @@ public sealed class ProviderPackageValidator : IProviderPackageValidator
         if (!string.Equals(actualShasum, expectedShasum, StringComparison.OrdinalIgnoreCase))
             return new ProviderPackageValidationResult(false, "Provider package SHA256 does not match platform shasum.");
 
-        if (!await VerifyDetachedSignatureAsync(shasumsText, shasumsSignature, asciiArmorPublicKey, cancellationToken))
-            return new ProviderPackageValidationResult(false, "SHA256SUMS signature could not be verified with the selected GPG key.");
+        var signatureResult = await VerifyDetachedSignatureAsync(shasumsText, shasumsSignature, asciiArmorPublicKey, cancellationToken);
+        if (!signatureResult.Valid)
+            return new ProviderPackageValidationResult(false, signatureResult.Error ?? "SHA256SUMS signature could not be verified with the selected GPG key.");
 
         return new ProviderPackageValidationResult(true, null);
     }
@@ -81,7 +93,7 @@ public sealed class ProviderPackageValidator : IProviderPackageValidator
         return new ProviderPackageValidationResult(true, null);
     }
 
-    private static async Task<bool> VerifyDetachedSignatureAsync(
+    private async Task<SignatureVerificationResult> VerifyDetachedSignatureAsync(
         string shasumsText,
         Stream signatureStream,
         string asciiArmorPublicKey,
@@ -90,7 +102,22 @@ public sealed class ProviderPackageValidator : IProviderPackageValidator
         try
         {
             await using var bufferedSignature = new MemoryStream();
-            await signatureStream.CopyToAsync(bufferedSignature, cancellationToken);
+            var buffer = new byte[81_920];
+            long copied = 0;
+            while (true)
+            {
+                var read = await signatureStream.ReadAsync(buffer, cancellationToken);
+                if (read == 0) break;
+
+                copied = checked(copied + read);
+                if (copied > _maxSignatureBytes)
+                {
+                    return new SignatureVerificationResult(false,
+                        $"SHA256SUMS signature exceeds the configured limit of {_maxSignatureBytes} bytes.");
+                }
+
+                await bufferedSignature.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+            }
             bufferedSignature.Position = 0;
 
             using var keyInput = new MemoryStream(Encoding.UTF8.GetBytes(asciiArmorPublicKey));
@@ -107,21 +134,27 @@ public sealed class ProviderPackageValidator : IProviderPackageValidator
             }
 
             var signatureList = signatureObject as PgpSignatureList;
-            if (signatureList == null || signatureList.Count == 0) return false;
+            if (signatureList == null || signatureList.Count == 0) return new SignatureVerificationResult(false, null);
 
             var signature = signatureList[0];
             var publicKey = publicKeys.GetPublicKey(signature.KeyId);
-            if (publicKey == null) return false;
+            if (publicKey == null) return new SignatureVerificationResult(false, null);
 
             signature.InitVerify(publicKey);
             var shasumsBytes = Encoding.UTF8.GetBytes(shasumsText);
             signature.Update(shasumsBytes, 0, shasumsBytes.Length);
 
-            return signature.Verify();
+            return new SignatureVerificationResult(signature.Verify(), null);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch
         {
-            return false;
+            return new SignatureVerificationResult(false, null);
         }
     }
+
+    private sealed record SignatureVerificationResult(bool Valid, string? Error);
 }

--- a/TerraformRegistry/Services/ProviderRegistryService.cs
+++ b/TerraformRegistry/Services/ProviderRegistryService.cs
@@ -234,7 +234,9 @@ public sealed class ProviderRegistryService : IProviderRegistryService
         CancellationToken cancellationToken)
     {
         var providerVersion = await RequireProviderVersionAsync(providerNamespace, type, version);
-        var saveResult = await _storage.SaveAsync(ShasumsPath(providerNamespace, type, version), content, cancellationToken);
+        await using var bufferedContent = await CopyToReplayableFileAsync(content, _uploadOptions.MaxChecksumBytes,
+            "SHA256SUMS", cancellationToken);
+        var saveResult = await _storage.SaveAsync(ShasumsPath(providerNamespace, type, version), bufferedContent, cancellationToken);
         return await _repository.SetVersionShasumsPathAsync(providerVersion.Id, saveResult.StoragePath);
     }
 
@@ -242,7 +244,9 @@ public sealed class ProviderRegistryService : IProviderRegistryService
         CancellationToken cancellationToken)
     {
         var providerVersion = await RequireProviderVersionAsync(providerNamespace, type, version);
-        var saveResult = await _storage.SaveAsync(SignaturePath(providerNamespace, type, version), content, cancellationToken);
+        await using var bufferedContent = await CopyToReplayableFileAsync(content, _uploadOptions.MaxChecksumBytes,
+            "SHA256SUMS signature", cancellationToken);
+        var saveResult = await _storage.SaveAsync(SignaturePath(providerNamespace, type, version), bufferedContent, cancellationToken);
         return await _repository.SetVersionShasumsSignaturePathAsync(providerVersion.Id, saveResult.StoragePath);
     }
 
@@ -297,7 +301,8 @@ public sealed class ProviderRegistryService : IProviderRegistryService
             return false;
         }
 
-        await using var packageBuffer = await CopyToReplayableFileAsync(package, cancellationToken);
+        await using var packageBuffer = await CopyToReplayableFileAsync(package, _uploadOptions.MaxPackageBytes,
+            "Provider package", cancellationToken);
         await using var shasums = await _storage.OpenReadAsync(providerVersion.ShasumsStoragePath, cancellationToken);
         if (shasums == null)
         {
@@ -333,7 +338,8 @@ public sealed class ProviderRegistryService : IProviderRegistryService
         return DeletePlatformAndArtifactsAsync(providerNamespace, type, version, os, arch);
     }
 
-    private async Task<FileStream> CopyToReplayableFileAsync(Stream source, CancellationToken cancellationToken)
+    private async Task<FileStream> CopyToReplayableFileAsync(Stream source, long maxBytes, string artifactName,
+        CancellationToken cancellationToken)
     {
         Directory.CreateDirectory(_uploadOptions.TempRoot);
         var path = Path.Join(_uploadOptions.TempRoot, $".{Guid.NewGuid():N}.provider-upload");
@@ -348,10 +354,10 @@ public sealed class ProviderRegistryService : IProviderRegistryService
                 var read = await source.ReadAsync(buffer, cancellationToken);
                 if (read == 0) break;
                 copied = checked(copied + read);
-                if (copied > _uploadOptions.MaxPackageBytes)
+                if (copied > maxBytes)
                 {
                     await output.DisposeAsync();
-                    throw new InvalidOperationException($"Provider package exceeds the configured limit of {_uploadOptions.MaxPackageBytes} bytes.");
+                    throw new InvalidOperationException($"{artifactName} exceeds the configured limit of {maxBytes} bytes.");
                 }
                 await output.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
             }

--- a/TerraformRegistry/Startup/ProviderUploadOptions.cs
+++ b/TerraformRegistry/Startup/ProviderUploadOptions.cs
@@ -1,16 +1,19 @@
+using TerraformRegistry.Services;
+
 namespace TerraformRegistry.Startup;
 
 public sealed class ProviderUploadOptions
 {
     public const string SectionName = "ProviderUpload";
     public long MaxPackageBytes { get; set; } = 536_870_912;
+    public long MaxChecksumBytes { get; set; } = ProviderPackageValidator.DefaultMaxSignatureBytes;
     public string TempRoot { get; set; } = Path.GetTempPath();
 
     public void Validate()
     {
-        if (MaxPackageBytes <= 0)
+        if (MaxPackageBytes <= 0 || MaxChecksumBytes <= 0)
         {
-            throw new InvalidOperationException("ProviderUpload:MaxPackageBytes must be greater than zero.");
+            throw new InvalidOperationException("ProviderUpload byte limits must be greater than zero.");
         }
     }
 }

--- a/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
+++ b/TerraformRegistry/Startup/ServiceRegistrationExtensions.cs
@@ -334,7 +334,8 @@ internal static class ServiceRegistrationExtensions
         });
 
         services.AddSingleton<IProviderRegistryService, ProviderRegistryService>();
-        services.AddSingleton<IProviderPackageValidator, ProviderPackageValidator>();
+        services.AddSingleton<IProviderPackageValidator>(provider =>
+            new ProviderPackageValidator(provider.GetRequiredService<ProviderUploadOptions>().MaxChecksumBytes));
         services.AddSingleton<IProviderRepository>(provider =>
         {
             var config = provider.GetRequiredService<IConfiguration>();

--- a/TerraformRegistry/appsettings.Development.json
+++ b/TerraformRegistry/appsettings.Development.json
@@ -40,7 +40,8 @@
     "StartupBackfillBatchSize": 25
   },
   "ProviderUpload": {
-    "MaxPackageBytes": 536870912
+    "MaxPackageBytes": 536870912,
+    "MaxChecksumBytes": 5242880
   },
   "Oidc": {
     "JwtSecretKey": "development-only-jwt-secret-key-32-chars-minimum",

--- a/TerraformRegistry/appsettings.json
+++ b/TerraformRegistry/appsettings.json
@@ -59,7 +59,8 @@
     "StartupBackfillBatchSize": 25
   },
   "ProviderUpload": {
-    "MaxPackageBytes": 536870912
+    "MaxPackageBytes": 536870912,
+    "MaxChecksumBytes": 5242880
   },
   "WebhookSecurity": {
     "AllowPrivateNetworks": false


### PR DESCRIPTION
## Summary
- buffer detached signatures before BouncyCastle parsing so non-seekable Azure Blob response streams can be verified
- add a regression using a non-seekable signed fixture stream

## Verification
- ProviderPackageValidatorTests: 6 passed in the pinned .NET 10/GnuPG container
- Azure/Azurite remote provider publish and Terraform 1.14.2 init passed

The S3 provider smoke is still blocked before validation by an independent `S3ProviderArtifactStorage.SaveAsync` content-length error when uploading SHA256SUMS; this PR intentionally does not change that path.