### PR TITLE
test: certify final release candidates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
       - "hotfix/**"
       - "remediation/phase/**"
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - main
       - develop

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -365,16 +365,31 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: Resolve candidate version
+        id: candidate-version
+        env:
+          GITHUB_REF_TYPE: branch
+          GITHUB_REF_NAME: ${{ github.head_ref || github.ref_name }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          version="$(.github/scripts/resolve-version.sh)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Verify final-candidate certification wiring
         run: bash scripts/remediation/gates/test-final-candidate-certification.sh
 
       - name: Run final-candidate certification
+        env:
+          FINAL_CANDIDATE_VERSION: ${{ steps.candidate-version.outputs.version }}
         run: >-
           FINAL_CANDIDATE_EVIDENCE_PATH="$RUNNER_TEMP/final-candidate-certification-evidence.json"
           bash scripts/remediation/gates/final-candidate-certification.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -349,7 +349,7 @@ jobs:
         run: bash scripts/remediation/gates/operability-certification.sh
 
   final-candidate-certification:
-    name: Final-candidate certification evidence
+    name: Pre-publication candidate verification
     # A release manager labels the final PR `final-candidate`; merge-queue
     # candidates are always certified. This is intentionally not tied to a
     # historical remediation branch name.
@@ -384,21 +384,21 @@ jobs:
           test -n "$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Verify final-candidate certification wiring
+      - name: Verify pre-publication candidate verification wiring
         run: bash scripts/remediation/gates/test-final-candidate-certification.sh
 
-      - name: Run final-candidate certification
+      - name: Run pre-publication candidate verification
         env:
           FINAL_CANDIDATE_VERSION: ${{ steps.candidate-version.outputs.version }}
         run: >-
           FINAL_CANDIDATE_EVIDENCE_PATH="$RUNNER_TEMP/final-candidate-certification-evidence.json"
           bash scripts/remediation/gates/final-candidate-certification.sh
 
-      - name: Upload final-candidate certification evidence
+      - name: Upload pre-publication candidate verification evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: final-candidate-certification-evidence
+          name: pre-publication-candidate-verification-evidence
           path: ${{ runner.temp }}/final-candidate-certification-evidence.json
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -347,6 +347,46 @@ jobs:
       - name: Run operability certification gate
         run: bash scripts/remediation/gates/operability-certification.sh
 
+  final-candidate-certification:
+    name: Final-candidate certification evidence
+    # A release manager labels the final PR `final-candidate`; merge-queue
+    # candidates are always certified. This is intentionally not tied to a
+    # historical remediation branch name.
+    if: >-
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'final-candidate'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Verify final-candidate certification wiring
+        run: bash scripts/remediation/gates/test-final-candidate-certification.sh
+
+      - name: Run final-candidate certification
+        run: >-
+          FINAL_CANDIDATE_EVIDENCE_PATH="$RUNNER_TEMP/final-candidate-certification-evidence.json"
+          bash scripts/remediation/gates/final-candidate-certification.sh
+
+      - name: Upload final-candidate certification evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: final-candidate-certification-evidence
+          path: ${{ runner.temp }}/final-candidate-certification-evidence.json
+          if-no-files-found: error
+          retention-days: 90
+
   docker:
     name: Docker build and scan
     needs:

--- a/docs/release-operations-runbook.md
+++ b/docs/release-operations-runbook.md
@@ -26,6 +26,16 @@ docker buildx imagetools inspect "$IMAGE:$VERSION"
 # Copy the reported sha256 digest into the change record.
 ```
 
+## Pre-publication candidate verification
+
+The labelled-candidate CI artifact verifies the portable P5/P6 gates before an
+image is published. It is not release certification: its `image_digest` is
+deliberately null and its release-certification status remains incomplete.
+After publication, create the explicit post-publication evidence record with
+the immutable registry digest for the exact candidate SHA and version before
+approving rollout. A local Docker image ID or a mutable tag is not acceptable
+digest evidence.
+
 The image is designed to run as the non-root `app` user. Retain the existing
 writable mounts for `/app/modules`, `/app/providers`, and `/data` when using
 local storage; the Phase 1 deployment gate verifies those paths.

--- a/docs/release-operations-runbook.md
+++ b/docs/release-operations-runbook.md
@@ -29,8 +29,7 @@ docker buildx imagetools inspect "$IMAGE:$VERSION"
 ## Pre-publication candidate verification
 
 The labelled-candidate CI artifact verifies the portable P5/P6 gates before an
-image is published. It is not release certification: its `image_digest` is
-deliberately null and its release-certification status remains incomplete.
+image is published. This artifact is not release certification until immutable post-publication digest evidence is recorded: its `image_digest` is deliberately null and its release-certification status remains incomplete.
 After publication, create the explicit post-publication evidence record with
 the immutable registry digest for the exact candidate SHA and version before
 approving rollout. A local Docker image ID or a mutable tag is not acceptable

--- a/scripts/remediation/gates/final-candidate-certification.sh
+++ b/scripts/remediation/gates/final-candidate-certification.sh
@@ -13,6 +13,7 @@ MATRIX_HOME="${FINAL_CANDIDATE_MATRIX_HOME:-${RUNNER_TEMP:-/tmp}/terraform-regis
 CANDIDATE_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
 CANDIDATE_REF="${GITHUB_REF:-$(git rev-parse --abbrev-ref HEAD)}"
 EVENT_NAME="${GITHUB_EVENT_NAME:-local}"
+CANDIDATE_VERSION="${FINAL_CANDIDATE_VERSION:?FINAL_CANDIDATE_VERSION must be resolved before certification starts}"
 DOTNET_SDK_VERSION="$(dotnet --version)"
 readonly TERRAFORM_VERSIONS='["1.12.0", "1.14.2"]'
 
@@ -47,6 +48,7 @@ write_evidence() {
   jq -n \
     --arg candidate_sha "$CANDIDATE_SHA" \
     --arg candidate_ref "$CANDIDATE_REF" \
+    --arg candidate_version "$CANDIDATE_VERSION" \
     --arg event_name "$EVENT_NAME" \
     --arg dotnet_sdk_version "$DOTNET_SDK_VERSION" \
     --arg image_digest_status 'not-published-by-certification' \
@@ -57,6 +59,7 @@ write_evidence() {
       schema_version: 1,
       candidate_sha: $candidate_sha,
       candidate_ref: $candidate_ref,
+      candidate_version: $candidate_version,
       event_name: $event_name,
       dotnet_sdk_version: $dotnet_sdk_version,
       terraform_versions: $terraform_versions,

--- a/scripts/remediation/gates/final-candidate-certification.sh
+++ b/scripts/remediation/gates/final-candidate-certification.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs the portable P5/P6 release evidence for a labelled final-candidate PR
+# or merge-queue candidate.  This script deliberately records a null digest:
+# certification builds local disposable images but does not publish an image,
+# so no immutable registry digest exists at this point.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+EVIDENCE_PATH="${FINAL_CANDIDATE_EVIDENCE_PATH:-$ROOT/final-candidate-certification-evidence.json}"
+MATRIX_HOME="${FINAL_CANDIDATE_MATRIX_HOME:-${RUNNER_TEMP:-/tmp}/terraform-registry-final-candidate-matrix}"
+CANDIDATE_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
+CANDIDATE_REF="${GITHUB_REF:-$(git rev-parse --abbrev-ref HEAD)}"
+EVENT_NAME="${GITHUB_EVENT_NAME:-local}"
+DOTNET_SDK_VERSION="$(dotnet --version)"
+readonly TERRAFORM_VERSIONS='["1.12.0", "1.14.2"]'
+
+declare -a gate_names=()
+declare -a gate_results=()
+status=0
+
+record_gate() {
+  local name="$1"
+  shift
+
+  if "$@"; then
+    gate_names+=("$name")
+    gate_results+=("passed")
+  else
+    gate_names+=("$name")
+    gate_results+=("failed")
+    status=1
+  fi
+}
+
+write_evidence() {
+  local gates_json='[]'
+  local index
+
+  for index in "${!gate_names[@]}"; do
+    gates_json="$(jq --arg name "${gate_names[$index]}" --arg result "${gate_results[$index]}" \
+      '. + [{name: $name, result: $result}]' <<<"$gates_json")"
+  done
+
+  mkdir -p "$(dirname "$EVIDENCE_PATH")"
+  jq -n \
+    --arg candidate_sha "$CANDIDATE_SHA" \
+    --arg candidate_ref "$CANDIDATE_REF" \
+    --arg event_name "$EVENT_NAME" \
+    --arg dotnet_sdk_version "$DOTNET_SDK_VERSION" \
+    --arg image_digest_status 'not-published-by-certification' \
+    --argjson terraform_versions "$TERRAFORM_VERSIONS" \
+    --argjson gates "$gates_json" \
+    --argjson passed "$([[ "$status" -eq 0 ]] && echo true || echo false)" \
+    '{
+      schema_version: 1,
+      candidate_sha: $candidate_sha,
+      candidate_ref: $candidate_ref,
+      event_name: $event_name,
+      dotnet_sdk_version: $dotnet_sdk_version,
+      terraform_versions: $terraform_versions,
+      gates: $gates,
+      passed: $passed,
+      image_digest: null,
+      image_digest_status: $image_digest_status,
+      image_digest_note: "Certification does not publish an image. image_digest remains null until the registry reports an immutable sha256 digest for this exact candidate.",
+      generated_at_utc: (now | todate)
+    }' > "$EVIDENCE_PATH"
+}
+
+cleanup_matrix() {
+  bash scripts/remediation/storage-emulators/storage-emulators.sh clean \
+    --home "$MATRIX_HOME/terraform-1.12.0" >/dev/null 2>&1 || true
+  bash scripts/remediation/storage-emulators/storage-emulators.sh clean \
+    --home "$MATRIX_HOME/terraform-1.14.2" >/dev/null 2>&1 || true
+}
+
+trap 'cleanup_matrix; write_evidence' EXIT
+
+record_gate operability-contract bash scripts/remediation/gates/test-operability-certification.sh
+record_gate operability bash scripts/remediation/gates/operability-certification.sh
+record_gate fault-load-contract bash scripts/remediation/gates/test-fault-load-certification.sh
+record_gate fault-load bash scripts/remediation/gates/fault-load-certification.sh
+record_gate terraform-backend-contract bash scripts/remediation/test-terraform-backend-matrix.sh
+record_gate terraform-backend-matrix bash scripts/remediation/terraform-backend-matrix.sh --home "$MATRIX_HOME"
+record_gate release-runbooks bash scripts/remediation/gates/release-runbooks.sh
+record_gate release-runbooks-contract bash scripts/remediation/gates/test-release-runbooks-gate.sh
+
+if [[ "$status" -ne 0 ]]; then
+  echo 'Final-candidate certification failed; inspect the evidence artifact for every gate result.' >&2
+  exit "$status"
+fi
+
+printf 'Final-candidate certification passed. Evidence: %s\n' "$EVIDENCE_PATH"

--- a/scripts/remediation/gates/final-candidate-certification.sh
+++ b/scripts/remediation/gates/final-candidate-certification.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Runs the portable P5/P6 release evidence for a labelled final-candidate PR
-# or merge-queue candidate.  This script deliberately records a null digest:
-# certification builds local disposable images but does not publish an image,
-# so no immutable registry digest exists at this point.
+# Runs portable pre-publication verification for a labelled final-candidate PR
+# or merge-queue candidate. It deliberately cannot complete release
+# certification: this job does not publish an image, so no immutable registry
+# digest exists until the explicit post-publication evidence step.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
 
@@ -51,7 +51,8 @@ write_evidence() {
     --arg candidate_version "$CANDIDATE_VERSION" \
     --arg event_name "$EVENT_NAME" \
     --arg dotnet_sdk_version "$DOTNET_SDK_VERSION" \
-    --arg image_digest_status 'not-published-by-certification' \
+    --arg verification_status 'pre-publication-verification' \
+    --arg release_certification_status 'incomplete-requires-immutable-registry-digest' \
     --argjson terraform_versions "$TERRAFORM_VERSIONS" \
     --argjson gates "$gates_json" \
     --argjson passed "$([[ "$status" -eq 0 ]] && echo true || echo false)" \
@@ -64,10 +65,14 @@ write_evidence() {
       dotnet_sdk_version: $dotnet_sdk_version,
       terraform_versions: $terraform_versions,
       gates: $gates,
-      passed: $passed,
+      pre_publication_verification_passed: $passed,
+      verification_status: $verification_status,
+      release_certification_complete: false,
+      release_certification_status: $release_certification_status,
       image_digest: null,
-      image_digest_status: $image_digest_status,
-      image_digest_note: "Certification does not publish an image. image_digest remains null until the registry reports an immutable sha256 digest for this exact candidate.",
+      post_publication_evidence_required: true,
+      required_post_publication_evidence: ["immutable-registry-digest"],
+      image_digest_note: "This is pre-publication verification, not release certification. image_digest remains null until the registry reports an immutable sha256 digest for this exact candidate in a post-publication evidence record.",
       generated_at_utc: (now | todate)
     }' > "$EVIDENCE_PATH"
 }
@@ -91,8 +96,8 @@ record_gate release-runbooks bash scripts/remediation/gates/release-runbooks.sh
 record_gate release-runbooks-contract bash scripts/remediation/gates/test-release-runbooks-gate.sh
 
 if [[ "$status" -ne 0 ]]; then
-  echo 'Final-candidate certification failed; inspect the evidence artifact for every gate result.' >&2
+  echo 'Pre-publication candidate verification failed; inspect the evidence artifact for every gate result.' >&2
   exit "$status"
 fi
 
-printf 'Final-candidate certification passed. Evidence: %s\n' "$EVIDENCE_PATH"
+printf 'Pre-publication candidate verification passed; release certification remains incomplete until immutable registry digest evidence is recorded. Evidence: %s\n' "$EVIDENCE_PATH"

--- a/scripts/remediation/gates/final-candidate-certification.sh
+++ b/scripts/remediation/gates/final-candidate-certification.sh
@@ -70,8 +70,8 @@ write_evidence() {
       release_certification_complete: false,
       release_certification_status: $release_certification_status,
       image_digest: null,
-      post_publication_evidence_required: true,
-      required_post_publication_evidence: ["immutable-registry-digest"],
+      required_post_publication_evidence: true,
+      required_post_publication_evidence_kinds: ["immutable-registry-digest"],
       image_digest_note: "This is pre-publication verification, not release certification. image_digest remains null until the registry reports an immutable sha256 digest for this exact candidate in a post-publication evidence record.",
       generated_at_utc: (now | todate)
     }' > "$EVIDENCE_PATH"

--- a/scripts/remediation/gates/test-final-candidate-certification.sh
+++ b/scripts/remediation/gates/test-final-candidate-certification.sh
@@ -22,7 +22,9 @@ for gate in \
 done
 
 grep -Fq 'FINAL_CANDIDATE_EVIDENCE_PATH' "$GATE"
+grep -Fq 'FINAL_CANDIDATE_VERSION' "$GATE"
 grep -Fq 'candidate_sha' "$GATE"
+grep -Fq 'candidate_version' "$GATE"
 grep -Fq 'image_digest' "$GATE"
 grep -Fq 'not-published-by-certification' "$GATE"
 
@@ -43,6 +45,9 @@ grep -Fq 'types: [opened, synchronize, reopened, labeled]' "$WORKFLOW"
 grep -Fq "'final-candidate'" <<<"$job"
 grep -Fq "github.event_name == 'merge_group'" <<<"$job"
 grep -Fq 'test-final-candidate-certification.sh' <<<"$job"
+grep -Fq 'fetch-depth: 0' <<<"$job"
+grep -Fq '.github/scripts/resolve-version.sh' <<<"$job"
+grep -Fq 'FINAL_CANDIDATE_VERSION' <<<"$job"
 grep -Fq 'final-candidate-certification.sh' <<<"$job"
 grep -Fq 'actions/upload-artifact@' <<<"$job"
 grep -Fq 'final-candidate-certification-evidence' <<<"$job"

--- a/scripts/remediation/gates/test-final-candidate-certification.sh
+++ b/scripts/remediation/gates/test-final-candidate-certification.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 GATE="$ROOT/scripts/remediation/gates/final-candidate-certification.sh"
-WORKFLOW="$ROOT/.github/workflows/ci.yaml"
+WORKFLOW="${FINAL_CANDIDATE_WORKFLOW:-$ROOT/.github/workflows/ci.yaml}"
 
 test -x "$GATE"
 
@@ -47,7 +47,31 @@ grep -Fq "github.event_name == 'merge_group'" <<<"$job"
 grep -Fq 'test-final-candidate-certification.sh' <<<"$job"
 grep -Fq 'fetch-depth: 0' <<<"$job"
 grep -Fq '.github/scripts/resolve-version.sh' <<<"$job"
-grep -Fq 'FINAL_CANDIDATE_VERSION' <<<"$job"
 grep -Fq 'final-candidate-certification.sh' <<<"$job"
 grep -Fq 'actions/upload-artifact@' <<<"$job"
 grep -Fq 'final-candidate-certification-evidence' <<<"$job"
+
+# Version evidence is meaningful only if the resolver's named step writes a
+# checked, nonempty value and the gate consumes that exact output.
+grep -Fxq '        id: candidate-version' <<<"$job"
+grep -Fxq '          test -n "$version"' <<<"$job"
+grep -Fxq '          echo "version=$version" >> "$GITHUB_OUTPUT"' <<<"$job"
+grep -Fxq '          FINAL_CANDIDATE_VERSION: ${{ steps.candidate-version.outputs.version }}' <<<"$job"
+
+if [[ "${FINAL_CANDIDATE_SKIP_MUTATION:-false}" != true ]]; then
+  mutation_root="$(mktemp -d)"
+  trap 'rm -rf "$mutation_root"' EXIT
+
+  for mutation in \
+    'id: candidate-version' \
+    'test -n "$version"' \
+    'echo "version=$version" >> "$GITHUB_OUTPUT"' \
+    'FINAL_CANDIDATE_VERSION: ${{ steps.candidate-version.outputs.version }}'; do
+    mutated_workflow="$mutation_root/ci.yaml"
+    sed "0,/$mutation/s//$mutation removed/" "$WORKFLOW" > "$mutated_workflow"
+    if FINAL_CANDIDATE_WORKFLOW="$mutated_workflow" FINAL_CANDIDATE_SKIP_MUTATION=true "$0" >/dev/null 2>&1; then
+      echo "Final-candidate version-handoff mutation was accepted: $mutation" >&2
+      exit 1
+    fi
+  done
+fi

--- a/scripts/remediation/gates/test-final-candidate-certification.sh
+++ b/scripts/remediation/gates/test-final-candidate-certification.sh
@@ -39,6 +39,7 @@ test -n "$job"
 
 # Candidates are selected by a durable release label or the merge queue. Do
 # not couple this final gate to an old one-off remediation branch name.
+grep -Fq 'types: [opened, synchronize, reopened, labeled]' "$WORKFLOW"
 grep -Fq "'final-candidate'" <<<"$job"
 grep -Fq "github.event_name == 'merge_group'" <<<"$job"
 grep -Fq 'test-final-candidate-certification.sh' <<<"$job"

--- a/scripts/remediation/gates/test-final-candidate-certification.sh
+++ b/scripts/remediation/gates/test-final-candidate-certification.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+GATE="$ROOT/scripts/remediation/gates/final-candidate-certification.sh"
+WORKFLOW="$ROOT/.github/workflows/ci.yaml"
+
+test -x "$GATE"
+
+# The certificate must run the executable P5/P6 evidence rather than merely
+# describe the historical certification jobs.
+for gate in \
+  'test-operability-certification.sh' \
+  'operability-certification.sh' \
+  'test-fault-load-certification.sh' \
+  'fault-load-certification.sh' \
+  'test-terraform-backend-matrix.sh' \
+  'terraform-backend-matrix.sh' \
+  'release-runbooks.sh' \
+  'test-release-runbooks-gate.sh'; do
+  grep -Fq "$gate" "$GATE"
+done
+
+grep -Fq 'FINAL_CANDIDATE_EVIDENCE_PATH' "$GATE"
+grep -Fq 'candidate_sha' "$GATE"
+grep -Fq 'image_digest' "$GATE"
+grep -Fq 'not-published-by-certification' "$GATE"
+
+job_body() {
+  awk '
+    $0 == "  final-candidate-certification:" { in_job = 1 }
+    in_job && $0 ~ /^  [[:alnum:]_-]+:$/ && $0 != "  final-candidate-certification:" { exit }
+    in_job { print }
+  ' "$WORKFLOW"
+}
+
+job="$(job_body)"
+test -n "$job"
+
+# Candidates are selected by a durable release label or the merge queue. Do
+# not couple this final gate to an old one-off remediation branch name.
+grep -Fq "'final-candidate'" <<<"$job"
+grep -Fq "github.event_name == 'merge_group'" <<<"$job"
+grep -Fq 'test-final-candidate-certification.sh' <<<"$job"
+grep -Fq 'final-candidate-certification.sh' <<<"$job"
+grep -Fq 'actions/upload-artifact@' <<<"$job"
+grep -Fq 'final-candidate-certification-evidence' <<<"$job"

--- a/scripts/remediation/gates/test-final-candidate-certification.sh
+++ b/scripts/remediation/gates/test-final-candidate-certification.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-GATE="$ROOT/scripts/remediation/gates/final-candidate-certification.sh"
+GATE="${FINAL_CANDIDATE_GATE:-$ROOT/scripts/remediation/gates/final-candidate-certification.sh}"
 WORKFLOW="${FINAL_CANDIDATE_WORKFLOW:-$ROOT/.github/workflows/ci.yaml}"
+RUNBOOK="$ROOT/docs/release-operations-runbook.md"
 
 test -x "$GATE"
 
@@ -26,7 +27,13 @@ grep -Fq 'FINAL_CANDIDATE_VERSION' "$GATE"
 grep -Fq 'candidate_sha' "$GATE"
 grep -Fq 'candidate_version' "$GATE"
 grep -Fq 'image_digest' "$GATE"
-grep -Fq 'not-published-by-certification' "$GATE"
+grep -Fq 'pre-publication-verification' "$GATE"
+grep -Fq 'incomplete-requires-immutable-registry-digest' "$GATE"
+grep -Fq 'release_certification_complete: false,' "$GATE"
+grep -Fq 'post_publication_evidence_required: true,' "$GATE"
+grep -Fq 'immutable-registry-digest' "$GATE"
+grep -Fq 'Pre-publication candidate verification' "$RUNBOOK"
+grep -Fq 'not release certification' "$RUNBOOK"
 
 job_body() {
   awk '
@@ -49,7 +56,8 @@ grep -Fq 'fetch-depth: 0' <<<"$job"
 grep -Fq '.github/scripts/resolve-version.sh' <<<"$job"
 grep -Fq 'final-candidate-certification.sh' <<<"$job"
 grep -Fq 'actions/upload-artifact@' <<<"$job"
-grep -Fq 'final-candidate-certification-evidence' <<<"$job"
+grep -Fq 'Pre-publication candidate verification' <<<"$job"
+grep -Fq 'pre-publication-candidate-verification-evidence' <<<"$job"
 
 # Version evidence is meaningful only if the resolver's named step writes a
 # checked, nonempty value and the gate consumes that exact output.
@@ -71,6 +79,19 @@ if [[ "${FINAL_CANDIDATE_SKIP_MUTATION:-false}" != true ]]; then
     sed "0,/$mutation/s//$mutation removed/" "$WORKFLOW" > "$mutated_workflow"
     if FINAL_CANDIDATE_WORKFLOW="$mutated_workflow" FINAL_CANDIDATE_SKIP_MUTATION=true "$0" >/dev/null 2>&1; then
       echo "Final-candidate version-handoff mutation was accepted: $mutation" >&2
+      exit 1
+    fi
+  done
+
+  for mutation in \
+    'release_certification_complete: false,' \
+    'post_publication_evidence_required: true,' \
+    'incomplete-requires-immutable-registry-digest'; do
+    mutated_gate="$mutation_root/final-candidate-certification.sh"
+    sed "0,/$mutation/s//MUTATED_RELEASE_COMPLETION_INVARIANT/" "$GATE" > "$mutated_gate"
+    chmod +x "$mutated_gate"
+    if FINAL_CANDIDATE_GATE="$mutated_gate" FINAL_CANDIDATE_SKIP_MUTATION=true "$0" >/dev/null 2>&1; then
+      echo "Final-candidate release-completion mutation was accepted: $mutation" >&2
       exit 1
     fi
   done

--- a/scripts/remediation/gates/test-final-candidate-certification.sh
+++ b/scripts/remediation/gates/test-final-candidate-certification.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 GATE="${FINAL_CANDIDATE_GATE:-$ROOT/scripts/remediation/gates/final-candidate-certification.sh}"
 WORKFLOW="${FINAL_CANDIDATE_WORKFLOW:-$ROOT/.github/workflows/ci.yaml}"
-RUNBOOK="$ROOT/docs/release-operations-runbook.md"
+RUNBOOK="${FINAL_CANDIDATE_RUNBOOK:-$ROOT/docs/release-operations-runbook.md}"
 
 test -x "$GATE"
 
@@ -30,10 +30,12 @@ grep -Fq 'image_digest' "$GATE"
 grep -Fq 'pre-publication-verification' "$GATE"
 grep -Fq 'incomplete-requires-immutable-registry-digest' "$GATE"
 grep -Fq 'release_certification_complete: false,' "$GATE"
-grep -Fq 'post_publication_evidence_required: true,' "$GATE"
+grep -Fq 'image_digest: null,' "$GATE"
+grep -Fq 'required_post_publication_evidence: true,' "$GATE"
+grep -Fq 'required_post_publication_evidence_kinds: ["immutable-registry-digest"],' "$GATE"
 grep -Fq 'immutable-registry-digest' "$GATE"
 grep -Fq 'Pre-publication candidate verification' "$RUNBOOK"
-grep -Fq 'not release certification' "$RUNBOOK"
+grep -Fq 'not release certification until immutable post-publication digest evidence is recorded' "$RUNBOOK"
 
 job_body() {
   awk '
@@ -85,14 +87,32 @@ if [[ "${FINAL_CANDIDATE_SKIP_MUTATION:-false}" != true ]]; then
 
   for mutation in \
     'release_certification_complete: false,' \
-    'post_publication_evidence_required: true,' \
-    'incomplete-requires-immutable-registry-digest'; do
+    'verification_status '\''pre-publication-verification'\''' \
+    'incomplete-requires-immutable-registry-digest' \
+    'image_digest: null,' \
+    'required_post_publication_evidence: true,' \
+    'required_post_publication_evidence_kinds: ["immutable-registry-digest"],'; do
     mutated_gate="$mutation_root/final-candidate-certification.sh"
-    sed "0,/$mutation/s//MUTATED_RELEASE_COMPLETION_INVARIANT/" "$GATE" > "$mutated_gate"
+    MUTATION="$mutation" perl -0pe 's/\Q$ENV{MUTATION}\E/MUTATED_RELEASE_COMPLETION_INVARIANT/' "$GATE" > "$mutated_gate"
     chmod +x "$mutated_gate"
     if FINAL_CANDIDATE_GATE="$mutated_gate" FINAL_CANDIDATE_SKIP_MUTATION=true "$0" >/dev/null 2>&1; then
       echo "Final-candidate release-completion mutation was accepted: $mutation" >&2
       exit 1
     fi
   done
+
+  non_null_digest_gate="$mutation_root/non-null-image-digest.sh"
+  sed '0,/image_digest: null,/s//image_digest: "sha256:not-a-registry-digest",/' "$GATE" > "$non_null_digest_gate"
+  chmod +x "$non_null_digest_gate"
+  if FINAL_CANDIDATE_GATE="$non_null_digest_gate" FINAL_CANDIDATE_SKIP_MUTATION=true "$0" >/dev/null 2>&1; then
+    echo 'Final-candidate non-null image-digest mutation was accepted.' >&2
+    exit 1
+  fi
+
+  weakened_runbook="$mutation_root/release-operations-runbook.md"
+  sed '0,/not release certification until immutable post-publication digest evidence is recorded/s//release certification is complete/' "$RUNBOOK" > "$weakened_runbook"
+  if FINAL_CANDIDATE_RUNBOOK="$weakened_runbook" FINAL_CANDIDATE_SKIP_MUTATION=true "$0" >/dev/null 2>&1; then
+    echo 'Final-candidate weakened runbook release-certification wording was accepted.' >&2
+    exit 1
+  fi
 fi


### PR DESCRIPTION
## Summary\n- run the portable operability, fault/load, Terraform backend, and runbook evidence for labelled final candidates and merge-queue candidates\n- upload durable JSON evidence with candidate identity, tool versions, individual gate results, and explicit image digest semantics\n- keep image digest null until an immutable registry digest is published for the exact candidate\n\n## Verification\n- actionlint .github/workflows/ci.yaml\n- bash scripts/remediation/gates/test-final-candidate-certification.sh\n- bash scripts/remediation/gates/test-fault-load-certification.sh\n- bash scripts/remediation/gates/release-runbooks.sh\n- bash scripts/remediation/gates/test-release-runbooks-gate.sh\n- bash scripts/remediation/test-terraform-backend-matrix.sh\n- pinned SDK Docker operability and fault/load gate run with host Docker socket\n\nLabel this PR `final-candidate` to execute the new combined certification before merge.