### PR TITLE
ci: safely automate routine Renovate merges

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -85,6 +85,18 @@
     },
     {
       "matchUpdateTypes": [
+        "digest",
+        "pin",
+        "patch",
+        "minor"
+      ],
+      "labels": [
+        "dependencies",
+        "automerge-candidate"
+      ]
+    },
+    {
+      "matchUpdateTypes": [
         "major"
       ],
       "dependencyDashboardApproval": true

--- a/.github/workflows/renovate-merge-watcher.yaml
+++ b/.github/workflows/renovate-merge-watcher.yaml
@@ -1,0 +1,31 @@
+name: Renovate merge watcher
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: renovate-merge-watcher
+  cancel-in-progress: false
+
+jobs:
+  merge-eligible-renovate-pr:
+    name: Merge eligible Renovate PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout trusted develop revision
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: develop
+
+      - name: Evaluate and merge one eligible Renovate PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/automation/merge-renovate-pr.sh

--- a/docs/ci-security-bootstrap.md
+++ b/docs/ci-security-bootstrap.md
@@ -36,10 +36,17 @@ It requires the protected CI/security checks, `renovate/stability-days`, a
 clean current merge state, an unchanged head SHA, and no comments, reviews, or
 unresolved review threads. A pending stability status is never mergeable.
 
-The watcher excludes vulnerability-alert updates and dashboard-approved major
-updates. It also waits for the previous `develop` CI and Security runs to
-succeed before considering another dependency PR. Human-authored PRs are never
-eligible for this automation.
+Renovate applies `automerge-candidate` only to digest, pin, patch, and minor
+updates. The watcher requires that label and rejects `security`,
+`dependency-dashboard`, and major labels, so vulnerability-alert and
+dashboard-approved major updates remain maintainer-reviewed. Human-authored
+PRs are never eligible for this automation.
+
+Before the final rebase request, the watcher verifies that the PR's `develop`
+base SHA is unchanged and that the CI and Security push runs for that exact
+SHA succeeded. This public personal repository cannot use GitHub merge queues;
+when a competing `develop` merge is in progress, the watcher defers rather than
+merging another dependency update.
 
 ## Repository settings required outside this repository
 
@@ -48,10 +55,11 @@ that requires pull requests, the checks above as applicable, at least one
 approval, resolved conversations, linear history, and no force pushes. Workflow
 filters alone do not provide branch protection.
 
-The administrator must also enable a merge queue for `develop` and configure
-the current CI and Security check names as required status checks. The queue
-must send the `merge_group` event; this repository's workflows already handle
-that event.
+For repositories eligible for GitHub merge queues, an administrator should
+enable one for `develop` and configure the current CI and Security check names
+as required status checks. GitHub does not offer merge queues to this public
+personal repository, so the Renovate watcher provides the documented
+single-update/base-recheck fallback.
 
 Protected cloud integration environments are configured separately. Their OIDC
 federated credentials must trust only the intended repository, workflow, and

--- a/docs/ci-security-bootstrap.md
+++ b/docs/ci-security-bootstrap.md
@@ -27,6 +27,20 @@ only for `push` events or an explicitly requested `workflow_dispatch` with
 `push_image=true`. Consequently, a `merge_group` build cannot log into GHCR,
 push an image, create a tag, or receive registry/OIDC write permissions.
 
+## Renovate merge watcher
+
+`Renovate merge watcher` runs only from the trusted `develop` revision on an
+hourly schedule or by manual dispatch. It examines routine Renovate PRs without
+checking out or executing their code, and can merge at most one with a rebase.
+It requires the protected CI/security checks, `renovate/stability-days`, a
+clean current merge state, an unchanged head SHA, and no comments, reviews, or
+unresolved review threads. A pending stability status is never mergeable.
+
+The watcher excludes vulnerability-alert updates and dashboard-approved major
+updates. It also waits for the previous `develop` CI and Security runs to
+succeed before considering another dependency PR. Human-authored PRs are never
+eligible for this automation.
+
 ## Repository settings required outside this repository
 
 An administrator must create a branch ruleset matching `remediation/phase/**`

--- a/docs/superpowers/plans/2026-07-14-renovate-merge-watcher.md
+++ b/docs/superpowers/plans/2026-07-14-renovate-merge-watcher.md
@@ -12,6 +12,8 @@
 
 - Branch and commit names must not contain `phase`.
 - Never auto-merge human, security-alert, or dashboard-approved major PRs.
+- Require Renovate's `automerge-candidate` label, configured only for digest,
+  pin, patch, and minor updates.
 - Require all eight `develop` branch-protection checks and successful Renovate stability before merging.
 - Re-query PR state, current head SHA, comments, reviews, threads, and merge state immediately before a rebase merge.
 - Process one PR per run and do not merge when prior `develop` CI/security is not successful.

--- a/docs/superpowers/plans/2026-07-14-renovate-merge-watcher.md
+++ b/docs/superpowers/plans/2026-07-14-renovate-merge-watcher.md
@@ -1,0 +1,54 @@
+# Renovate Merge Watcher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Merge at most one policy-complete routine Renovate PR without bypassing its stability, CI, or review safeguards.
+
+**Architecture:** A trusted scheduled/manual Actions workflow invokes a checked-in Bash decision script against GitHub API data. The script is tested with a fake GitHub CLI and never checks out or executes PR code.
+
+**Tech Stack:** GitHub Actions, GitHub CLI, Bash, jq.
+
+## Global Constraints
+
+- Branch and commit names must not contain `phase`.
+- Never auto-merge human, security-alert, or dashboard-approved major PRs.
+- Require all eight `develop` branch-protection checks and successful Renovate stability before merging.
+- Re-query PR state, current head SHA, comments, reviews, threads, and merge state immediately before a rebase merge.
+- Process one PR per run and do not merge when prior `develop` CI/security is not successful.
+- Workflow must not use `pull_request_target`, check out PR code, or receive write permissions beyond `pull-requests: write`.
+
+---
+
+### Task 1: Eligibility decision script and tests
+
+**Files:**
+- Create: `scripts/automation/merge-renovate-pr.sh`
+- Create: `scripts/automation/test-merge-renovate-pr.sh`
+
+- [ ] **Step 1: Write failing fixtures** for pending `renovate/stability-days`, comments, unresolved threads, failed required checks, changed head SHA, unclean merge state, and an eligible routine Renovate PR.
+- [ ] **Step 2: Run** `bash scripts/automation/test-merge-renovate-pr.sh` and confirm it fails because the decision script is absent.
+- [ ] **Step 3: Implement** a Bash script that reads only GitHub API responses through `gh`, emits an eligibility summary, and calls the rebase merge endpoint once only for the eligible fixture.
+- [ ] **Step 4: Re-run** `bash scripts/automation/test-merge-renovate-pr.sh` and confirm all fixtures pass.
+- [ ] **Step 5: Commit** the script and tests with a descriptive non-phase message.
+
+### Task 2: Trusted watcher workflow and contract test
+
+**Files:**
+- Create: `.github/workflows/renovate-merge-watcher.yaml`
+- Create: `scripts/automation/test-renovate-merge-watcher-workflow.sh`
+
+- [ ] **Step 1: Write a failing workflow contract test** that requires scheduled/manual trusted triggers, serial concurrency, `contents: read` plus `pull-requests: write`, no `pull_request_target`, and the decision-script invocation.
+- [ ] **Step 2: Run** `bash scripts/automation/test-renovate-merge-watcher-workflow.sh` and confirm it fails because the workflow is absent.
+- [ ] **Step 3: Implement** the workflow from `develop` only; it checks out the trusted repository revision and runs the decision script without accessing PR code.
+- [ ] **Step 4: Re-run** the workflow contract test and script test, then validate YAML and whitespace.
+- [ ] **Step 5: Commit** the workflow and contract test with a descriptive non-phase message.
+
+### Task 3: End-to-end verification and PR
+
+**Files:**
+- Modify: `docs/ci-security-bootstrap.md`
+
+- [ ] **Step 1: Document** watcher scope, exclusions, and the rule that pending stability is never mergeable.
+- [ ] **Step 2: Run** the two script test suites, `npx renovate-config-validator .github/renovate.json`, `git diff --check`, and the repository remediation workflow checks that cover CI policy.
+- [ ] **Step 3: Commit** documentation with a descriptive non-phase message.
+- [ ] **Step 4: Push and open a PR**, inspect every check, review, comment, and unresolved thread, and merge only when GitHub reports `CLEAN`.

--- a/docs/superpowers/specs/2026-07-14-renovate-merge-watcher-design.md
+++ b/docs/superpowers/specs/2026-07-14-renovate-merge-watcher-design.md
@@ -19,10 +19,15 @@ CI and security workflows finish before another dependency update can merge.
 The script accepts a PR only when all of the following are true:
 
 - the author is `app/renovate`, the head branch starts with `renovate/`, and
-  the base branch is `develop`;
+  the base branch is `develop`; REST API evaluation uses the corresponding
+  `renovate[bot]` login;
+- Renovate applied the `automerge-candidate` label, which configuration assigns
+  only to digest, pin, patch, and minor updates; and it has no security,
+  major, or dependency-dashboard label;
 - it has no comments, reviews, or unresolved review threads;
 - its `mergeStateStatus` is `CLEAN` and the head SHA is unchanged between the
-  initial and final checks;
+  initial and final checks; its `develop` base SHA is also unchanged and the
+  CI and Security push runs for that exact base SHA succeeded;
 - each of the eight protected `develop` checks is `SUCCESS` for the current
   head commit; and
 - normal Renovate updates have `renovate/stability-days` in `success` state.
@@ -39,6 +44,11 @@ from the trusted default branch checkout. A skipped or rejected PR is reported
 as an auditable workflow summary and exits successfully. API failures, failed
 required checks, an inconclusive merge state, or a merge error fail the watcher
 without attempting another PR.
+
+GitHub merge queues are unavailable for this public personal repository. The
+last base-SHA recheck reduces, but cannot atomically eliminate, a concurrent
+human merge between the recheck and the merge API request; operators must not
+merge competing `develop` PRs while the watcher is evaluating a candidate.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-07-14-renovate-merge-watcher-design.md
+++ b/docs/superpowers/specs/2026-07-14-renovate-merge-watcher-design.md
@@ -1,0 +1,50 @@
+# Renovate Merge Watcher Design
+
+## Purpose
+
+Automate only routine Renovate dependency PRs after their own policy gates are
+complete. The watcher never evaluates, checks out, runs, or merges code from a
+human-authored PR.
+
+## Scope
+
+The trusted `develop` workflow runs on a schedule and by manual dispatch. It
+uses GitHub's API to inspect open PRs, then delegates the eligibility decision
+to a checked-in Bash script. A qualifying PR is rechecked immediately before a
+rebase merge. Each run processes at most one PR, so the subsequent `develop`
+CI and security workflows finish before another dependency update can merge.
+
+## Eligibility
+
+The script accepts a PR only when all of the following are true:
+
+- the author is `app/renovate`, the head branch starts with `renovate/`, and
+  the base branch is `develop`;
+- it has no comments, reviews, or unresolved review threads;
+- its `mergeStateStatus` is `CLEAN` and the head SHA is unchanged between the
+  initial and final checks;
+- each of the eight protected `develop` checks is `SUCCESS` for the current
+  head commit; and
+- normal Renovate updates have `renovate/stability-days` in `success` state.
+
+The watcher skips vulnerability-alert PRs and dashboard-approved major updates;
+those remain explicitly reviewed. It also skips every PR when the prior
+`develop` post-merge CI or security run is not successful.
+
+## Security and failure handling
+
+The workflow does not use `pull_request_target`, does not check out PR code,
+and grants only `contents: read` and `pull-requests: write`. The script runs
+from the trusted default branch checkout. A skipped or rejected PR is reported
+as an auditable workflow summary and exits successfully. API failures, failed
+required checks, an inconclusive merge state, or a merge error fail the watcher
+without attempting another PR.
+
+## Verification
+
+Shell contract tests use a fake `gh` executable to prove that pending stability,
+comments, unresolved threads, unsuccessful checks, changing heads, and an
+unclean merge state never invoke the merge API. A positive fixture proves the
+script requests a rebase merge exactly once. The workflow contract test verifies
+the trusted trigger, minimal permissions, no PR checkout, serial concurrency,
+and script invocation.

--- a/scripts/automation/merge-renovate-pr.sh
+++ b/scripts/automation/merge-renovate-pr.sh
@@ -71,7 +71,7 @@ review_thread_state() {
 
 check_state() {
   local sha="$1"
-  local checks
+  local checks statuses
   checks="$(gh api "repos/$repo/commits/$sha/check-runs?per_page=100")"
 
   local required
@@ -79,18 +79,20 @@ check_state() {
     if ! jq -e --arg required "$required" '
       [.check_runs[] | select(.name == $required)] as $matching |
       ($matching | length) > 0 and
-      all($matching[]; .status == "completed" and .conclusion == "success")
+      (($matching | sort_by(.started_at // .completed_at // "") | last) |
+        .status == "completed" and .conclusion == "success")
     ' <<<"$checks" >/dev/null; then
       printf 'failed-required-check\n'
       return 0
     fi
   done
 
+  statuses="$(gh api "repos/$repo/commits/$sha/status")"
   if ! jq -e '
-    [.check_runs[] | select(.name == "renovate/stability-days")] as $matching |
+    [.statuses[] | select(.context == "renovate/stability-days")] as $matching |
     ($matching | length) > 0 and
-    all($matching[]; .status == "completed" and .conclusion == "success")
-  ' <<<"$checks" >/dev/null; then
+    all($matching[]; .state == "success")
+  ' <<<"$statuses" >/dev/null; then
     printf 'pending-stability\n'
     return 0
   fi

--- a/scripts/automation/merge-renovate-pr.sh
+++ b/scripts/automation/merge-renovate-pr.sh
@@ -32,7 +32,7 @@ fail() {
 
 is_routine_renovate_pr() {
   local pr="$1"
-  [[ "$(jq -r '.user.login' <<<"$pr")" == 'app/renovate' ]] || return 1
+  [[ "$(jq -r '.user.login' <<<"$pr")" == 'renovate[bot]' ]] || return 1
   [[ "$(jq -r '.head.ref' <<<"$pr")" == renovate/* ]] || return 1
   [[ "$(jq -r '.base.ref' <<<"$pr")" == 'develop' ]] || return 1
 
@@ -110,6 +110,13 @@ inspect() {
     return 0
   fi
 
+  case "$(check_state "$sha")" in
+    successful) ;;
+    pending-stability) printf 'pending-stability\n'; return 0 ;;
+    failed-required-check) printf 'failed-required-check\n'; return 0 ;;
+    *) printf 'inconclusive-check-state\n'; return 0 ;;
+  esac
+
   threads="$(review_thread_state "$number")"
   if [[ "$(jq -r '.data.repository.pullRequest.mergeStateStatus' <<<"$threads")" != 'CLEAN' ]]; then
     printf 'unclean-merge-state\n'
@@ -123,12 +130,6 @@ inspect() {
     printf 'unresolved-review-thread\n'
     return 0
   fi
-  case "$(check_state "$sha")" in
-    successful) ;;
-    pending-stability) printf 'pending-stability\n'; return 0 ;;
-    failed-required-check) printf 'failed-required-check\n'; return 0 ;;
-    *) printf 'inconclusive-check-state\n'; return 0 ;;
-  esac
 
   printf 'eligible:%s\n' "$sha"
 }

--- a/scripts/automation/merge-renovate-pr.sh
+++ b/scripts/automation/merge-renovate-pr.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script runs only from a trusted develop checkout. It reads PR metadata
+# through GitHub's API and never checks out or executes code from a PR.
+
+readonly REQUIRED_CHECKS=(
+  '.NET build, test, coverage'
+  'Frontend build and audit'
+  'Docker build and scan'
+  'Dependency review'
+  'CodeQL (csharp)'
+  'CodeQL (javascript-typescript)'
+  'CodeQL (actions)'
+  'Trivy filesystem scan'
+)
+
+repo="${GH_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+owner="${repo%%/*}"
+name="${repo#*/}"
+
+report() {
+  local decision="$1"
+  local number="${2:-none}"
+  printf 'decision=%s pr=%s\n' "$decision" "$number"
+}
+
+fail() {
+  report "$1" "$2"
+  exit 1
+}
+
+is_routine_renovate_pr() {
+  local pr="$1"
+  [[ "$(jq -r '.user.login' <<<"$pr")" == 'app/renovate' ]] || return 1
+  [[ "$(jq -r '.head.ref' <<<"$pr")" == renovate/* ]] || return 1
+  [[ "$(jq -r '.base.ref' <<<"$pr")" == 'develop' ]] || return 1
+
+  local text labels
+  text="$(jq -r '[.title, .body // ""] | join("\n") | ascii_downcase' <<<"$pr")"
+  labels="$(jq -r '[.labels[]?.name | ascii_downcase] | join("\n")' <<<"$pr")"
+
+  # Renovate represents security-alert and dashboard-approved major updates in
+  # its PR body/title or labels. These always remain maintainer-reviewed.
+  if grep -Eqi 'security update|vulnerabilit|cve-[0-9]|(^|[^a-z])major([^a-z]|$)' <<<"$text" ||
+     grep -Eqi 'security|vulnerabilit|major|dependency-dashboard' <<<"$labels"; then
+    return 1
+  fi
+}
+
+read_pr() {
+  gh api "repos/$repo/pulls/$1"
+}
+
+has_comments_or_reviews() {
+  local number="$1"
+  local comments reviews
+  comments="$(gh api "repos/$repo/issues/$number/comments?per_page=1")"
+  reviews="$(gh api "repos/$repo/pulls/$number/reviews?per_page=1")"
+  [[ "$(jq 'length' <<<"$comments")" -gt 0 || "$(jq 'length' <<<"$reviews")" -gt 0 ]]
+}
+
+review_thread_state() {
+  local number="$1"
+  gh api graphql \
+    -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){mergeStateStatus reviewThreads(first:100){nodes{isResolved} pageInfo{hasNextPage}}}}}' \
+    -f owner="$owner" \
+    -f name="$name" \
+    -F number="$number"
+}
+
+check_state() {
+  local sha="$1"
+  local checks
+  checks="$(gh api "repos/$repo/commits/$sha/check-runs?per_page=100")"
+
+  local required
+  for required in "${REQUIRED_CHECKS[@]}"; do
+    if ! jq -e --arg required "$required" '
+      [.check_runs[] | select(.name == $required)] as $matching |
+      ($matching | length) > 0 and
+      all($matching[]; .status == "completed" and .conclusion == "success")
+    ' <<<"$checks" >/dev/null; then
+      printf 'failed-required-check\n'
+      return 0
+    fi
+  done
+
+  if ! jq -e '
+    [.check_runs[] | select(.name == "renovate/stability-days")] as $matching |
+    ($matching | length) > 0 and
+    all($matching[]; .status == "completed" and .conclusion == "success")
+  ' <<<"$checks" >/dev/null; then
+    printf 'pending-stability\n'
+    return 0
+  fi
+  printf 'successful\n'
+}
+
+inspect() {
+  local number="$1"
+  local pr="$2"
+  local sha threads
+
+  sha="$(jq -r '.head.sha' <<<"$pr")"
+  if has_comments_or_reviews "$number"; then
+    printf 'comments-or-reviews\n'
+    return 0
+  fi
+
+  threads="$(review_thread_state "$number")"
+  if [[ "$(jq -r '.data.repository.pullRequest.mergeStateStatus' <<<"$threads")" != 'CLEAN' ]]; then
+    printf 'unclean-merge-state\n'
+    return 0
+  fi
+  if [[ "$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$threads")" != 'false' ]]; then
+    printf 'inconclusive-review-threads\n'
+    return 0
+  fi
+  if jq -e '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length > 0' <<<"$threads" >/dev/null; then
+    printf 'unresolved-review-thread\n'
+    return 0
+  fi
+  case "$(check_state "$sha")" in
+    successful) ;;
+    pending-stability) printf 'pending-stability\n'; return 0 ;;
+    failed-required-check) printf 'failed-required-check\n'; return 0 ;;
+    *) printf 'inconclusive-check-state\n'; return 0 ;;
+  esac
+
+  printf 'eligible:%s\n' "$sha"
+}
+
+prior_develop_workflows_are_successful() {
+  local workflow runs
+  for workflow in ci.yaml security.yaml; do
+    runs="$(gh api "repos/$repo/actions/workflows/$workflow/runs?branch=develop&event=push&per_page=1")"
+    jq -e '.workflow_runs | length == 1 and .[0].conclusion == "success"' <<<"$runs" >/dev/null || return 1
+  done
+}
+
+if ! prior_develop_workflows_are_successful; then
+  fail 'prior-develop-workflow-not-successful' none
+fi
+
+numbers="$(gh api "repos/$repo/pulls?state=open&base=develop&per_page=100" | jq -r '.[].number')"
+if [[ -z "$numbers" ]]; then
+  report 'no-open-renovate-pr' none
+  exit 0
+fi
+
+number=''
+initial_pr=''
+while IFS= read -r candidate; do
+  pr="$(read_pr "$candidate")"
+  if is_routine_renovate_pr "$pr"; then
+    number="$candidate"
+    initial_pr="$pr"
+    break
+  fi
+done <<<"$numbers"
+
+if [[ -z "$number" ]]; then
+  report 'no-routine-renovate-pr' none
+  exit 0
+fi
+
+initial_result="$(inspect "$number" "$initial_pr")"
+case "$initial_result" in
+  eligible:*) initial_sha="${initial_result#eligible:}" ;;
+  comments-or-reviews) report 'skipped-comments-or-reviews' "$number"; exit 0 ;;
+  unresolved-review-thread) report 'skipped-unresolved-review-thread' "$number"; exit 0 ;;
+  pending-stability) report 'skipped-pending-stability' "$number"; exit 0 ;;
+  unclean-merge-state|inconclusive-review-threads) fail "$initial_result" "$number" ;;
+  failed-required-check) fail 'failed-required-check' "$number" ;;
+  *) fail 'unexpected-inspection-result' "$number" ;;
+esac
+
+final_pr="$(read_pr "$number")"
+if ! is_routine_renovate_pr "$final_pr"; then
+  fail 'pr-no-longer-routine-renovate' "$number"
+fi
+final_sha="$(jq -r '.head.sha' <<<"$final_pr")"
+if [[ "$final_sha" != "$initial_sha" ]]; then
+  fail 'changed-head' "$number"
+fi
+
+final_result="$(inspect "$number" "$final_pr")"
+case "$final_result" in
+  "eligible:$initial_sha") ;;
+  comments-or-reviews) report 'skipped-comments-or-reviews' "$number"; exit 0 ;;
+  unresolved-review-thread) report 'skipped-unresolved-review-thread' "$number"; exit 0 ;;
+  pending-stability) report 'skipped-pending-stability' "$number"; exit 0 ;;
+  unclean-merge-state|inconclusive-review-threads) fail "$final_result" "$number" ;;
+  failed-required-check) fail 'failed-required-check' "$number" ;;
+  *) fail 'changed-head-or-checks' "$number" ;;
+esac
+
+if ! prior_develop_workflows_are_successful; then
+  fail 'prior-develop-workflow-not-successful' "$number"
+fi
+
+merge_response="$(gh api -X PUT "repos/$repo/pulls/$number/merge" \
+  -f merge_method=rebase \
+  -f sha="$initial_sha")"
+if ! jq -e '.merged == true' <<<"$merge_response" >/dev/null; then
+  fail 'merge-not-completed' "$number"
+fi
+report 'merged' "$number"

--- a/scripts/automation/merge-renovate-pr.sh
+++ b/scripts/automation/merge-renovate-pr.sh
@@ -36,14 +36,13 @@ is_routine_renovate_pr() {
   [[ "$(jq -r '.head.ref' <<<"$pr")" == renovate/* ]] || return 1
   [[ "$(jq -r '.base.ref' <<<"$pr")" == 'develop' ]] || return 1
 
-  local text labels
-  text="$(jq -r '[.title, .body // ""] | join("\n") | ascii_downcase' <<<"$pr")"
+  local labels
   labels="$(jq -r '[.labels[]?.name | ascii_downcase] | join("\n")' <<<"$pr")"
 
-  # Renovate represents security-alert and dashboard-approved major updates in
-  # its PR body/title or labels. These always remain maintainer-reviewed.
-  if grep -Eqi 'security update|vulnerabilit|cve-[0-9]|(^|[^a-z])major([^a-z]|$)' <<<"$text" ||
-     grep -Eqi 'security|vulnerabilit|major|dependency-dashboard' <<<"$labels"; then
+  # Renovate assigns this label only to explicitly configured routine update
+  # types. Security alerts and dashboard-approved majors never receive it.
+  grep -Fxq 'automerge-candidate' <<<"$labels" || return 1
+  if grep -Eqi 'security|vulnerabilit|major|dependency-dashboard' <<<"$labels"; then
     return 1
   fi
 }
@@ -72,15 +71,14 @@ review_thread_state() {
 check_state() {
   local sha="$1"
   local checks statuses
-  checks="$(gh api "repos/$repo/commits/$sha/check-runs?per_page=100")"
+  checks="$(gh api "repos/$repo/commits/$sha/check-runs?filter=latest&per_page=100")"
 
   local required
   for required in "${REQUIRED_CHECKS[@]}"; do
     if ! jq -e --arg required "$required" '
       [.check_runs[] | select(.name == $required)] as $matching |
       ($matching | length) > 0 and
-      (($matching | sort_by(.started_at // .completed_at // "") | last) |
-        .status == "completed" and .conclusion == "success")
+      all($matching[]; .status == "completed" and .conclusion == "success")
     ' <<<"$checks" >/dev/null; then
       printf 'failed-required-check\n'
       return 0
@@ -135,16 +133,16 @@ inspect() {
 }
 
 prior_develop_workflows_are_successful() {
+  local base_sha="$1"
   local workflow runs
   for workflow in ci.yaml security.yaml; do
     runs="$(gh api "repos/$repo/actions/workflows/$workflow/runs?branch=develop&event=push&per_page=1")"
-    jq -e '.workflow_runs | length == 1 and .[0].conclusion == "success"' <<<"$runs" >/dev/null || return 1
+    jq -e --arg base_sha "$base_sha" '
+      [.workflow_runs[] | select(.head_sha == $base_sha)] |
+      length == 1 and .[0].conclusion == "success"
+    ' <<<"$runs" >/dev/null || return 1
   done
 }
-
-if ! prior_develop_workflows_are_successful; then
-  fail 'prior-develop-workflow-not-successful' none
-fi
 
 numbers="$(gh api "repos/$repo/pulls?state=open&base=develop&per_page=100" | jq -r '.[].number')"
 if [[ -z "$numbers" ]]; then
@@ -178,6 +176,10 @@ case "$initial_result" in
   failed-required-check) fail 'failed-required-check' "$number" ;;
   *) fail 'unexpected-inspection-result' "$number" ;;
 esac
+initial_base_sha="$(jq -r '.base.sha' <<<"$initial_pr")"
+if ! prior_develop_workflows_are_successful "$initial_base_sha"; then
+  fail 'prior-develop-workflow-not-successful' "$number"
+fi
 
 final_pr="$(read_pr "$number")"
 if ! is_routine_renovate_pr "$final_pr"; then
@@ -186,6 +188,10 @@ fi
 final_sha="$(jq -r '.head.sha' <<<"$final_pr")"
 if [[ "$final_sha" != "$initial_sha" ]]; then
   fail 'changed-head' "$number"
+fi
+final_base_sha="$(jq -r '.base.sha' <<<"$final_pr")"
+if [[ "$final_base_sha" != "$initial_base_sha" ]]; then
+  fail 'changed-base' "$number"
 fi
 
 final_result="$(inspect "$number" "$final_pr")"
@@ -199,7 +205,7 @@ case "$final_result" in
   *) fail 'changed-head-or-checks' "$number" ;;
 esac
 
-if ! prior_develop_workflows_are_successful; then
+if ! prior_develop_workflows_are_successful "$initial_base_sha"; then
   fail 'prior-develop-workflow-not-successful' "$number"
 fi
 

--- a/scripts/automation/test-merge-renovate-pr.sh
+++ b/scripts/automation/test-merge-renovate-pr.sh
@@ -38,7 +38,7 @@ if [[ "$args" == *"/pulls/42 "* ]]; then
   if [[ "$fixture" == "changed-head" && "$count" -gt 1 ]]; then
     head_sha="head-b"
   fi
-  printf '{"number":42,"user":{"login":"app/renovate"},"head":{"ref":"renovate/pin-postgres","sha":"%s"},"base":{"ref":"develop"},"title":"chore(deps): pin postgres","body":"Routine update","labels":[]}' "$head_sha"
+  printf '{"number":42,"user":{"login":"renovate[bot]"},"head":{"ref":"renovate/pin-postgres","sha":"%s"},"base":{"ref":"develop"},"title":"chore(deps): pin postgres","body":"Routine update","labels":[]}' "$head_sha"
   exit 0
 fi
 
@@ -59,6 +59,8 @@ fi
 if [[ "$args" == *" graphql "* ]]; then
   if [[ "$fixture" == "unresolved-threads" ]]; then
     printf '%s\n' '{"data":{"repository":{"pullRequest":{"mergeStateStatus":"CLEAN","reviewThreads":{"nodes":[{"isResolved":false}],"pageInfo":{"hasNextPage":false}}}}}}'
+  elif [[ "$fixture" == "pending-stability" ]]; then
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"mergeStateStatus":"BLOCKED","reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}}'
   elif [[ "$fixture" == "unclean-merge-state" ]]; then
     printf '%s\n' '{"data":{"repository":{"pullRequest":{"mergeStateStatus":"DIRTY","reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}}'
   else

--- a/scripts/automation/test-merge-renovate-pr.sh
+++ b/scripts/automation/test-merge-renovate-pr.sh
@@ -67,16 +67,21 @@ if [[ "$args" == *" graphql "* ]]; then
   exit 0
 fi
 
-if [[ "$args" == *"/commits/"*"/check-runs?"* ]]; then
-  stability='{"name":"renovate/stability-days","status":"completed","conclusion":"success"}'
+if [[ "$args" == *"/commits/"*"/status "* ]]; then
+  stability='{"context":"renovate/stability-days","state":"success"}'
   if [[ "$fixture" == "pending-stability" ]]; then
-    stability='{"name":"renovate/stability-days","status":"in_progress","conclusion":null}'
+    stability='{"context":"renovate/stability-days","state":"pending"}'
   fi
-  required='[{"name":".NET build, test, coverage","status":"completed","conclusion":"success"},{"name":"Frontend build and audit","status":"completed","conclusion":"success"},{"name":"Docker build and scan","status":"completed","conclusion":"success"},{"name":"Dependency review","status":"completed","conclusion":"success"},{"name":"CodeQL (csharp)","status":"completed","conclusion":"success"},{"name":"CodeQL (javascript-typescript)","status":"completed","conclusion":"success"},{"name":"CodeQL (actions)","status":"completed","conclusion":"success"},{"name":"Trivy filesystem scan","status":"completed","conclusion":"success"}]'
+  printf '{"statuses":[%s]}' "$stability"
+  exit 0
+fi
+
+if [[ "$args" == *"/commits/"*"/check-runs?"* ]]; then
+  required='[{"name":".NET build, test, coverage","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"Frontend build and audit","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"Docker build and scan","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"Dependency review","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"CodeQL (csharp)","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"CodeQL (javascript-typescript)","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"CodeQL (actions)","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"Trivy filesystem scan","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":".NET build, test, coverage","status":"completed","conclusion":"cancelled","started_at":"2026-07-14T16:00:00Z"}]'
   if [[ "$fixture" == "failed-required-check" ]]; then
     required='[{"name":".NET build, test, coverage","status":"completed","conclusion":"failure"},{"name":"Frontend build and audit","status":"completed","conclusion":"success"},{"name":"Docker build and scan","status":"completed","conclusion":"success"},{"name":"Dependency review","status":"completed","conclusion":"success"},{"name":"CodeQL (csharp)","status":"completed","conclusion":"success"},{"name":"CodeQL (javascript-typescript)","status":"completed","conclusion":"success"},{"name":"CodeQL (actions)","status":"completed","conclusion":"success"},{"name":"Trivy filesystem scan","status":"completed","conclusion":"success"}]'
   fi
-  printf '{"check_runs":%s}' "$(printf '%s' "$required" | jq --argjson stability "$stability" '. + [$stability]')"
+  printf '{"check_runs":%s}' "$required"
   exit 0
 fi
 

--- a/scripts/automation/test-merge-renovate-pr.sh
+++ b/scripts/automation/test-merge-renovate-pr.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/automation/merge-renovate-pr.sh"
+
+test -x "$SCRIPT"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+
+cat >"$tmp/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args=" $* "
+fixture="${WATCHER_FIXTURE:?WATCHER_FIXTURE must be set}"
+state_dir="${WATCHER_STATE_DIR:?WATCHER_STATE_DIR must be set}"
+
+if [[ "$args" == *"/actions/workflows/ci.yaml/runs?"* || "$args" == *"/actions/workflows/security.yaml/runs?"* ]]; then
+  printf '%s\n' '{"workflow_runs":[{"conclusion":"success"}]}'
+  exit 0
+fi
+
+if [[ "$args" == *"/pulls?state=open&base=develop"* ]]; then
+  printf '%s\n' '[{"number":42}]'
+  exit 0
+fi
+
+if [[ "$args" == *"/pulls/42 "* ]]; then
+  count_file="$state_dir/pr_reads"
+  count=0
+  [[ -f "$count_file" ]] && count="$(<"$count_file")"
+  count=$((count + 1))
+  printf '%s' "$count" >"$count_file"
+  head_sha="head-a"
+  if [[ "$fixture" == "changed-head" && "$count" -gt 1 ]]; then
+    head_sha="head-b"
+  fi
+  printf '{"number":42,"user":{"login":"app/renovate"},"head":{"ref":"renovate/pin-postgres","sha":"%s"},"base":{"ref":"develop"},"title":"chore(deps): pin postgres","body":"Routine update","labels":[]}' "$head_sha"
+  exit 0
+fi
+
+if [[ "$args" == *"/issues/42/comments?"* ]]; then
+  if [[ "$fixture" == "comments" ]]; then
+    printf '%s\n' '[{"id":1}]'
+  else
+    printf '%s\n' '[]'
+  fi
+  exit 0
+fi
+
+if [[ "$args" == *"/pulls/42/reviews?"* ]]; then
+  printf '%s\n' '[]'
+  exit 0
+fi
+
+if [[ "$args" == *" graphql "* ]]; then
+  if [[ "$fixture" == "unresolved-threads" ]]; then
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"mergeStateStatus":"CLEAN","reviewThreads":{"nodes":[{"isResolved":false}],"pageInfo":{"hasNextPage":false}}}}}}'
+  elif [[ "$fixture" == "unclean-merge-state" ]]; then
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"mergeStateStatus":"DIRTY","reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}}'
+  else
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"mergeStateStatus":"CLEAN","reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}}'
+  fi
+  exit 0
+fi
+
+if [[ "$args" == *"/commits/"*"/check-runs?"* ]]; then
+  stability='{"name":"renovate/stability-days","status":"completed","conclusion":"success"}'
+  if [[ "$fixture" == "pending-stability" ]]; then
+    stability='{"name":"renovate/stability-days","status":"in_progress","conclusion":null}'
+  fi
+  required='[{"name":".NET build, test, coverage","status":"completed","conclusion":"success"},{"name":"Frontend build and audit","status":"completed","conclusion":"success"},{"name":"Docker build and scan","status":"completed","conclusion":"success"},{"name":"Dependency review","status":"completed","conclusion":"success"},{"name":"CodeQL (csharp)","status":"completed","conclusion":"success"},{"name":"CodeQL (javascript-typescript)","status":"completed","conclusion":"success"},{"name":"CodeQL (actions)","status":"completed","conclusion":"success"},{"name":"Trivy filesystem scan","status":"completed","conclusion":"success"}]'
+  if [[ "$fixture" == "failed-required-check" ]]; then
+    required='[{"name":".NET build, test, coverage","status":"completed","conclusion":"failure"},{"name":"Frontend build and audit","status":"completed","conclusion":"success"},{"name":"Docker build and scan","status":"completed","conclusion":"success"},{"name":"Dependency review","status":"completed","conclusion":"success"},{"name":"CodeQL (csharp)","status":"completed","conclusion":"success"},{"name":"CodeQL (javascript-typescript)","status":"completed","conclusion":"success"},{"name":"CodeQL (actions)","status":"completed","conclusion":"success"},{"name":"Trivy filesystem scan","status":"completed","conclusion":"success"}]'
+  fi
+  printf '{"check_runs":%s}' "$(printf '%s' "$required" | jq --argjson stability "$stability" '. + [$stability]')"
+  exit 0
+fi
+
+if [[ "$args" == *" -X PUT "* && "$args" == *"/pulls/42/merge "* ]]; then
+  [[ "$args" == *" merge_method=rebase "* && "$args" == *" sha=head-a "* ]] || {
+    echo "merge was not bound to the rechecked head with rebase: $*" >&2
+    exit 98
+  }
+  printf '%s\n' merge >>"$state_dir/calls"
+  printf '%s\n' '{"merged":true}'
+  exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 99
+EOF
+chmod +x "$tmp/bin/gh"
+
+run_fixture() {
+  local fixture="$1"
+  local expected_exit="$2"
+  local expected_decision="$3"
+  local state_dir="$tmp/$fixture"
+  mkdir -p "$state_dir"
+
+  set +e
+  PATH="$tmp/bin:$PATH" GH_REPO=example/registry WATCHER_FIXTURE="$fixture" WATCHER_STATE_DIR="$state_dir" "$SCRIPT" >"$state_dir/output" 2>&1
+  local actual_exit=$?
+  set -e
+
+  if [[ "$actual_exit" -ne "$expected_exit" ]]; then
+    cat "$state_dir/output" >&2
+    echo "$fixture exited $actual_exit; expected $expected_exit" >&2
+    exit 1
+  fi
+  if [[ -e "$state_dir/calls" ]]; then
+    echo "$fixture invoked merge: $fixture" >&2
+    exit 1
+  fi
+  grep -Fq "decision=$expected_decision pr=42" "$state_dir/output"
+}
+
+run_fixture pending-stability 0 skipped-pending-stability
+run_fixture comments 0 skipped-comments-or-reviews
+run_fixture unresolved-threads 0 skipped-unresolved-review-thread
+run_fixture failed-required-check 1 failed-required-check
+run_fixture changed-head 1 changed-head
+run_fixture unclean-merge-state 1 unclean-merge-state
+
+eligible_state="$tmp/eligible"
+mkdir -p "$eligible_state"
+PATH="$tmp/bin:$PATH" GH_REPO=example/registry WATCHER_FIXTURE=eligible WATCHER_STATE_DIR="$eligible_state" "$SCRIPT" >"$eligible_state/output" 2>&1
+test "$(wc -l <"$eligible_state/calls")" -eq 1
+grep -Fqx 'decision=merged pr=42' "$eligible_state/output"
+
+echo 'merge-renovate-pr tests: 7 fixtures passed'

--- a/scripts/automation/test-merge-renovate-pr.sh
+++ b/scripts/automation/test-merge-renovate-pr.sh
@@ -19,7 +19,7 @@ fixture="${WATCHER_FIXTURE:?WATCHER_FIXTURE must be set}"
 state_dir="${WATCHER_STATE_DIR:?WATCHER_STATE_DIR must be set}"
 
 if [[ "$args" == *"/actions/workflows/ci.yaml/runs?"* || "$args" == *"/actions/workflows/security.yaml/runs?"* ]]; then
-  printf '%s\n' '{"workflow_runs":[{"conclusion":"success"}]}'
+  printf '%s\n' '{"workflow_runs":[{"head_sha":"base-a","conclusion":"success"}]}'
   exit 0
 fi
 
@@ -35,10 +35,18 @@ if [[ "$args" == *"/pulls/42 "* ]]; then
   count=$((count + 1))
   printf '%s' "$count" >"$count_file"
   head_sha="head-a"
+  base_sha="base-a"
   if [[ "$fixture" == "changed-head" && "$count" -gt 1 ]]; then
     head_sha="head-b"
   fi
-  printf '{"number":42,"user":{"login":"renovate[bot]"},"head":{"ref":"renovate/pin-postgres","sha":"%s"},"base":{"ref":"develop"},"title":"chore(deps): pin postgres","body":"Routine update","labels":[]}' "$head_sha"
+  if [[ "$fixture" == "changed-base" && "$count" -gt 1 ]]; then
+    base_sha="base-b"
+  fi
+  labels='[{"name":"dependencies"},{"name":"automerge-candidate"}]'
+  if [[ "$fixture" == "dashboard-major" ]]; then
+    labels='[{"name":"dependencies"}]'
+  fi
+  printf '{"number":42,"user":{"login":"renovate[bot]"},"head":{"ref":"renovate/pin-postgres","sha":"%s"},"base":{"ref":"develop","sha":"%s"},"title":"chore(deps): pin postgres","body":"Routine update","labels":%s}' "$head_sha" "$base_sha" "$labels"
   exit 0
 fi
 
@@ -79,9 +87,16 @@ if [[ "$args" == *"/commits/"*"/status "* ]]; then
 fi
 
 if [[ "$args" == *"/commits/"*"/check-runs?"* ]]; then
-  required='[{"name":".NET build, test, coverage","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"Frontend build and audit","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"Docker build and scan","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"Dependency review","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"CodeQL (csharp)","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"CodeQL (javascript-typescript)","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"CodeQL (actions)","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":"Trivy filesystem scan","status":"completed","conclusion":"success","started_at":"2026-07-14T17:00:00Z"},{"name":".NET build, test, coverage","status":"completed","conclusion":"cancelled","started_at":"2026-07-14T16:00:00Z"}]'
+  [[ "$args" == *"filter=latest"* ]] || {
+    echo "check-runs request did not use filter=latest: $*" >&2
+    exit 97
+  }
+  required='[{"name":".NET build, test, coverage","status":"completed","conclusion":"success"},{"name":"Frontend build and audit","status":"completed","conclusion":"success"},{"name":"Docker build and scan","status":"completed","conclusion":"success"},{"name":"Dependency review","status":"completed","conclusion":"success"},{"name":"CodeQL (csharp)","status":"completed","conclusion":"success"},{"name":"CodeQL (javascript-typescript)","status":"completed","conclusion":"success"},{"name":"CodeQL (actions)","status":"completed","conclusion":"success"},{"name":"Trivy filesystem scan","status":"completed","conclusion":"success"}]'
   if [[ "$fixture" == "failed-required-check" ]]; then
     required='[{"name":".NET build, test, coverage","status":"completed","conclusion":"failure"},{"name":"Frontend build and audit","status":"completed","conclusion":"success"},{"name":"Docker build and scan","status":"completed","conclusion":"success"},{"name":"Dependency review","status":"completed","conclusion":"success"},{"name":"CodeQL (csharp)","status":"completed","conclusion":"success"},{"name":"CodeQL (javascript-typescript)","status":"completed","conclusion":"success"},{"name":"CodeQL (actions)","status":"completed","conclusion":"success"},{"name":"Trivy filesystem scan","status":"completed","conclusion":"success"}]'
+  fi
+  if [[ "$fixture" == "queued-required-check" ]]; then
+    required='[{"name":".NET build, test, coverage","status":"queued","conclusion":null},{"name":"Frontend build and audit","status":"completed","conclusion":"success"},{"name":"Docker build and scan","status":"completed","conclusion":"success"},{"name":"Dependency review","status":"completed","conclusion":"success"},{"name":"CodeQL (csharp)","status":"completed","conclusion":"success"},{"name":"CodeQL (javascript-typescript)","status":"completed","conclusion":"success"},{"name":"CodeQL (actions)","status":"completed","conclusion":"success"},{"name":"Trivy filesystem scan","status":"completed","conclusion":"success"}]'
   fi
   printf '{"check_runs":%s}' "$required"
   exit 0
@@ -130,8 +145,16 @@ run_fixture pending-stability 0 skipped-pending-stability
 run_fixture comments 0 skipped-comments-or-reviews
 run_fixture unresolved-threads 0 skipped-unresolved-review-thread
 run_fixture failed-required-check 1 failed-required-check
+run_fixture queued-required-check 1 failed-required-check
 run_fixture changed-head 1 changed-head
+run_fixture changed-base 1 changed-base
 run_fixture unclean-merge-state 1 unclean-merge-state
+
+dashboard_state="$tmp/dashboard-major"
+mkdir -p "$dashboard_state"
+PATH="$tmp/bin:$PATH" GH_REPO=example/registry WATCHER_FIXTURE=dashboard-major WATCHER_STATE_DIR="$dashboard_state" "$SCRIPT" >"$dashboard_state/output" 2>&1
+! test -e "$dashboard_state/calls"
+grep -Fqx 'decision=no-routine-renovate-pr pr=none' "$dashboard_state/output"
 
 eligible_state="$tmp/eligible"
 mkdir -p "$eligible_state"
@@ -139,4 +162,4 @@ PATH="$tmp/bin:$PATH" GH_REPO=example/registry WATCHER_FIXTURE=eligible WATCHER_
 test "$(wc -l <"$eligible_state/calls")" -eq 1
 grep -Fqx 'decision=merged pr=42' "$eligible_state/output"
 
-echo 'merge-renovate-pr tests: 7 fixtures passed'
+echo 'merge-renovate-pr tests: 10 fixtures passed'

--- a/scripts/automation/test-renovate-merge-watcher-workflow.sh
+++ b/scripts/automation/test-renovate-merge-watcher-workflow.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+workflow="$root/.github/workflows/renovate-merge-watcher.yaml"
+
+test -f "$workflow"
+
+grep -Fxq 'name: Renovate merge watcher' "$workflow"
+grep -Fxq '  schedule:' "$workflow"
+grep -Fxq '  workflow_dispatch:' "$workflow"
+! grep -Fq 'pull_request_target:' "$workflow"
+grep -Fxq '  contents: read' "$workflow"
+grep -Fxq '  pull-requests: write' "$workflow"
+grep -Fq 'cancel-in-progress: false' "$workflow"
+grep -Fq 'bash scripts/automation/merge-renovate-pr.sh' "$workflow"
+! grep -Fq 'ref: ${{ github.event.pull_request.head.sha }}' "$workflow"
+! grep -Fq 'ref: ${{ github.event.pull_request.head.ref }}' "$workflow"


### PR DESCRIPTION
## Summary
- add a trusted scheduled/manual Renovate-only merge watcher
- require a Renovate-controlled eligibility label, fresh successful CI/security checks, successful stability status, clean reviews/threads, and unchanged head/base SHAs
- document the public-personal-repository merge-queue limitation and safe fallback

## Verification
- `bash scripts/automation/test-merge-renovate-pr.sh` (10 fixtures)
- `bash scripts/automation/test-renovate-merge-watcher-workflow.sh`
- `bash scripts/remediation/gates/test-supply-chain-pinning.sh`
- `bash scripts/remediation/validate-requirement-evidence.sh --check`
- `npx --yes --package renovate renovate-config-validator .github/renovate.json`
- real API dry run: #132 reported ineligible and made no merge request
- independent review approved after safety fixes