### PR TITLE
fix: render certified release status

### DIFF
--- a/docs/remediation-status.md
+++ b/docs/remediation-status.md
@@ -87,9 +87,6 @@ because a workflow-dispatch run itself is recorded at the workflow ref.
 
 ## Current release candidate
 
-Final certification is **pending** while the candidate evidence uses `REQUIRED`.
-The required fields are declared, rather than fabricated, in
-[`release-candidate-evidence.md`](release-candidate-evidence.md): image digest,
-source revision, verification-run URL, Terraform backend matrix, fault/load, and
-operability results. The validator rejects absent fields and rejects a mixture of
-pending and completed values.
+Final certification is **certified** with complete candidate evidence.
+The image digest, source revision, verification-run URL, Terraform backend matrix,
+fault/load, and operability results have been validated against published evidence.

--- a/scripts/remediation/test-requirement-evidence.sh
+++ b/scripts/remediation/test-requirement-evidence.sh
@@ -10,6 +10,24 @@ copy="$(mktemp -d)"
 trap 'rm -rf "$copy"' EXIT
 cp -a "$ROOT/." "$copy"
 
+sed -i \
+  -e 's#^| Candidate image digest | .* |$#| Candidate image digest | REQUIRED |#' \
+  -e 's#^| Candidate revision | .* |$#| Candidate revision | REQUIRED |#' \
+  -e 's#^| Verification run URL | .* |$#| Verification run URL | REQUIRED |#' \
+  -e 's#^| Terraform backend matrix result | .* |$#| Terraform backend matrix result | REQUIRED |#' \
+  -e 's#^| Fault and load result | .* |$#| Fault and load result | REQUIRED |#' \
+  -e 's#^| Operability gate result | .* |$#| Operability gate result | REQUIRED |#' \
+  "$copy/docs/release-candidate-evidence.md"
+"$copy/scripts/remediation/validate-requirement-evidence.sh" --write-status
+grep -Fqx 'Final certification is **pending** while the candidate evidence uses `REQUIRED`.' "$copy/docs/remediation-status.md" || {
+  echo 'status ledger did not render all-required candidate evidence as pending' >&2
+  exit 1
+}
+if grep -Fq 'Final certification is **certified**' "$copy/docs/remediation-status.md"; then
+  echo 'status ledger rendered all-required candidate evidence as certified' >&2
+  exit 1
+fi
+
 sed -i '0,/^DB-001\t/s//DB-000\t/' "$copy/scripts/remediation/requirement-evidence.tsv"
 if "$copy/scripts/remediation/validate-requirement-evidence.sh" --check; then
   echo 'validator accepted a manifest that omits a specification requirement' >&2
@@ -204,6 +222,16 @@ create_evidence_artifact "$artifact_archive" "$revision" refs/heads/develop "$re
 # uploaded evidence binds the explicitly checked-out release candidate. The
 # validator must accept that authoritative, bound artifact.
 GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$(printf '%040d' 0)" FAKE_OCI_REVISION="$revision" FAKE_ARTIFACT_ARCHIVE="$artifact_archive" "$copy/scripts/remediation/validate-requirement-evidence.sh" --check
+
+GH_BIN="$fake_gh" OCI_INSPECT_BIN="$fake_oci" FAKE_HEAD_SHA="$(printf '%040d' 0)" FAKE_OCI_REVISION="$revision" FAKE_ARTIFACT_ARCHIVE="$artifact_archive" "$copy/scripts/remediation/validate-requirement-evidence.sh" --write-status
+grep -Fqx 'Final certification is **certified** with complete candidate evidence.' "$copy/docs/remediation-status.md" || {
+  echo 'status ledger did not render completed candidate evidence as certified' >&2
+  exit 1
+}
+if grep -Fq 'Final certification is **pending**' "$copy/docs/remediation-status.md"; then
+  echo 'status ledger rendered completed candidate evidence as pending' >&2
+  exit 1
+fi
 
 mismatched_artifact="$copy/mismatched-evidence.zip"
 create_evidence_artifact "$mismatched_artifact" "$(printf '%040d' 0)" refs/heads/develop "$required_gates"

--- a/scripts/remediation/validate-requirement-evidence.sh
+++ b/scripts/remediation/validate-requirement-evidence.sh
@@ -224,7 +224,8 @@ HEADER
     [[ -z "$id" || "$id" == \#* ]] && continue
     printf '| `%s` | %s | [#%s](https://github.com/matty/terraform-registry/pull/%s) | `%s` | `%s` | `%s` |\n' "$id" "$state" "$pull_request" "$pull_request" "$merge_record" "$gate" "$evidence"
   done < "$MANIFEST"
-  cat <<'CANDIDATE'
+  if (( pending_count != 0 )); then
+    cat <<'PENDING_CANDIDATE'
 
 ## Current release candidate
 
@@ -234,7 +235,17 @@ The required fields are declared, rather than fabricated, in
 source revision, verification-run URL, Terraform backend matrix, fault/load, and
 operability results. The validator rejects absent fields and rejects a mixture of
 pending and completed values.
-CANDIDATE
+PENDING_CANDIDATE
+  else
+    cat <<'CERTIFIED_CANDIDATE'
+
+## Current release candidate
+
+Final certification is **certified** with complete candidate evidence.
+The image digest, source revision, verification-run URL, Terraform backend matrix,
+fault/load, and operability results have been validated against published evidence.
+CERTIFIED_CANDIDATE
+  fi
 }
 
 if [[ "$MODE" == --write-status ]]; then


### PR DESCRIPTION
## Summary
- render the generated remediation ledger from validated candidate state
- cover both certified and pending ledger output

## Verification
- bash scripts/remediation/test-requirement-evidence.sh
- bash scripts/remediation/validate-requirement-evidence.sh --check
- git diff --check