### PR TITLE
revert: defer postgres digest update until stable

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: postgres:18@sha256:b913fd5699b8bd23fa4b06d72ecdd939fad43b80fb8651bac06caa0e6d135cac
+    image: postgres:18@sha256:48ebba8b80dc3be58b5ae431f47a33535289959cddfe13f5f887298de959fae0
     ports:
       - "5433:5432"
     volumes:

--- a/docker-compose.psql.yml
+++ b/docker-compose.psql.yml
@@ -1,7 +1,7 @@
 ---
 services:
   postgres:
-    image: postgres:18@sha256:b913fd5699b8bd23fa4b06d72ecdd939fad43b80fb8651bac06caa0e6d135cac
+    image: postgres:18@sha256:48ebba8b80dc3be58b5ae431f47a33535289959cddfe13f5f887298de959fae0
     ports:
       - "5433:5432"
     volumes:

--- a/scripts/remediation/storage-emulators/compose.yaml
+++ b/scripts/remediation/storage-emulators/compose.yaml
@@ -23,7 +23,7 @@ services:
       mc mb --ignore-existing local/modules'
 
   postgres:
-    image: postgres:18@sha256:b913fd5699b8bd23fa4b06d72ecdd939fad43b80fb8651bac06caa0e6d135cac
+    image: postgres:18@sha256:48ebba8b80dc3be58b5ae431f47a33535289959cddfe13f5f887298de959fae0
     environment:
       POSTGRES_USER: terraform_reg_user
       POSTGRES_PASSWORD: terraform_reg_password


### PR DESCRIPTION
## Summary
- restores the prior PostgreSQL image digest in each Compose consumer
- corrects the premature merge before Renovate minimum release age cleared

## Verification
- bash scripts/remediation/gates/test-supply-chain-pinning.sh
- bash scripts/remediation/storage-emulators/test-ci-workflow.sh
- bash scripts/remediation/storage-emulators/test-smoke-script.sh
- git diff --check

## Follow-up
Renovate may recreate the digest update after its stability policy is satisfied.