### PR TITLE
fix: stream provider artifacts to S3

### DIFF
--- a/TerraformRegistry.API/Interfaces/IProviderArtifactStorage.cs
+++ b/TerraformRegistry.API/Interfaces/IProviderArtifactStorage.cs
@@ -3,6 +3,11 @@ namespace TerraformRegistry.API.Interfaces;
 public interface IProviderArtifactStorage
 {
     Task<ProviderArtifactSaveResult> SaveAsync(string relativePath, Stream content, CancellationToken cancellationToken);
+    Task<ProviderArtifactSaveResult> SaveAsync(
+        string relativePath,
+        Stream content,
+        long contentLength,
+        CancellationToken cancellationToken) => SaveAsync(relativePath, content, cancellationToken);
     Task<string> CreateDownloadUrlAsync(string storagePath, CancellationToken cancellationToken);
     Task<Stream?> OpenReadAsync(string storagePath, CancellationToken cancellationToken);
     Task<bool> ExistsAsync(string storagePath, CancellationToken cancellationToken);

--- a/TerraformRegistry.API/Interfaces/IProviderRegistryService.cs
+++ b/TerraformRegistry.API/Interfaces/IProviderRegistryService.cs
@@ -23,7 +23,21 @@ public interface IProviderRegistryService
 
     Task<ProviderVersion> CreateVersionAsync(string providerNamespace, string type, CreateProviderVersionRequest request);
     Task<bool> UploadShasumsAsync(string providerNamespace, string type, string version, Stream content, CancellationToken cancellationToken);
+    Task<bool> UploadShasumsAsync(
+        string providerNamespace,
+        string type,
+        string version,
+        Stream content,
+        long contentLength,
+        CancellationToken cancellationToken) => UploadShasumsAsync(providerNamespace, type, version, content, cancellationToken);
     Task<bool> UploadShasumsSignatureAsync(string providerNamespace, string type, string version, Stream content, CancellationToken cancellationToken);
+    Task<bool> UploadShasumsSignatureAsync(
+        string providerNamespace,
+        string type,
+        string version,
+        Stream content,
+        long contentLength,
+        CancellationToken cancellationToken) => UploadShasumsSignatureAsync(providerNamespace, type, version, content, cancellationToken);
     Task<bool> DeleteVersionAsync(string providerNamespace, string type, string version);
 
     Task<ProviderPlatform> CreatePlatformAsync(string providerNamespace, string type, string version, CreateProviderPlatformRequest request);

--- a/TerraformRegistry.S3/S3ProviderArtifactStorage.cs
+++ b/TerraformRegistry.S3/S3ProviderArtifactStorage.cs
@@ -80,6 +80,19 @@ public sealed partial class S3ProviderArtifactStorage : IProviderArtifactStorage
     public async Task<ProviderArtifactSaveResult> SaveAsync(string relativePath, Stream content,
         CancellationToken cancellationToken)
     {
+        if (!content.CanSeek)
+        {
+            throw new InvalidOperationException("S3 provider artifact uploads require a known content length.");
+        }
+
+        return await SaveAsync(relativePath, content, content.Length - content.Position, cancellationToken);
+    }
+
+    public async Task<ProviderArtifactSaveResult> SaveAsync(string relativePath, Stream content, long contentLength,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(contentLength);
+
         var objectKey = GetObjectKey(relativePath);
 
         await _s3Client.PutObjectAsync(new PutObjectRequest
@@ -87,7 +100,9 @@ public sealed partial class S3ProviderArtifactStorage : IProviderArtifactStorage
             BucketName = _bucketName,
             Key = objectKey,
             InputStream = content,
-            AutoCloseStream = false
+            AutoCloseStream = false,
+            AutoResetStreamPosition = false,
+            Headers = { ContentLength = contentLength }
         }, cancellationToken);
 
         var metadata = await _s3Client.GetObjectMetadataAsync(new GetObjectMetadataRequest

--- a/TerraformRegistry.Tests/IntegrationTests/ProviderManagementApiTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/ProviderManagementApiTests.cs
@@ -308,6 +308,30 @@ public class ProviderManagementApiTests(ITestOutputHelper output) : IntegrationT
         Assert.Equal(HttpStatusCode.NoContent, signatureResponse.StatusCode);
     }
 
+    [Theory]
+    [InlineData("shasums")]
+    [InlineData("shasums.sig")]
+    public async Task UploadProviderSidecarWithoutContentLengthReturnsLengthRequired(string sidecar)
+    {
+        var client = await CreatePublisherClientAsync("provider-length-required@example.com", "provider-length-required");
+        var ns = NewNamespace();
+        await CreateProviderVersionAsync(client, ns);
+
+        await using var body = new NonSeekableReadStream([1, 2, 3]);
+        using var request = new HttpRequestMessage(
+            HttpMethod.Put,
+            $"/api/providers/{ns}/example/versions/1.0.0/{sidecar}")
+        {
+            Content = new StreamContent(body)
+        };
+
+        Assert.Null(request.Content.Headers.ContentLength);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.LengthRequired, response.StatusCode);
+    }
+
     [Fact]
     public async Task UpdateAndDeleteProviderEnforcesDedicatedPermissions()
     {
@@ -409,4 +433,28 @@ public class ProviderManagementApiTests(ITestOutputHelper output) : IntegrationT
     };
 
     private static string NewNamespace() => $"acme{Guid.NewGuid():N}";
+
+    private sealed class NonSeekableReadStream(byte[] bytes) : Stream
+    {
+        private readonly MemoryStream _inner = new(bytes);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => throw new NotSupportedException();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override int Read(Span<byte> buffer) => _inner.Read(buffer);
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            _inner.ReadAsync(buffer, cancellationToken);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
 }

--- a/TerraformRegistry.Tests/IntegrationTests/ProviderManagementApiTests.cs
+++ b/TerraformRegistry.Tests/IntegrationTests/ProviderManagementApiTests.cs
@@ -326,6 +326,7 @@ public class ProviderManagementApiTests(ITestOutputHelper output) : IntegrationT
         };
 
         Assert.Null(request.Content.Headers.ContentLength);
+        request.Headers.TransferEncodingChunked = true;
 
         var response = await client.SendAsync(request);
 

--- a/TerraformRegistry.Tests/UnitTests/S3/S3ProviderArtifactStorageTests.cs
+++ b/TerraformRegistry.Tests/UnitTests/S3/S3ProviderArtifactStorageTests.cs
@@ -41,6 +41,32 @@ public class S3ProviderArtifactStorageTests
     }
 
     [Fact]
+    public async Task SaveAsyncSetsContentLengthForNonSeekableRequestStream()
+    {
+        PutObjectRequest? capturedRequest = null;
+        _s3Client
+            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PutObjectRequest, CancellationToken>((request, _) => capturedRequest = request)
+            .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK });
+        _s3Client
+            .Setup(x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetObjectMetadataResponse { ContentLength = 3 });
+
+        var storage = CreateStorage();
+        await using var content = new NonSeekableReadStream([1, 2, 3]);
+
+        await storage.SaveAsync(
+            "acme/example/1.0.0/terraform-provider-example_1.0.0_SHA256SUMS",
+            content,
+            contentLength: 3,
+            CancellationToken.None);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(3, capturedRequest!.Headers.ContentLength);
+        Assert.False(capturedRequest.AutoResetStreamPosition);
+    }
+
+    [Fact]
     public async Task CreateDownloadUrlAsyncReturnsPresignedUrlForStoredArtifact()
     {
         const string expectedUrl = "https://example.invalid/provider.zip";
@@ -268,5 +294,29 @@ public class S3ProviderArtifactStorageTests
                 ["S3:PresignedUrlExpiryMinutes"] = "17"
             })
             .Build();
+    }
+
+    private sealed class NonSeekableReadStream(byte[] bytes) : Stream
+    {
+        private readonly MemoryStream _inner = new(bytes);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => throw new NotSupportedException();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override int Read(Span<byte> buffer) => _inner.Read(buffer);
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            _inner.ReadAsync(buffer, cancellationToken);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 }

--- a/TerraformRegistry/Handlers/ProviderHandlers.cs
+++ b/TerraformRegistry/Handlers/ProviderHandlers.cs
@@ -367,10 +367,12 @@ public static class ProviderHandlers
         if (denied != null) return denied;
 
         if (request.ContentLength == 0) return ErrorResponseExtensions.BadRequest("SHA256SUMS content is required.");
+        if (request.ContentLength is null) return Results.StatusCode(StatusCodes.Status411LengthRequired);
 
         try
         {
-            var uploaded = await providerService.UploadShasumsAsync(@namespace, type, version, request.Body, context.RequestAborted);
+            var uploaded = await providerService.UploadShasumsAsync(
+                @namespace, type, version, request.Body, request.ContentLength.Value, context.RequestAborted);
             return uploaded ? Results.NoContent() : ErrorResponseExtensions.NotFound("Provider version not found");
         }
         catch (ArgumentException ex)
@@ -395,10 +397,12 @@ public static class ProviderHandlers
         if (denied != null) return denied;
 
         if (request.ContentLength == 0) return ErrorResponseExtensions.BadRequest("SHA256SUMS signature content is required.");
+        if (request.ContentLength is null) return Results.StatusCode(StatusCodes.Status411LengthRequired);
 
         try
         {
-            var uploaded = await providerService.UploadShasumsSignatureAsync(@namespace, type, version, request.Body, context.RequestAborted);
+            var uploaded = await providerService.UploadShasumsSignatureAsync(
+                @namespace, type, version, request.Body, request.ContentLength.Value, context.RequestAborted);
             return uploaded ? Results.NoContent() : ErrorResponseExtensions.NotFound("Provider version not found");
         }
         catch (ArgumentException ex)

--- a/TerraformRegistry/Services/ProviderRegistryService.cs
+++ b/TerraformRegistry/Services/ProviderRegistryService.cs
@@ -240,6 +240,15 @@ public sealed class ProviderRegistryService : IProviderRegistryService
         return await _repository.SetVersionShasumsPathAsync(providerVersion.Id, saveResult.StoragePath);
     }
 
+    public async Task<bool> UploadShasumsAsync(string providerNamespace, string type, string version, Stream content,
+        long contentLength, CancellationToken cancellationToken)
+    {
+        var providerVersion = await RequireProviderVersionAsync(providerNamespace, type, version);
+        var saveResult = await _storage.SaveAsync(
+            ShasumsPath(providerNamespace, type, version), content, contentLength, cancellationToken);
+        return await _repository.SetVersionShasumsPathAsync(providerVersion.Id, saveResult.StoragePath);
+    }
+
     public async Task<bool> UploadShasumsSignatureAsync(string providerNamespace, string type, string version, Stream content,
         CancellationToken cancellationToken)
     {
@@ -247,6 +256,15 @@ public sealed class ProviderRegistryService : IProviderRegistryService
         await using var bufferedContent = await CopyToReplayableFileAsync(content, _uploadOptions.MaxChecksumBytes,
             "SHA256SUMS signature", cancellationToken);
         var saveResult = await _storage.SaveAsync(SignaturePath(providerNamespace, type, version), bufferedContent, cancellationToken);
+        return await _repository.SetVersionShasumsSignaturePathAsync(providerVersion.Id, saveResult.StoragePath);
+    }
+
+    public async Task<bool> UploadShasumsSignatureAsync(string providerNamespace, string type, string version, Stream content,
+        long contentLength, CancellationToken cancellationToken)
+    {
+        var providerVersion = await RequireProviderVersionAsync(providerNamespace, type, version);
+        var saveResult = await _storage.SaveAsync(
+            SignaturePath(providerNamespace, type, version), content, contentLength, cancellationToken);
         return await _repository.SetVersionShasumsSignaturePathAsync(providerVersion.Id, saveResult.StoragePath);
     }
 

--- a/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
+++ b/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
@@ -27,6 +27,54 @@ project_for() {
   printf 'tfregstorage%s' "$(printf '%s' "$1" | sha256sum | cut -c1-12)"
 }
 
+run_s3_provider_sidecar_contract() {
+  local project="$1" home_dir="$2" network="$3" fixture="$4"
+  local provider_namespace shasums_name signature_name
+  provider_namespace="e2esidecar$(date +%s)"
+  shasums_name='terraform-provider-example_1.0.0_SHA256SUMS'
+  signature_name='terraform-provider-example_1.0.0_SHA256SUMS.sig'
+
+  printf '%s  terraform-provider-example_1.0.0_linux_amd64.zip\n' \
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' > "$fixture/$shasums_name"
+  printf '%s\n' 'fabricated provider sidecar signature' > "$fixture/$signature_name"
+
+  docker compose --project-name "$project" --project-directory "$home_dir" -f "$home_dir/compose.yaml" \
+    exec -T postgres psql -U terraform_reg_user -d terraform_registry -v ON_ERROR_STOP=1 -c \
+    "INSERT INTO users (id, email, provider, provider_id) VALUES ('dev-user-001', 'dev@localhost', 'emulator', 'dev-user-001') ON CONFLICT (id) DO NOTHING; INSERT INTO user_roles (user_id, role_id, assigned_by) SELECT 'dev-user-001', id, 'storage-emulator-contract' FROM roles WHERE name = 'admin' ON CONFLICT (user_id, role_id) DO NOTHING;"
+
+  docker run --rm --network "$network" curlimages/curl:8.16.0 -fsS -o /dev/null -w '%{http_code}' \
+    -H 'Content-Type: application/json' \
+    --data "{\"namespace\":\"${provider_namespace}\",\"type\":\"example\",\"display_name\":\"Example\"}" \
+    'http://app:5131/api/providers' | grep -qx '201'
+  docker run --rm --network "$network" curlimages/curl:8.16.0 -fsS -o /dev/null -w '%{http_code}' \
+    -H 'Content-Type: application/json' \
+    --data '{"key_id":"test-key","ascii_armor":"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmock\\n-----END PGP PUBLIC KEY BLOCK-----","source":"emulator"}' \
+    "http://app:5131/api/providers/${provider_namespace}/example/gpg-keys" | grep -qx '201'
+  docker run --rm --network "$network" curlimages/curl:8.16.0 -fsS -o /dev/null -w '%{http_code}' \
+    -H 'Content-Type: application/json' \
+    --data '{"version":"1.0.0","protocols":["5.0"],"key_id":"test-key"}' \
+    "http://app:5131/api/providers/${provider_namespace}/example/versions" | grep -qx '201'
+
+  for sidecar in "$shasums_name" "$signature_name"; do
+    local destination='shasums'
+    [[ "$sidecar" = "$signature_name" ]] && destination='shasums.sig'
+    docker run --rm --network "$network" \
+      -v "$fixture/$sidecar:/fixture/$sidecar:ro" \
+      curlimages/curl:8.16.0 -fsS -o /dev/null -w '%{http_code}' \
+      --upload-file "/fixture/$sidecar" \
+      "http://app:5131/api/providers/${provider_namespace}/example/versions/1.0.0/${destination}" | grep -qx '204'
+  done
+
+  for sidecar in "$shasums_name" "$signature_name"; do
+    docker compose --project-name "$project" --project-directory "$home_dir" -f "$home_dir/compose.yaml" \
+      run --rm --no-deps --entrypoint /bin/sh minio-init -c \
+      "mc alias set local http://minio:9000 minioadmin minioadmin >/dev/null && mc cat local/modules/providers/${provider_namespace}/example/1.0.0/${sidecar}" \
+      | cmp - "$fixture/$sidecar"
+  done
+
+  printf 'MinIO S3 provider sidecar upload/read contract passed.\n'
+}
+
 run_provider() {
   local storage_provider="$1"
   local project app caddy network fixture workspace caddy_ip module_namespace
@@ -55,10 +103,14 @@ run_provider() {
   done
   [[ "$(docker logs "$app" 2>&1)" == *"Application started"* ]]
 
+  network="${project}_default"
+  if [[ "$storage_provider" = s3 ]]; then
+    run_s3_provider_sidecar_contract "$project" "$HOME_DIR" "$network" "$fixture"
+  fi
+
   unzip -q "$ROOT/TerraformRegistry.Tests/TestData/test-module.zip" -d "$fixture/module"
   tar -C "$fixture/module" -czf "$fixture/test-module.tar.gz" .
 
-  network="${project}_default"
   for archive in zip tar.gz; do
     local version archive_file content_type
     if [[ "$archive" = zip ]]; then

--- a/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
+++ b/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
@@ -38,9 +38,11 @@ run_s3_provider_sidecar_contract() {
     '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' > "$fixture/$shasums_name"
   printf '%s\n' 'fabricated provider sidecar signature' > "$fixture/$signature_name"
 
-  docker compose --project-name "$project" --project-directory "$home_dir" -f "$home_dir/compose.yaml" \
-    exec -T postgres psql -U terraform_reg_user -d terraform_registry -v ON_ERROR_STOP=1 -c \
-    "INSERT INTO users (id, email, provider, provider_id) VALUES ('dev-user-001', 'dev@localhost', 'emulator', 'dev-user-001') ON CONFLICT (id) DO NOTHING; INSERT INTO user_roles (user_id, role_id, assigned_by) SELECT 'dev-user-001', id, 'storage-emulator-contract' FROM roles WHERE name = 'admin' ON CONFLICT (user_id, role_id) DO NOTHING;"
+  # Establish the configured DevAuthBypass identity through the application's
+  # development-only login endpoint. This creates the user and assigns the
+  # configured admin role before protected provider routes load RBAC claims.
+  docker run --rm --network "$network" curlimages/curl:8.16.0 -fsS -o /dev/null -w '%{http_code}' \
+    -X POST 'http://app:5131/api/auth/dev-login' | grep -qx '200'
 
   docker run --rm --network "$network" curlimages/curl:8.16.0 -fsS -o /dev/null -w '%{http_code}' \
     -H 'Content-Type: application/json' \

--- a/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
+++ b/scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh
@@ -27,6 +27,16 @@ project_for() {
   printf 'tfregstorage%s' "$(printf '%s' "$1" | sha256sum | cut -c1-12)"
 }
 
+bootstrap_emulator_admin() {
+  local network="$1"
+
+  # Establish the configured DevAuthBypass identity through the application's
+  # development-only login endpoint. This creates the user and assigns the
+  # configured admin role before either protected smoke flow loads RBAC claims.
+  docker run --rm --network "$network" curlimages/curl:8.16.0 -fsS -o /dev/null -w '%{http_code}' \
+    -X POST 'http://app:5131/api/auth/dev-login' | grep -qx '200'
+}
+
 run_s3_provider_sidecar_contract() {
   local project="$1" home_dir="$2" network="$3" fixture="$4"
   local provider_namespace shasums_name signature_name
@@ -37,12 +47,6 @@ run_s3_provider_sidecar_contract() {
   printf '%s  terraform-provider-example_1.0.0_linux_amd64.zip\n' \
     '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' > "$fixture/$shasums_name"
   printf '%s\n' 'fabricated provider sidecar signature' > "$fixture/$signature_name"
-
-  # Establish the configured DevAuthBypass identity through the application's
-  # development-only login endpoint. This creates the user and assigns the
-  # configured admin role before protected provider routes load RBAC claims.
-  docker run --rm --network "$network" curlimages/curl:8.16.0 -fsS -o /dev/null -w '%{http_code}' \
-    -X POST 'http://app:5131/api/auth/dev-login' | grep -qx '200'
 
   docker run --rm --network "$network" curlimages/curl:8.16.0 -fsS -o /dev/null -w '%{http_code}' \
     -H 'Content-Type: application/json' \
@@ -106,6 +110,7 @@ run_provider() {
   [[ "$(docker logs "$app" 2>&1)" == *"Application started"* ]]
 
   network="${project}_default"
+  bootstrap_emulator_admin "$network"
   if [[ "$storage_provider" = s3 ]]; then
     run_s3_provider_sidecar_contract "$project" "$HOME_DIR" "$network" "$fixture"
   fi

--- a/scripts/remediation/storage-emulators/compose.yaml
+++ b/scripts/remediation/storage-emulators/compose.yaml
@@ -41,6 +41,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       TF_REG_DevAuthBypass: "true"
+      TF_REG_AdminEmails: dev@localhost
       TF_REG_DatabaseProvider: postgres
       TF_REG_PostgreSQL__ConnectionString: Host=postgres;Database=terraform_registry;Username=terraform_reg_user;Password=terraform_reg_password
       TF_REG_BaseUrl: https://registry.local

--- a/scripts/remediation/storage-emulators/compose.yaml
+++ b/scripts/remediation/storage-emulators/compose.yaml
@@ -40,6 +40,7 @@ services:
       dockerfile: Dockerfile
     environment:
       ASPNETCORE_ENVIRONMENT: Development
+      TF_REG_DevAuthBypass: "true"
       TF_REG_DatabaseProvider: postgres
       TF_REG_PostgreSQL__ConnectionString: Host=postgres;Database=terraform_registry;Username=terraform_reg_user;Password=terraform_reg_password
       TF_REG_BaseUrl: https://registry.local

--- a/scripts/remediation/storage-emulators/test-smoke-script.sh
+++ b/scripts/remediation/storage-emulators/test-smoke-script.sh
@@ -13,4 +13,5 @@ grep -Fq '[[ "$(docker logs "$app" 2>&1)" == *"Application started"* ]]' "$SMOKE
 grep -Fq 'run_s3_provider_sidecar_contract' "$SMOKE"
 grep -Fq 'providers/${provider_namespace}/example/1.0.0/${sidecar}' "$SMOKE"
 grep -Fq "'http://app:5131/api/auth/dev-login' | grep -qx '200'" "$SMOKE"
+grep -Fq 'bootstrap_emulator_admin "$network"' "$SMOKE"
 grep -Fq 'TF_REG_AdminEmails: dev@localhost' "$ROOT/scripts/remediation/storage-emulators/compose.yaml"

--- a/scripts/remediation/storage-emulators/test-smoke-script.sh
+++ b/scripts/remediation/storage-emulators/test-smoke-script.sh
@@ -10,3 +10,5 @@ if grep -Eq 'docker logs .*\| grep -q' "$SMOKE"; then
 fi
 
 grep -Fq '[[ "$(docker logs "$app" 2>&1)" == *"Application started"* ]]' "$SMOKE"
+grep -Fq 'run_s3_provider_sidecar_contract' "$SMOKE"
+grep -Fq 'providers/${provider_namespace}/example/1.0.0/${sidecar}' "$SMOKE"

--- a/scripts/remediation/storage-emulators/test-smoke-script.sh
+++ b/scripts/remediation/storage-emulators/test-smoke-script.sh
@@ -12,3 +12,5 @@ fi
 grep -Fq '[[ "$(docker logs "$app" 2>&1)" == *"Application started"* ]]' "$SMOKE"
 grep -Fq 'run_s3_provider_sidecar_contract' "$SMOKE"
 grep -Fq 'providers/${provider_namespace}/example/1.0.0/${sidecar}' "$SMOKE"
+grep -Fq "'http://app:5131/api/auth/dev-login' | grep -qx '200'" "$SMOKE"
+grep -Fq 'TF_REG_AdminEmails: dev@localhost' "$ROOT/scripts/remediation/storage-emulators/compose.yaml"


### PR DESCRIPTION
## Summary
- propagate known SHA256SUMS request lengths from HTTP handlers to provider artifact storage
- set the AWS S3 content-length header for non-seekable request streams without buffering
- reject lengthless sidecar uploads rather than issuing an indeterminate S3 request

## Verification
- `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --no-restore --filter FullyQualifiedName~S3ProviderArtifactStorageTests` (16 passed)
- MinIO S3 provider sidecar upload/download contract: SHA256SUMS and signature uploads returned 204 and objects were stored
- `bash scripts/remediation/phase-1-storage-emulator-terraform-smoke.sh --provider s3 --home /home/rocky/.terraform-registry-storage-test-s3-provider` (passed; harness cleaned)

Note: the live provider package step exercised the separately tracked signature-validator failure after both S3 sidecars were stored; this PR does not change signature validation.