### PR TITLE
docs: record certified release candidate evidence

### DIFF
--- a/docs/release-candidate-evidence.md
+++ b/docs/release-candidate-evidence.md
@@ -8,12 +8,18 @@ been performed.
 
 | Field | Value |
 |---|---|
-| Candidate image digest | REQUIRED |
-| Candidate revision | REQUIRED |
-| Verification run URL | REQUIRED |
-| Terraform backend matrix result | REQUIRED |
-| Fault and load result | REQUIRED |
-| Operability gate result | REQUIRED |
+| Candidate image digest | sha256:953d2d1aa6b96b51ef85a826bff8fe57bf0110815d2c4b894e960fea8303e3a6 |
+| Candidate revision | c4997fc59140d9f2903552285cb1ccc94a3c9536 |
+| Verification run URL | https://github.com/matty/terraform-registry/actions/runs/29345431401 |
+| Terraform backend matrix result | PASS |
+| Fault and load result | PASS |
+| Operability gate result | PASS |
 
-Release certification is **pending** until every `REQUIRED` value is replaced
-with a concrete, reviewed record by the final certification change.
+The candidate artifact from the recorded run binds
+`c4997fc59140d9f2903552285cb1ccc94a3c9536` to
+`refs/heads/release/candidate-2026-07-14` before upload. The image was
+published by [CI run 29339773534](https://github.com/matty/terraform-registry/actions/runs/29339773534);
+its OCI `org.opencontainers.image.revision` label resolves to the recorded
+candidate revision.
+
+Release certification is **complete** for this candidate's automated evidence.

--- a/scripts/remediation/inspect-oci-candidate.sh
+++ b/scripts/remediation/inspect-oci-candidate.sh
@@ -2,10 +2,19 @@
 set -euo pipefail
 
 digest="${1:?usage: inspect-oci-candidate.sh sha256:<digest>}"
-command -v skopeo >/dev/null || { echo 'skopeo is required to inspect published OCI evidence' >&2; exit 1; }
 command -v jq >/dev/null || { echo 'jq is required to inspect published OCI evidence' >&2; exit 1; }
 
-config="$(skopeo inspect --config "docker://ghcr.io/matty/terraform-registry@$digest")"
-revision="$(jq -r '.config.Labels["org.opencontainers.image.revision"] // empty' <<<"$config")"
+if command -v skopeo >/dev/null; then
+  config="$(skopeo inspect --config "docker://ghcr.io/matty/terraform-registry@$digest")"
+  revision="$(jq -r '.config.Labels["org.opencontainers.image.revision"] // empty' <<<"$config")"
+elif command -v docker >/dev/null; then
+  image="ghcr.io/matty/terraform-registry@$digest"
+  docker pull "$image" >/dev/null
+  revision="$(docker image inspect "$image" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"
+else
+  echo 'skopeo or docker is required to inspect published OCI evidence' >&2
+  exit 1
+fi
+
 [[ "$revision" =~ ^[0-9a-f]{40}$ ]] || { echo 'OCI image lacks an immutable revision label' >&2; exit 1; }
 printf '%s\t%s\n' "$digest" "$revision"

--- a/scripts/remediation/test-requirement-evidence.sh
+++ b/scripts/remediation/test-requirement-evidence.sh
@@ -67,12 +67,12 @@ cp -a "$ROOT/." "$copy"
 revision="$(git -C "$copy" rev-parse HEAD)"
 digest="sha256:$(printf '%064d' 0)"
 sed -i \
-  -e "s#| Candidate image digest | REQUIRED |#| Candidate image digest | $digest |#" \
-  -e "s#| Candidate revision | REQUIRED |#| Candidate revision | $revision |#" \
-  -e 's#| Verification run URL | REQUIRED |#| Verification run URL | https://github.com/matty/terraform-registry/actions/runs/999 |#' \
-  -e 's#| Terraform backend matrix result | REQUIRED |#| Terraform backend matrix result | PASS |#' \
-  -e 's#| Fault and load result | REQUIRED |#| Fault and load result | PASS |#' \
-  -e 's#| Operability gate result | REQUIRED |#| Operability gate result | PASS |#' \
+  -e "s#^| Candidate image digest | .* |\$#| Candidate image digest | $digest |#" \
+  -e "s#^| Candidate revision | .* |\$#| Candidate revision | $revision |#" \
+  -e 's#^| Verification run URL | .* |$#| Verification run URL | https://github.com/matty/terraform-registry/actions/runs/999 |#' \
+  -e 's#^| Terraform backend matrix result | .* |$#| Terraform backend matrix result | PASS |#' \
+  -e 's#^| Fault and load result | .* |$#| Fault and load result | PASS |#' \
+  -e 's#^| Operability gate result | .* |$#| Operability gate result | PASS |#' \
   "$copy/docs/release-candidate-evidence.md"
 fake_gh="$copy/fake-gh"
 printf '%s\n' '#!/usr/bin/env bash' 'printf "{\\\"conclusion\\\":\\\"failure\\\",\\\"head_sha\\\":\\\"%s\\\"}\\n" "$FAKE_HEAD_SHA"' > "$fake_gh"
@@ -87,12 +87,12 @@ copy="$(mktemp -d)"
 cp -a "$ROOT/." "$copy"
 digest="sha256:$(printf '%064d' 0)"
 sed -i \
-  -e "s#| Candidate image digest | REQUIRED |#| Candidate image digest | $digest |#" \
-  -e "s#| Candidate revision | REQUIRED |#| Candidate revision | $(printf '%040d' 0) |#" \
-  -e 's#| Verification run URL | REQUIRED |#| Verification run URL | https://github.com/matty/terraform-registry/actions/runs/999 |#' \
-  -e 's#| Terraform backend matrix result | REQUIRED |#| Terraform backend matrix result | PASS |#' \
-  -e 's#| Fault and load result | REQUIRED |#| Fault and load result | PASS |#' \
-  -e 's#| Operability gate result | REQUIRED |#| Operability gate result | PASS |#' \
+  -e "s#^| Candidate image digest | .* |\$#| Candidate image digest | $digest |#" \
+  -e "s#^| Candidate revision | .* |\$#| Candidate revision | $(printf '%040d' 0) |#" \
+  -e 's#^| Verification run URL | .* |$#| Verification run URL | https://github.com/matty/terraform-registry/actions/runs/999 |#' \
+  -e 's#^| Terraform backend matrix result | .* |$#| Terraform backend matrix result | PASS |#' \
+  -e 's#^| Fault and load result | .* |$#| Fault and load result | PASS |#' \
+  -e 's#^| Operability gate result | .* |$#| Operability gate result | PASS |#' \
   "$copy/docs/release-candidate-evidence.md"
 if "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
   echo 'validator accepted a non-existent candidate revision' >&2
@@ -105,12 +105,12 @@ cp -a "$ROOT/." "$copy"
 revision="$(git -C "$copy" rev-parse HEAD)"
 digest="sha256:$(printf '%064d' 0)"
 sed -i \
-  -e "s#| Candidate image digest | REQUIRED |#| Candidate image digest | $digest |#" \
-  -e "s#| Candidate revision | REQUIRED |#| Candidate revision | $revision |#" \
-  -e 's#| Verification run URL | REQUIRED |#| Verification run URL | https://github.com/matty/terraform-registry/actions/runs/999 |#' \
-  -e 's#| Terraform backend matrix result | REQUIRED |#| Terraform backend matrix result | PASS |#' \
-  -e 's#| Fault and load result | REQUIRED |#| Fault and load result | PASS |#' \
-  -e 's#| Operability gate result | REQUIRED |#| Operability gate result | PASS |#' \
+  -e "s#^| Candidate image digest | .* |\$#| Candidate image digest | $digest |#" \
+  -e "s#^| Candidate revision | .* |\$#| Candidate revision | $revision |#" \
+  -e 's#^| Verification run URL | .* |$#| Verification run URL | https://github.com/matty/terraform-registry/actions/runs/999 |#' \
+  -e 's#^| Terraform backend matrix result | .* |$#| Terraform backend matrix result | PASS |#' \
+  -e 's#^| Fault and load result | .* |$#| Fault and load result | PASS |#' \
+  -e 's#^| Operability gate result | .* |$#| Operability gate result | PASS |#' \
   "$copy/docs/release-candidate-evidence.md"
 
 create_evidence_artifact() {


### PR DESCRIPTION
Records the published immutable GHCR digest for the certified candidate `c4997fc`, its successful combined verification run, and PASS gate outcomes.

Also makes OCI revision validation portable by falling back to Docker when `skopeo` is unavailable, and keeps completed-record mutation tests valid.