### PR TITLE
fix: defer Renovate checks still settling

### DIFF
--- a/docs/ci-security-bootstrap.md
+++ b/docs/ci-security-bootstrap.md
@@ -35,6 +35,9 @@ checking out or executing their code, and can merge at most one with a rebase.
 It requires the protected CI/security checks, `renovate/stability-days`, a
 clean current merge state, an unchanged head SHA, and no comments, reviews, or
 unresolved review threads. A pending stability status is never mergeable.
+Queued, in-progress, or superseded-cancelled required checks defer the watcher
+successfully; a completed non-success check remains blocking and is reported as
+a watcher failure.
 
 Renovate applies `automerge-candidate` only to digest, pin, patch, and minor
 updates. The watcher requires that label and rejects `security`,

--- a/scripts/automation/merge-renovate-pr.sh
+++ b/scripts/automation/merge-renovate-pr.sh
@@ -77,9 +77,22 @@ check_state() {
   for required in "${REQUIRED_CHECKS[@]}"; do
     if ! jq -e --arg required "$required" '
       [.check_runs[] | select(.name == $required)] as $matching |
-      ($matching | length) > 0 and
-      all($matching[]; .status == "completed" and .conclusion == "success")
+      ($matching | length) > 0 and all($matching[]; .status == "completed")
     ' <<<"$checks" >/dev/null; then
+      printf 'pending-required-check\n'
+      return 0
+    fi
+    if ! jq -e --arg required "$required" '
+      [.check_runs[] | select(.name == $required)] as $matching |
+      all($matching[]; .conclusion == "success")
+    ' <<<"$checks" >/dev/null; then
+      if jq -e --arg required "$required" '
+        [.check_runs[] | select(.name == $required)] |
+        any(.[]; .conclusion == "cancelled")
+      ' <<<"$checks" >/dev/null; then
+        printf 'pending-required-check\n'
+        return 0
+      fi
       printf 'failed-required-check\n'
       return 0
     fi
@@ -110,6 +123,7 @@ inspect() {
 
   case "$(check_state "$sha")" in
     successful) ;;
+    pending-required-check) printf 'pending-required-check\n'; return 0 ;;
     pending-stability) printf 'pending-stability\n'; return 0 ;;
     failed-required-check) printf 'failed-required-check\n'; return 0 ;;
     *) printf 'inconclusive-check-state\n'; return 0 ;;
@@ -169,6 +183,7 @@ fi
 initial_result="$(inspect "$number" "$initial_pr")"
 case "$initial_result" in
   eligible:*) initial_sha="${initial_result#eligible:}" ;;
+  pending-required-check) report 'skipped-pending-required-check' "$number"; exit 0 ;;
   comments-or-reviews) report 'skipped-comments-or-reviews' "$number"; exit 0 ;;
   unresolved-review-thread) report 'skipped-unresolved-review-thread' "$number"; exit 0 ;;
   pending-stability) report 'skipped-pending-stability' "$number"; exit 0 ;;
@@ -197,6 +212,7 @@ fi
 final_result="$(inspect "$number" "$final_pr")"
 case "$final_result" in
   "eligible:$initial_sha") ;;
+  pending-required-check) report 'skipped-pending-required-check' "$number"; exit 0 ;;
   comments-or-reviews) report 'skipped-comments-or-reviews' "$number"; exit 0 ;;
   unresolved-review-thread) report 'skipped-unresolved-review-thread' "$number"; exit 0 ;;
   pending-stability) report 'skipped-pending-stability' "$number"; exit 0 ;;

--- a/scripts/automation/test-merge-renovate-pr.sh
+++ b/scripts/automation/test-merge-renovate-pr.sh
@@ -98,6 +98,9 @@ if [[ "$args" == *"/commits/"*"/check-runs?"* ]]; then
   if [[ "$fixture" == "queued-required-check" ]]; then
     required='[{"name":".NET build, test, coverage","status":"queued","conclusion":null},{"name":"Frontend build and audit","status":"completed","conclusion":"success"},{"name":"Docker build and scan","status":"completed","conclusion":"success"},{"name":"Dependency review","status":"completed","conclusion":"success"},{"name":"CodeQL (csharp)","status":"completed","conclusion":"success"},{"name":"CodeQL (javascript-typescript)","status":"completed","conclusion":"success"},{"name":"CodeQL (actions)","status":"completed","conclusion":"success"},{"name":"Trivy filesystem scan","status":"completed","conclusion":"success"}]'
   fi
+  if [[ "$fixture" == "cancelled-required-check" ]]; then
+    required='[{"name":".NET build, test, coverage","status":"completed","conclusion":"success"},{"name":"Frontend build and audit","status":"completed","conclusion":"success"},{"name":"Docker build and scan","status":"completed","conclusion":"cancelled"},{"name":"Dependency review","status":"completed","conclusion":"success"},{"name":"CodeQL (csharp)","status":"completed","conclusion":"success"},{"name":"CodeQL (javascript-typescript)","status":"completed","conclusion":"success"},{"name":"CodeQL (actions)","status":"completed","conclusion":"success"},{"name":"Trivy filesystem scan","status":"completed","conclusion":"success"}]'
+  fi
   printf '{"check_runs":%s}' "$required"
   exit 0
 fi
@@ -145,7 +148,8 @@ run_fixture pending-stability 0 skipped-pending-stability
 run_fixture comments 0 skipped-comments-or-reviews
 run_fixture unresolved-threads 0 skipped-unresolved-review-thread
 run_fixture failed-required-check 1 failed-required-check
-run_fixture queued-required-check 1 failed-required-check
+run_fixture queued-required-check 0 skipped-pending-required-check
+run_fixture cancelled-required-check 0 skipped-pending-required-check
 run_fixture changed-head 1 changed-head
 run_fixture changed-base 1 changed-base
 run_fixture unclean-merge-state 1 unclean-merge-state
@@ -162,4 +166,4 @@ PATH="$tmp/bin:$PATH" GH_REPO=example/registry WATCHER_FIXTURE=eligible WATCHER_
 test "$(wc -l <"$eligible_state/calls")" -eq 1
 grep -Fqx 'decision=merged pr=42' "$eligible_state/output"
 
-echo 'merge-renovate-pr tests: 10 fixtures passed'
+echo 'merge-renovate-pr tests: 11 fixtures passed'


### PR DESCRIPTION
## Summary
- defer rather than fail while required CI checks are queued, in progress, or superseded-cancelled
- retain hard failure behavior for completed unsuccessful required checks
- add cancelled-check regression coverage and document the distinction

## Verification
- `bash scripts/automation/test-merge-renovate-pr.sh` (11 fixtures)
- `bash scripts/automation/test-renovate-merge-watcher-workflow.sh`
- `bash scripts/remediation/gates/test-supply-chain-pinning.sh`
- `bash scripts/remediation/validate-requirement-evidence.sh --check`
- real API dry run reported `skipped-pending-required-check` for #132 with no merge request