### PR TITLE
fix: bind candidate certification to exact commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -402,6 +402,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
        contains(github.event.pull_request.labels.*.name, 'final-candidate'))
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -413,7 +413,7 @@ jobs:
         id: candidate
         env:
           CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
-          CANDIDATE_REF: ${{ inputs.candidate_ref || github.event.pull_request.head.label || github.ref }}
+          CANDIDATE_REF: ${{ inputs.candidate_ref || (github.event_name == 'pull_request' && format('refs/heads/{0}', github.event.pull_request.head.ref)) || github.ref }}
         run: |
           # shellcheck disable=SC2153 # supplied through the step-level env map
           candidate_sha="$CANDIDATE_SHA"
@@ -427,6 +427,10 @@ jobs:
             echo 'candidate_ref must identify the candidate source.' >&2
             exit 1
           }
+          [[ "$candidate_ref" == refs/heads/* || "$candidate_ref" == refs/tags/* ]] || {
+            echo 'candidate_ref must be a canonical refs/heads/* or refs/tags/* reference.' >&2
+            exit 1
+          }
           echo "sha=$candidate_sha" >> "$GITHUB_OUTPUT"
           echo "ref=$candidate_ref" >> "$GITHUB_OUTPUT"
 
@@ -435,6 +439,26 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ steps.candidate.outputs.sha }}
+
+      - name: Validate candidate reference provenance
+        env:
+          CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
+          CANDIDATE_REF: ${{ steps.candidate.outputs.ref }}
+        run: |
+          git check-ref-format "$CANDIDATE_REF"
+          case "$CANDIDATE_REF" in
+            refs/heads/*|refs/tags/*) ;;
+            *)
+              echo 'candidate_ref must be a canonical refs/heads/* or refs/tags/* reference.' >&2
+              exit 1
+              ;;
+          esac
+          git fetch --no-tags origin "$CANDIDATE_REF"
+          resolved_ref_sha="$(git rev-parse 'FETCH_HEAD^{commit}')"
+          [[ "$resolved_ref_sha" == "$CANDIDATE_SHA" ]] || {
+            echo 'candidate_ref does not resolve to the requested immutable candidate SHA.' >&2
+            exit 1
+          }
 
       - name: Verify immutable candidate checkout
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,14 @@ on:
     types: [checks_requested]
   workflow_dispatch:
     inputs:
+      candidate_sha:
+        description: "Immutable 40-character commit SHA to certify"
+        required: true
+        type: string
+      candidate_ref:
+        description: "Candidate branch, tag, or source reference for evidence"
+        required: true
+        type: string
       version:
         description: "Optional version override"
         required: false
@@ -391,6 +399,7 @@ jobs:
     # candidates are always certified. This is intentionally not tied to a
     # historical remediation branch name.
     if: >-
+      github.event_name == 'workflow_dispatch' ||
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
        contains(github.event.pull_request.labels.*.name, 'final-candidate'))
@@ -400,10 +409,43 @@ jobs:
       contents: read
 
     steps:
+      - name: Validate immutable candidate inputs
+        id: candidate
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
+          CANDIDATE_REF: ${{ inputs.candidate_ref || github.event.pull_request.head.label || github.ref }}
+        run: |
+          # shellcheck disable=SC2153 # supplied through the step-level env map
+          candidate_sha="$CANDIDATE_SHA"
+          # shellcheck disable=SC2153 # supplied through the step-level env map
+          candidate_ref="$CANDIDATE_REF"
+          [[ "$candidate_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo 'candidate_sha must be an immutable 40-character lowercase commit SHA.' >&2
+            exit 1
+          }
+          test -n "$candidate_ref" || {
+            echo 'candidate_ref must identify the candidate source.' >&2
+            exit 1
+          }
+          echo "sha=$candidate_sha" >> "$GITHUB_OUTPUT"
+          echo "ref=$candidate_ref" >> "$GITHUB_OUTPUT"
+
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          ref: ${{ steps.candidate.outputs.sha }}
+
+      - name: Verify immutable candidate checkout
+        env:
+          CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
+        run: |
+          checked_out_sha="$(git rev-parse HEAD)"
+          git cat-file -e "$CANDIDATE_SHA^{commit}"
+          [[ "$checked_out_sha" == "$CANDIDATE_SHA" ]] || {
+            echo 'checkout did not resolve the requested immutable candidate SHA.' >&2
+            exit 1
+          }
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
@@ -414,7 +456,7 @@ jobs:
         id: candidate-version
         env:
           GITHUB_REF_TYPE: branch
-          GITHUB_REF_NAME: ${{ github.head_ref || github.ref_name }}
+          GITHUB_REF_NAME: ${{ steps.candidate.outputs.ref }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           version="$(.github/scripts/resolve-version.sh)"
@@ -427,8 +469,11 @@ jobs:
       - name: Run pre-publication candidate verification
         env:
           FINAL_CANDIDATE_VERSION: ${{ steps.candidate-version.outputs.version }}
-        run: >-
-          FINAL_CANDIDATE_EVIDENCE_PATH="$RUNNER_TEMP/final-candidate-certification-evidence.json"
+          FINAL_CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
+          FINAL_CANDIDATE_REF: ${{ steps.candidate.outputs.ref }}
+        run: |
+          FINAL_CANDIDATE_EVIDENCE_PATH="$RUNNER_TEMP/final-candidate-certification-evidence.json" \
+          env -u GITHUB_SHA -u GITHUB_REF \
           bash scripts/remediation/gates/final-candidate-certification.sh
 
       - name: Upload pre-publication candidate verification evidence

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -395,12 +395,11 @@ jobs:
 
   final-candidate-certification:
     name: Pre-publication candidate verification
-    # A release manager labels the final PR `final-candidate`; merge-queue
-    # candidates are always certified. This is intentionally not tied to a
-    # historical remediation branch name.
+    # A release manager labels a same-repository final PR `final-candidate`,
+    # or explicitly supplies the immutable candidate identity by dispatch.
+    # Merge-group refs are synthetic and deliberately cannot certify a release.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        contains(github.event.pull_request.labels.*.name, 'final-candidate'))
@@ -413,8 +412,8 @@ jobs:
       - name: Validate immutable candidate inputs
         id: candidate
         env:
-          CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
-          CANDIDATE_REF: ${{ inputs.candidate_ref || (github.event_name == 'pull_request' && format('refs/heads/{0}', github.event.pull_request.head.ref)) || github.ref }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha }}
+          CANDIDATE_REF: ${{ inputs.candidate_ref || (github.event_name == 'pull_request' && format('refs/heads/{0}', github.event.pull_request.head.ref)) }}
         run: |
           # shellcheck disable=SC2153 # supplied through the step-level env map
           candidate_sha="$CANDIDATE_SHA"

--- a/scripts/remediation/gates/final-candidate-certification.sh
+++ b/scripts/remediation/gates/final-candidate-certification.sh
@@ -10,12 +10,25 @@ cd "$ROOT"
 
 EVIDENCE_PATH="${FINAL_CANDIDATE_EVIDENCE_PATH:-$ROOT/final-candidate-certification-evidence.json}"
 MATRIX_HOME="${FINAL_CANDIDATE_MATRIX_HOME:-${RUNNER_TEMP:-/tmp}/terraform-registry-final-candidate-matrix}"
-CANDIDATE_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
-CANDIDATE_REF="${GITHUB_REF:-$(git rev-parse --abbrev-ref HEAD)}"
+CANDIDATE_SHA="${FINAL_CANDIDATE_SHA:?FINAL_CANDIDATE_SHA must identify the immutable candidate commit}"
+CANDIDATE_REF="${FINAL_CANDIDATE_REF:?FINAL_CANDIDATE_REF must identify the candidate source}"
 EVENT_NAME="${GITHUB_EVENT_NAME:-local}"
 CANDIDATE_VERSION="${FINAL_CANDIDATE_VERSION:?FINAL_CANDIDATE_VERSION must be resolved before certification starts}"
-DOTNET_SDK_VERSION="$(dotnet --version)"
 readonly TERRAFORM_VERSIONS='["1.12.0", "1.14.2"]'
+
+[[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+  echo 'FINAL_CANDIDATE_SHA must be an immutable 40-character lowercase commit SHA.' >&2
+  exit 2
+}
+
+checked_out_sha="$(git rev-parse HEAD)"
+git cat-file -e "$CANDIDATE_SHA^{commit}"
+[[ "$checked_out_sha" == "$CANDIDATE_SHA" ]] || {
+  echo 'The checked-out source does not match FINAL_CANDIDATE_SHA.' >&2
+  exit 2
+}
+
+DOTNET_SDK_VERSION="$(dotnet --version)"
 
 declare -a gate_names=()
 declare -a gate_results=()

--- a/scripts/remediation/gates/test-final-candidate-certification.sh
+++ b/scripts/remediation/gates/test-final-candidate-certification.sh
@@ -24,6 +24,9 @@ done
 
 grep -Fq 'FINAL_CANDIDATE_EVIDENCE_PATH' "$GATE"
 grep -Fq 'FINAL_CANDIDATE_VERSION' "$GATE"
+grep -Fq 'FINAL_CANDIDATE_SHA' "$GATE"
+grep -Fq 'FINAL_CANDIDATE_REF' "$GATE"
+! grep -Fq 'CANDIDATE_SHA="${GITHUB_SHA:-' "$GATE"
 grep -Fq 'candidate_sha' "$GATE"
 grep -Fq 'candidate_version' "$GATE"
 grep -Fq 'image_digest' "$GATE"
@@ -45,16 +48,36 @@ job_body() {
   ' "$WORKFLOW"
 }
 
+workflow_dispatch_body() {
+  awk '
+    $0 == "  workflow_dispatch:" { in_dispatch = 1 }
+    in_dispatch && $0 ~ /^  [[:alnum:]_-]+:$/ && $0 != "  workflow_dispatch:" { exit }
+    in_dispatch { print }
+  ' "$WORKFLOW"
+}
+
 job="$(job_body)"
 test -n "$job"
+workflow_dispatch="$(workflow_dispatch_body)"
+test -n "$workflow_dispatch"
 
 # Candidates are selected by a durable release label or the merge queue. Do
 # not couple this final gate to an old one-off remediation branch name.
 grep -Fq 'types: [opened, synchronize, reopened, labeled]' "$WORKFLOW"
 grep -Fq "'final-candidate'" <<<"$job"
 grep -Fq "github.event_name == 'merge_group'" <<<"$job"
+grep -Fq "github.event_name == 'workflow_dispatch'" <<<"$job"
 grep -Fq 'test-final-candidate-certification.sh' <<<"$job"
 grep -Fq 'fetch-depth: 0' <<<"$job"
+grep -Fxq '      candidate_sha:' <<<"$workflow_dispatch"
+grep -Fxq '      candidate_ref:' <<<"$workflow_dispatch"
+grep -Fxq '        id: candidate' <<<"$job"
+grep -Fxq '          echo "sha=$candidate_sha" >> "$GITHUB_OUTPUT"' <<<"$job"
+grep -Fxq '          echo "ref=$candidate_ref" >> "$GITHUB_OUTPUT"' <<<"$job"
+grep -Fxq '          ref: ${{ steps.candidate.outputs.sha }}' <<<"$job"
+grep -Fq 'git rev-parse HEAD' <<<"$job"
+grep -Fxq "            echo 'checkout did not resolve the requested immutable candidate SHA.' >&2" <<<"$job"
+grep -Fxq '          env -u GITHUB_SHA -u GITHUB_REF \' <<<"$job"
 grep -Fq '.github/scripts/resolve-version.sh' <<<"$job"
 grep -Fq 'final-candidate-certification.sh' <<<"$job"
 grep -Fq 'actions/upload-artifact@' <<<"$job"
@@ -67,18 +90,31 @@ grep -Fxq '        id: candidate-version' <<<"$job"
 grep -Fxq '          test -n "$version"' <<<"$job"
 grep -Fxq '          echo "version=$version" >> "$GITHUB_OUTPUT"' <<<"$job"
 grep -Fxq '          FINAL_CANDIDATE_VERSION: ${{ steps.candidate-version.outputs.version }}' <<<"$job"
+grep -Fxq '          FINAL_CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}' <<<"$job"
+grep -Fxq '          FINAL_CANDIDATE_REF: ${{ steps.candidate.outputs.ref }}' <<<"$job"
 
 if [[ "${FINAL_CANDIDATE_SKIP_MUTATION:-false}" != true ]]; then
   mutation_root="$(mktemp -d)"
   trap 'rm -rf "$mutation_root"' EXIT
 
   for mutation in \
+    'candidate_sha:' \
+    'candidate_ref:' \
+    'id: candidate' \
+    'echo "sha=$candidate_sha" >> "$GITHUB_OUTPUT"' \
+    'echo "ref=$candidate_ref" >> "$GITHUB_OUTPUT"' \
+    'ref: ${{ steps.candidate.outputs.sha }}' \
+    'checkout did not resolve the requested immutable candidate SHA' \
+    'env -u GITHUB_SHA -u GITHUB_REF' \
+    'FINAL_CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}' \
+    'FINAL_CANDIDATE_REF: ${{ steps.candidate.outputs.ref }}' \
     'id: candidate-version' \
     'test -n "$version"' \
     'echo "version=$version" >> "$GITHUB_OUTPUT"' \
     'FINAL_CANDIDATE_VERSION: ${{ steps.candidate-version.outputs.version }}'; do
     mutated_workflow="$mutation_root/ci.yaml"
-    sed "0,/$mutation/s//$mutation removed/" "$WORKFLOW" > "$mutated_workflow"
+    MUTATION="$mutation" perl -0pe 's/\Q$ENV{MUTATION}\E/$ENV{MUTATION} . q( removed)/e' \
+      "$WORKFLOW" > "$mutated_workflow"
     if FINAL_CANDIDATE_WORKFLOW="$mutated_workflow" FINAL_CANDIDATE_SKIP_MUTATION=true "$0" >/dev/null 2>&1; then
       echo "Final-candidate version-handoff mutation was accepted: $mutation" >&2
       exit 1

--- a/scripts/remediation/gates/test-final-candidate-certification.sh
+++ b/scripts/remediation/gates/test-final-candidate-certification.sh
@@ -68,11 +68,14 @@ grep -Fq 'types: [opened, synchronize, reopened, labeled]' "$WORKFLOW"
 grep -Fq "'final-candidate'" <<<"$job"
 grep -Fq "github.event_name == 'merge_group'" <<<"$job"
 grep -Fq "github.event_name == 'workflow_dispatch'" <<<"$job"
+grep -Fxq '       github.event.pull_request.head.repo.full_name == github.repository &&' <<<"$job"
 grep -Fq 'test-final-candidate-certification.sh' <<<"$job"
 grep -Fq 'fetch-depth: 0' <<<"$job"
 grep -Fxq '      candidate_sha:' <<<"$workflow_dispatch"
 grep -Fxq '      candidate_ref:' <<<"$workflow_dispatch"
 grep -Fxq '        id: candidate' <<<"$job"
+grep -Fxq '          CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}' <<<"$job"
+grep -Fxq "          CANDIDATE_REF: \${{ inputs.candidate_ref || (github.event_name == 'pull_request' && format('refs/heads/{0}', github.event.pull_request.head.ref)) || github.ref }}" <<<"$job"
 grep -Fxq '          echo "sha=$candidate_sha" >> "$GITHUB_OUTPUT"' <<<"$job"
 grep -Fxq '          echo "ref=$candidate_ref" >> "$GITHUB_OUTPUT"' <<<"$job"
 grep -Fxq '          ref: ${{ steps.candidate.outputs.sha }}' <<<"$job"
@@ -130,6 +133,19 @@ if [[ "${FINAL_CANDIDATE_SKIP_MUTATION:-false}" != true ]]; then
       "$WORKFLOW" > "$mutated_workflow"
     if FINAL_CANDIDATE_WORKFLOW="$mutated_workflow" FINAL_CANDIDATE_SKIP_MUTATION=true "$0" >/dev/null 2>&1; then
       echo "Final-candidate version-handoff mutation was accepted: $mutation" >&2
+      exit 1
+    fi
+  done
+
+  for source_mutation in \
+    'github.event.pull_request.head.sha' \
+    'github.event.pull_request.head.ref' \
+    'github.event.pull_request.head.repo.full_name == github.repository'; do
+    mutated_workflow="$mutation_root/ci-source.yaml"
+    SOURCE_MUTATION="$source_mutation" perl -0pe 's/\Q$ENV{SOURCE_MUTATION}\E/github.sha/' \
+      "$WORKFLOW" > "$mutated_workflow"
+    if FINAL_CANDIDATE_WORKFLOW="$mutated_workflow" FINAL_CANDIDATE_SKIP_MUTATION=true "$0" >/dev/null 2>&1; then
+      echo "Final-candidate event-source mutation was accepted: $source_mutation" >&2
       exit 1
     fi
   done

--- a/scripts/remediation/gates/test-final-candidate-certification.sh
+++ b/scripts/remediation/gates/test-final-candidate-certification.sh
@@ -51,6 +51,7 @@ job_body() {
 workflow_dispatch_body() {
   awk '
     $0 == "  workflow_dispatch:" { in_dispatch = 1 }
+    in_dispatch && /^[^[:space:]]/ { exit }
     in_dispatch && $0 ~ /^  [[:alnum:]_-]+:$/ && $0 != "  workflow_dispatch:" { exit }
     in_dispatch { print }
   ' "$WORKFLOW"
@@ -75,6 +76,12 @@ grep -Fxq '        id: candidate' <<<"$job"
 grep -Fxq '          echo "sha=$candidate_sha" >> "$GITHUB_OUTPUT"' <<<"$job"
 grep -Fxq '          echo "ref=$candidate_ref" >> "$GITHUB_OUTPUT"' <<<"$job"
 grep -Fxq '          ref: ${{ steps.candidate.outputs.sha }}' <<<"$job"
+grep -Fxq '      - name: Validate candidate reference provenance' <<<"$job"
+grep -Fxq '          git check-ref-format "$CANDIDATE_REF"' <<<"$job"
+grep -Fxq '            refs/heads/*|refs/tags/*) ;;' <<<"$job"
+grep -Fxq '          git fetch --no-tags origin "$CANDIDATE_REF"' <<<"$job"
+grep -Fxq "          resolved_ref_sha=\"\$(git rev-parse 'FETCH_HEAD^{commit}')\"" <<<"$job"
+grep -Fxq "            echo 'candidate_ref does not resolve to the requested immutable candidate SHA.' >&2" <<<"$job"
 grep -Fq 'git rev-parse HEAD' <<<"$job"
 grep -Fxq "            echo 'checkout did not resolve the requested immutable candidate SHA.' >&2" <<<"$job"
 grep -Fxq '          env -u GITHUB_SHA -u GITHUB_REF \' <<<"$job"
@@ -104,6 +111,12 @@ if [[ "${FINAL_CANDIDATE_SKIP_MUTATION:-false}" != true ]]; then
     'echo "sha=$candidate_sha" >> "$GITHUB_OUTPUT"' \
     'echo "ref=$candidate_ref" >> "$GITHUB_OUTPUT"' \
     'ref: ${{ steps.candidate.outputs.sha }}' \
+    'Validate candidate reference provenance' \
+    'git check-ref-format "$CANDIDATE_REF"' \
+    'refs/heads/*|refs/tags/*)' \
+    'git fetch --no-tags origin "$CANDIDATE_REF"' \
+    "resolved_ref_sha=\"\$(git rev-parse 'FETCH_HEAD^{commit}')\"" \
+    'candidate_ref does not resolve to the requested immutable candidate SHA' \
     'checkout did not resolve the requested immutable candidate SHA' \
     'env -u GITHUB_SHA -u GITHUB_REF' \
     'FINAL_CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}' \
@@ -120,6 +133,14 @@ if [[ "${FINAL_CANDIDATE_SKIP_MUTATION:-false}" != true ]]; then
       exit 1
     fi
   done
+
+  dispatch_root_escape_workflow="$mutation_root/dispatch-root-escape.yaml"
+  perl -0pe 's/^      candidate_sha:$/      candidate_sha removed/m' "$WORKFLOW" > "$dispatch_root_escape_workflow"
+  printf '\nsentinel:\n      candidate_sha:\n' >> "$dispatch_root_escape_workflow"
+  if FINAL_CANDIDATE_WORKFLOW="$dispatch_root_escape_workflow" FINAL_CANDIDATE_SKIP_MUTATION=true "$0" >/dev/null 2>&1; then
+    echo 'Final-candidate workflow-dispatch parser accepted a root-level escape.' >&2
+    exit 1
+  fi
 
   for mutation in \
     'release_certification_complete: false,' \

--- a/scripts/remediation/gates/test-final-candidate-certification.sh
+++ b/scripts/remediation/gates/test-final-candidate-certification.sh
@@ -26,7 +26,10 @@ grep -Fq 'FINAL_CANDIDATE_EVIDENCE_PATH' "$GATE"
 grep -Fq 'FINAL_CANDIDATE_VERSION' "$GATE"
 grep -Fq 'FINAL_CANDIDATE_SHA' "$GATE"
 grep -Fq 'FINAL_CANDIDATE_REF' "$GATE"
-! grep -Fq 'CANDIDATE_SHA="${GITHUB_SHA:-' "$GATE"
+if grep -Fq 'CANDIDATE_SHA="${GITHUB_SHA:-' "$GATE"; then
+  echo 'Final-candidate gate falls back to the event SHA.' >&2
+  exit 1
+fi
 grep -Fq 'candidate_sha' "$GATE"
 grep -Fq 'candidate_version' "$GATE"
 grep -Fq 'image_digest' "$GATE"
@@ -62,11 +65,15 @@ test -n "$job"
 workflow_dispatch="$(workflow_dispatch_body)"
 test -n "$workflow_dispatch"
 
-# Candidates are selected by a durable release label or the merge queue. Do
-# not couple this final gate to an old one-off remediation branch name.
+# Candidates are selected only by a durable same-repository release label or
+# explicit immutable dispatch inputs. Do not couple this final gate to an old
+# one-off remediation branch name.
 grep -Fq 'types: [opened, synchronize, reopened, labeled]' "$WORKFLOW"
 grep -Fq "'final-candidate'" <<<"$job"
-grep -Fq "github.event_name == 'merge_group'" <<<"$job"
+if grep -Fq "github.event_name == 'merge_group'" <<<"$job"; then
+  echo 'Final-candidate certification must not be eligible for merge groups.' >&2
+  exit 1
+fi
 grep -Fq "github.event_name == 'workflow_dispatch'" <<<"$job"
 grep -Fxq '       github.event.pull_request.head.repo.full_name == github.repository &&' <<<"$job"
 grep -Fq 'test-final-candidate-certification.sh' <<<"$job"
@@ -74,8 +81,16 @@ grep -Fq 'fetch-depth: 0' <<<"$job"
 grep -Fxq '      candidate_sha:' <<<"$workflow_dispatch"
 grep -Fxq '      candidate_ref:' <<<"$workflow_dispatch"
 grep -Fxq '        id: candidate' <<<"$job"
-grep -Fxq '          CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}' <<<"$job"
-grep -Fxq "          CANDIDATE_REF: \${{ inputs.candidate_ref || (github.event_name == 'pull_request' && format('refs/heads/{0}', github.event.pull_request.head.ref)) || github.ref }}" <<<"$job"
+grep -Fxq '          CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha }}' <<<"$job"
+grep -Fxq "          CANDIDATE_REF: \${{ inputs.candidate_ref || (github.event_name == 'pull_request' && format('refs/heads/{0}', github.event.pull_request.head.ref)) }}" <<<"$job"
+if grep -Fq 'github.sha' <<<"$job"; then
+  echo 'Final-candidate certification must not use a synthetic GitHub SHA.' >&2
+  exit 1
+fi
+if grep -Fq 'github.ref' <<<"$job"; then
+  echo 'Final-candidate certification must not use a synthetic GitHub ref.' >&2
+  exit 1
+fi
 grep -Fxq '          echo "sha=$candidate_sha" >> "$GITHUB_OUTPUT"' <<<"$job"
 grep -Fxq '          echo "ref=$candidate_ref" >> "$GITHUB_OUTPUT"' <<<"$job"
 grep -Fxq '          ref: ${{ steps.candidate.outputs.sha }}' <<<"$job"
@@ -149,6 +164,14 @@ if [[ "${FINAL_CANDIDATE_SKIP_MUTATION:-false}" != true ]]; then
       exit 1
     fi
   done
+
+  merge_group_workflow="$mutation_root/ci-merge-group.yaml"
+  perl -0pe "s/github\.event_name == 'workflow_dispatch' \|\|/github.event_name == 'workflow_dispatch' ||\n      github.event_name == 'merge_group' ||/" \
+    "$WORKFLOW" > "$merge_group_workflow"
+  if FINAL_CANDIDATE_WORKFLOW="$merge_group_workflow" FINAL_CANDIDATE_SKIP_MUTATION=true "$0" >/dev/null 2>&1; then
+    echo 'Final-candidate certification accepted a merge-group eligibility path.' >&2
+    exit 1
+  fi
 
   dispatch_root_escape_workflow="$mutation_root/dispatch-root-escape.yaml"
   perl -0pe 's/^      candidate_sha:$/      candidate_sha removed/m' "$WORKFLOW" > "$dispatch_root_escape_workflow"


### PR DESCRIPTION
## Summary
- require an immutable candidate SHA and reference for manual certification reruns
- explicitly check out and verify the exact candidate commit before generating evidence
- fail closed when the gate identity and checkout differ, with structural mutation coverage

## Verification
- `docker run --rm -v "$PWD:/repo:ro" -w /repo rhysd/actionlint:1.7.10 -color .github/workflows/ci.yaml`
- `docker run --rm -v "$PWD:/src:ro" -w /src mcr.microsoft.com/dotnet/sdk:10.0.301 bash scripts/remediation/gates/test-final-candidate-certification.sh`
- mismatch regression: existing non-HEAD commit is rejected with exit 2 before certification gates run

## Exact rerun
After merge, run CI with `candidate_sha=c4997fc59140d9f2903552285cb1ccc94a3c9536` and `candidate_ref=test/final-candidate-certification`. The job checks out that SHA explicitly and its evidence artifact records the same SHA.