### PR TITLE
fix: validate bound candidate evidence artifact

### DIFF
--- a/docs/remediation-status.md
+++ b/docs/remediation-status.md
@@ -11,8 +11,10 @@ certification from historical records.
 
 The listed gates document merged-work automation; their branch-specific CI
 invocations are not treated as current-candidate evidence. A completed candidate
-must instead be tied to one successful CI run for its exact revision, with the
-combined `Pre-publication candidate verification` job successful.
+must instead be tied to one successful CI run with the combined
+`Pre-publication candidate verification` job successful. Its immutable candidate
+identity is verified from that run's bound pre-publication evidence artifact,
+because a workflow-dispatch run itself is recorded at the workflow ref.
 
 ## Requirement evidence
 

--- a/scripts/remediation/test-requirement-evidence.sh
+++ b/scripts/remediation/test-requirement-evidence.sh
@@ -112,9 +112,77 @@ sed -i \
   -e 's#| Fault and load result | REQUIRED |#| Fault and load result | PASS |#' \
   -e 's#| Operability gate result | REQUIRED |#| Operability gate result | PASS |#' \
   "$copy/docs/release-candidate-evidence.md"
+
+create_evidence_artifact() {
+  local archive="$1"
+  local artifact_sha="$2"
+  local artifact_ref="$3"
+  local gates_json="$4"
+  local pre_publication_passed="${5:-true}"
+  local artifact_dir
+  artifact_dir="$(mktemp -d)"
+  jq -n \
+    --arg candidate_sha "$artifact_sha" \
+    --arg candidate_ref "$artifact_ref" \
+    --argjson gates "$gates_json" \
+    --argjson pre_publication_passed "$pre_publication_passed" \
+    '{
+      schema_version: 1,
+      candidate_sha: $candidate_sha,
+      candidate_ref: $candidate_ref,
+      candidate_version: "0.0.0-test",
+      event_name: "workflow_dispatch",
+      dotnet_sdk_version: "10.0.301",
+      terraform_versions: ["1.12.0", "1.14.2"],
+      gates: $gates,
+      pre_publication_verification_passed: $pre_publication_passed,
+      verification_status: "pre-publication-verification",
+      release_certification_complete: false,
+      release_certification_status: "incomplete-requires-immutable-registry-digest",
+      image_digest: null,
+      required_post_publication_evidence: true,
+      required_post_publication_evidence_kinds: ["immutable-registry-digest"],
+      generated_at_utc: "2026-07-14T00:00:00Z"
+    }' > "$artifact_dir/final-candidate-certification-evidence.json"
+  # GitHub exposes action artifacts as ZIP archives. The portable test fixture
+  # uses the Python standard library because the development image supplies
+  # unzip (needed by the validator) but not the optional zip CLI.
+  python3 - "$artifact_dir" "$archive" <<'PY'
+import sys
+import zipfile
+
+source_dir, archive = sys.argv[1:]
+with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as output:
+    output.write(
+        f"{source_dir}/final-candidate-certification-evidence.json",
+        "final-candidate-certification-evidence.json",
+    )
+PY
+  rm -rf "$artifact_dir"
+}
+
+required_gates='[
+  {"name":"operability-contract","result":"passed"},
+  {"name":"operability","result":"passed"},
+  {"name":"fault-load-contract","result":"passed"},
+  {"name":"fault-load","result":"passed"},
+  {"name":"terraform-backend-contract","result":"passed"},
+  {"name":"terraform-backend-matrix","result":"passed"},
+  {"name":"release-runbooks","result":"passed"},
+  {"name":"release-runbooks-contract","result":"passed"}
+]'
+
 fake_gh="$copy/fake-gh"
 printf '%s\n' \
   '#!/usr/bin/env bash' \
+  'if [[ "$*" == *"/artifacts/"*"/zip"* ]]; then' \
+  '  cat "${FAKE_ARTIFACT_ARCHIVE:?}"' \
+  '  exit 0' \
+  'fi' \
+  'if [[ "$*" == *"/artifacts"* ]]; then' \
+  '  printf "%s\\n" "${FAKE_ARTIFACT_ID-123}"' \
+  '  exit 0' \
+  'fi' \
   'if [[ "$*" == *"/jobs"* ]]; then' \
   "  printf '%s\\n' $'Pre-publication candidate verification\\tsuccess'" \
   '  exit 0' \
@@ -129,17 +197,66 @@ chmod +x "$fake_gh"
 fake_oci="$copy/fake-oci"
 printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\\t%s\\n" "$1" "${FAKE_OCI_REVISION:?}"' > "$fake_oci"
 chmod +x "$fake_oci"
-GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$revision" FAKE_OCI_REVISION="$revision" "$copy/scripts/remediation/validate-requirement-evidence.sh" --check
+artifact_archive="$copy/evidence.zip"
+create_evidence_artifact "$artifact_archive" "$revision" refs/heads/develop "$required_gates"
 
-if GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$(printf '%040d' 0)" FAKE_OCI_REVISION="$revision" "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
-  echo 'validator accepted a verification run for a different revision' >&2
+# A workflow_dispatch run is recorded at the workflow ref (develop), while its
+# uploaded evidence binds the explicitly checked-out release candidate. The
+# validator must accept that authoritative, bound artifact.
+GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$(printf '%040d' 0)" FAKE_OCI_REVISION="$revision" FAKE_ARTIFACT_ARCHIVE="$artifact_archive" "$copy/scripts/remediation/validate-requirement-evidence.sh" --check
+
+mismatched_artifact="$copy/mismatched-evidence.zip"
+create_evidence_artifact "$mismatched_artifact" "$(printf '%040d' 0)" refs/heads/develop "$required_gates"
+if GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$(printf '%040d' 0)" FAKE_OCI_REVISION="$revision" FAKE_ARTIFACT_ARCHIVE="$mismatched_artifact" "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
+  echo 'validator accepted evidence for a different candidate revision' >&2
   exit 1
 fi
-if GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$revision" FAKE_OCI_REVISION="$revision" FAKE_RUN_NAME=other "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
+
+if GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$(printf '%040d' 0)" FAKE_OCI_REVISION="$revision" FAKE_ARTIFACT_ID= FAKE_ARTIFACT_ARCHIVE="$artifact_archive" "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
+  echo 'validator accepted a missing candidate evidence artifact' >&2
+  exit 1
+fi
+
+if GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$(printf '%040d' 0)" FAKE_OCI_REVISION="$revision" FAKE_ARTIFACT_ARCHIVE="$copy/unreadable-evidence.zip" "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
+  echo 'validator accepted an unreadable candidate evidence artifact' >&2
+  exit 1
+fi
+
+missing_gate_artifact="$copy/missing-gate-evidence.zip"
+missing_gate_json='[
+  {"name":"operability-contract","result":"passed"},
+  {"name":"operability","result":"passed"},
+  {"name":"fault-load-contract","result":"passed"},
+  {"name":"fault-load","result":"passed"},
+  {"name":"terraform-backend-contract","result":"passed"},
+  {"name":"terraform-backend-matrix","result":"passed"},
+  {"name":"release-runbooks","result":"passed"}
+]'
+create_evidence_artifact "$missing_gate_artifact" "$revision" refs/heads/develop "$missing_gate_json"
+if GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$(printf '%040d' 0)" FAKE_OCI_REVISION="$revision" FAKE_ARTIFACT_ARCHIVE="$missing_gate_artifact" "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
+  echo 'validator accepted evidence with a missing required gate' >&2
+  exit 1
+fi
+
+failed_verification_artifact="$copy/failed-verification-evidence.zip"
+create_evidence_artifact "$failed_verification_artifact" "$revision" refs/heads/develop "$required_gates" false
+if GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$(printf '%040d' 0)" FAKE_OCI_REVISION="$revision" FAKE_ARTIFACT_ARCHIVE="$failed_verification_artifact" "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
+  echo 'validator accepted evidence whose pre-publication verification failed' >&2
+  exit 1
+fi
+
+noncanonical_ref_artifact="$copy/noncanonical-ref-evidence.zip"
+create_evidence_artifact "$noncanonical_ref_artifact" "$revision" refs/pull/1/head "$required_gates"
+if GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$(printf '%040d' 0)" FAKE_OCI_REVISION="$revision" FAKE_ARTIFACT_ARCHIVE="$noncanonical_ref_artifact" "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
+  echo 'validator accepted evidence with a non-canonical candidate reference' >&2
+  exit 1
+fi
+
+if GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$(printf '%040d' 0)" FAKE_OCI_REVISION="$revision" FAKE_ARTIFACT_ARCHIVE="$artifact_archive" FAKE_RUN_NAME=other "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
   echo 'validator accepted a non-CI workflow as candidate verification' >&2
   exit 1
 fi
-if GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$revision" FAKE_OCI_REVISION="$(printf '%040d' 0)" "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
+if GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$(printf '%040d' 0)" FAKE_OCI_REVISION="$(printf '%040d' 0)" FAKE_ARTIFACT_ARCHIVE="$artifact_archive" "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
   echo 'validator accepted a digest whose OCI revision label is unrelated' >&2
   exit 1
 fi

--- a/scripts/remediation/validate-requirement-evidence.sh
+++ b/scripts/remediation/validate-requirement-evidence.sh
@@ -20,6 +20,103 @@ fail() {
   return 1
 }
 
+verify_candidate_evidence_artifact() {
+  local run_id="$1"
+  local candidate_revision="$2"
+  local artifact_ids artifact_id artifact_dir artifact_archive artifact_evidence artifact_ref
+  local required_gate gate_count
+
+  mapfile -t artifact_ids < <("$GH_BIN" api "repos/matty/terraform-registry/actions/runs/$run_id/artifacts" --paginate --jq \
+    '.artifacts[] | select(.name == "pre-publication-candidate-verification-evidence" and .expired == false) | .id' 2>/dev/null) || {
+    fail "candidate verification artifacts cannot be read"
+    return 1
+  }
+  (( ${#artifact_ids[@]} == 1 )) || {
+    fail "candidate verification must have exactly one readable pre-publication evidence artifact"
+    return 1
+  }
+  artifact_id="${artifact_ids[0]}"
+  [[ "$artifact_id" =~ ^[1-9][0-9]*$ ]] || {
+    fail "candidate verification evidence artifact has an invalid identifier"
+    return 1
+  }
+
+  artifact_dir="$(mktemp -d)" || {
+    fail "candidate verification evidence cannot be staged"
+    return 1
+  }
+  artifact_archive="$artifact_dir/evidence.zip"
+  artifact_evidence="$artifact_dir/final-candidate-certification-evidence.json"
+  if ! "$GH_BIN" api "repos/matty/terraform-registry/actions/artifacts/$artifact_id/zip" > "$artifact_archive" 2>/dev/null; then
+    rm -rf "$artifact_dir"
+    fail "candidate verification evidence artifact cannot be downloaded"
+    return 1
+  fi
+  if [[ "$(unzip -Z1 "$artifact_archive" 2>/dev/null)" != 'final-candidate-certification-evidence.json' ]] ||
+     ! unzip -p "$artifact_archive" final-candidate-certification-evidence.json > "$artifact_evidence" 2>/dev/null; then
+    rm -rf "$artifact_dir"
+    fail "candidate verification evidence artifact is unreadable or has an unexpected layout"
+    return 1
+  fi
+
+  if ! jq -e --arg candidate_sha "$candidate_revision" '
+      .schema_version == 1 and
+      (.candidate_sha == $candidate_sha) and
+      (.candidate_ref | type == "string" and length > 0) and
+      (.candidate_version | type == "string" and length > 0) and
+      (.event_name | type == "string" and (. == "workflow_dispatch" or . == "pull_request")) and
+      (.dotnet_sdk_version | type == "string" and length > 0) and
+      (.terraform_versions == ["1.12.0", "1.14.2"]) and
+      (.gates | type == "array" and length > 0 and all(.[]; type == "object" and (.name | type == "string" and length > 0) and (.result | type == "string"))) and
+      (.pre_publication_verification_passed == true) and
+      (.verification_status == "pre-publication-verification") and
+      (.release_certification_complete == false) and
+      (.release_certification_status == "incomplete-requires-immutable-registry-digest") and
+      (.image_digest == null) and
+      (.required_post_publication_evidence == true) and
+      (.required_post_publication_evidence_kinds | type == "array" and index("immutable-registry-digest")) and
+      (.generated_at_utc | type == "string" and length > 0)
+    ' "$artifact_evidence" >/dev/null 2>&1; then
+    rm -rf "$artifact_dir"
+    fail "candidate verification evidence artifact has an invalid schema, identity, or status"
+    return 1
+  fi
+
+  artifact_ref="$(jq -er '.candidate_ref | strings' "$artifact_evidence" 2>/dev/null)" || {
+    rm -rf "$artifact_dir"
+    fail "candidate verification evidence artifact lacks a canonical candidate reference"
+    return 1
+  }
+  case "$artifact_ref" in refs/heads/*|refs/tags/*) ;; *)
+    rm -rf "$artifact_dir"
+    fail "candidate verification evidence artifact has a non-canonical candidate reference"
+    return 1
+  esac
+  if ! git check-ref-format "$artifact_ref"; then
+    rm -rf "$artifact_dir"
+    fail "candidate verification evidence artifact has an invalid candidate reference"
+    return 1
+  fi
+
+  for required_gate in \
+    operability-contract operability fault-load-contract fault-load \
+    terraform-backend-contract terraform-backend-matrix \
+    release-runbooks release-runbooks-contract; do
+    gate_count="$(jq -er --arg name "$required_gate" '[.gates[] | select(.name == $name and .result == "passed")] | length' "$artifact_evidence" 2>/dev/null)" || {
+      rm -rf "$artifact_dir"
+      fail "candidate verification evidence artifact has unreadable gate results"
+      return 1
+    }
+    [[ "$gate_count" == 1 ]] || {
+      rm -rf "$artifact_dir"
+      fail "candidate verification evidence artifact lacks one successful '$required_gate' gate result"
+      return 1
+    }
+  done
+
+  rm -rf "$artifact_dir"
+}
+
 test -f "$SPEC" || fail "missing specification: $SPEC"
 test -f "$MANIFEST" || fail "missing manifest: $MANIFEST"
 test -f "$CANDIDATE" || fail "missing candidate evidence: $CANDIDATE"
@@ -88,12 +185,13 @@ if (( pending_count == 0 )); then
   run_head_sha="$("$GH_BIN" api "repos/matty/terraform-registry/actions/runs/$run_id" --jq '.head_sha' 2>/dev/null)" || fail "candidate verification run head cannot be read"
   run_name="$("$GH_BIN" api "repos/matty/terraform-registry/actions/runs/$run_id" --jq '.name' 2>/dev/null)" || fail "candidate verification run name cannot be read"
   [[ "$run_conclusion" == success ]] || fail "candidate verification run did not succeed"
-  [[ "$run_head_sha" == "$candidate_revision" ]] || fail "candidate verification run does not verify the candidate revision"
+  [[ "$run_head_sha" =~ ^[0-9a-f]{40}$ ]] || fail "candidate verification run does not identify an immutable workflow revision"
   [[ "$run_name" == CI ]] || fail "candidate verification run is not the CI workflow"
   run_jobs="$("$GH_BIN" api "repos/matty/terraform-registry/actions/runs/$run_id/jobs" --paginate --jq '.jobs[] | [.name, .conclusion] | @tsv' 2>/dev/null)" || fail "candidate verification jobs cannot be read"
   for required_job in 'Pre-publication candidate verification'; do
     grep -Fqx "$required_job"$'\t''success' <<<"$run_jobs" || fail "candidate verification lacks successful '$required_job' evidence"
   done
+  verify_candidate_evidence_artifact "$run_id" "$candidate_revision"
   for index in 3 4 5; do [[ "${candidate_values[$index]}" == PASS ]] || fail "candidate gate result must be PASS"; done
 fi
 
@@ -112,8 +210,10 @@ certification from historical records.
 
 The listed gates document merged-work automation; their branch-specific CI
 invocations are not treated as current-candidate evidence. A completed candidate
-must instead be tied to one successful CI run for its exact revision, with the
-combined `Pre-publication candidate verification` job successful.
+must instead be tied to one successful CI run with the combined
+`Pre-publication candidate verification` job successful. Its immutable candidate
+identity is verified from that run's bound pre-publication evidence artifact,
+because a workflow-dispatch run itself is recorded at the workflow ref.
 
 ## Requirement evidence
 


### PR DESCRIPTION
## Summary
- verify the named, non-expired pre-publication artifact from the recorded CI run
- bind candidate identity to artifact JSON so workflow-dispatch runs can certify an explicitly checked-out SHA
- fail closed on invalid artifact schema/status, noncanonical refs, and missing gate outcomes

## Verification
- `bash scripts/remediation/test-requirement-evidence.sh`
- `bash scripts/remediation/validate-requirement-evidence.sh --check`
- `bash -n scripts/remediation/validate-requirement-evidence.sh scripts/remediation/test-requirement-evidence.sh`
- `bash scripts/remediation/gates/test-final-candidate-certification.sh`