### PR TITLE
chore: retire completed remediation tooling

### DIFF
--- a/docs/superpowers/plans/2026-07-15-remediation-cleanup.md
+++ b/docs/superpowers/plans/2026-07-15-remediation-cleanup.md
@@ -1,0 +1,86 @@
+# Remediation Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace completed-remediation automation with durable verification tooling and remove campaign-only CI, scripts, and documentation.
+
+**Architecture:** Durable safeguards move unchanged from `scripts/remediation/` to `scripts/verification/`; workflows and user-facing runbooks refer only to the new location. CI jobs attached exclusively to historical audit branches, together with their scripts and bootstrap documentation, are removed.
+
+**Tech Stack:** Bash, GitHub Actions YAML, Markdown, Ruby YAML parser.
+
+## Global Constraints
+
+- Preserve supply-chain, release-runbook, storage-emulator, Terraform backend, and final-candidate behavior.
+- Remove active `scripts/remediation/` callers without changing application code.
+- Use static verification because .NET SDK 10.0.301 is unavailable in this environment.
+
+---
+
+### Task 1: Relocate durable verification tooling
+
+**Files:**
+
+- Move retained gate scripts to `scripts/verification/gates/`.
+- Move storage emulators, Terraform smoke/matrix tooling, and the backup/restore evidence helper to `scripts/verification/`.
+- Modify relocated scripts to refer only to `scripts/verification/` paths.
+
+**Interfaces:** Produces the same executable command-line entry points under `scripts/verification/`.
+
+- [ ] **Step 1: Move the retained files with `git mv`.**
+
+Run `git mv scripts/remediation/storage-emulators scripts/verification/storage-emulators`; move supply-chain, release-runbook, and final-candidate scripts from `scripts/remediation/gates/` to `scripts/verification/gates/`; then move `terraform-backend-matrix.sh`, `test-terraform-backend-matrix.sh`, `terraform-provider-smoke.Dockerfile`, `phase-1-storage-emulator-terraform-smoke.sh`, `phase-1-local-terraform-smoke.sh`, and `phase-0-backup-restore-evidence.sh` into `scripts/verification/`.
+
+- [ ] **Step 2: Replace internal `scripts/remediation/` references in the moved scripts with `scripts/verification/`.**
+
+- [ ] **Step 3: Run `find scripts/verification -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n`; expect exit status 0.**
+
+- [ ] **Step 4: Commit with `git commit -m "chore: relocate durable verification scripts"`.**
+
+### Task 2: Retire campaign-only CI and scripts
+
+**Files:**
+
+- Delete the remaining `scripts/remediation/` directory.
+- Delete `.github/workflows/phase-1-real-azure-gate.yaml`.
+- Modify `.github/workflows/ci.yaml` and `.github/workflows/security.yaml`.
+
+**Interfaces:** CI retains ordinary verification and release-candidate certification without historical audit branch selectors.
+
+- [ ] **Step 1: Delete audit-only jobs from `.github/workflows/ci.yaml`: `migration-safety-gate`, `phase-1-deployment-gate`, `bounded-ingestion-security-gate`, `mirror-containment-gate`, `publication-fault-gate`, `fault-load-certification`, and `operability-certification`.**
+
+- [ ] **Step 2: Remove `remediation/phase/**` trigger branches from CI and security workflows, then replace retained workflow paths with `scripts/verification/` equivalents.**
+
+- [ ] **Step 3: Delete the real-Azure phase-1 workflow and the no-longer-referenced scripts. Update final-candidate certification to run only retained verification contracts and checks; remove audit-only operability and fault/load calls.**
+
+- [ ] **Step 4: Run `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' .github/workflows/*.yaml`; expect exit status 0.**
+
+- [ ] **Step 5: Commit with `git commit -m "ci: retire completed remediation gates"`.**
+
+### Task 3: Update durable documentation
+
+**Files:**
+
+- Delete `docs/ci-security-bootstrap.md`.
+- Modify `docs/build-inputs.md`, `docs/release-operations-runbook.md`, and `docs/phase-0-migration-recovery-runbook.md`.
+
+**Interfaces:** The runbooks document only retained `scripts/verification/` commands.
+
+- [ ] **Step 1: Delete `docs/ci-security-bootstrap.md` with `git rm`.**
+
+- [ ] **Step 2: Change retained runbook and build-input script paths to `scripts/verification/`; remove wording that describes the concluded remediation campaign.**
+
+- [ ] **Step 3: Run `rg -n 'scripts/remediation/|remediation/phase' README.md docs .github scripts -g '!docs/superpowers/**'`; expect no results.**
+
+- [ ] **Step 4: Commit with `git commit -m "docs: remove completed remediation guidance"`.**
+
+### Task 4: Run focused verification
+
+**Files:** Verify `.github/workflows/*.yaml` and `scripts/verification/**/*.sh`.
+
+- [ ] **Step 1: Run `find scripts/verification -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n`; expect exit status 0.**
+
+- [ ] **Step 2: Run the retained static contracts: `test-supply-chain-pinning.sh`, `test-release-runbooks-gate.sh`, `test-terraform-backend-matrix.sh`, and `test-final-candidate-certification.sh`; expect exit status 0.**
+
+- [ ] **Step 3: Re-run the YAML parser and stale-path search from Tasks 2 and 3; expect exit status 0 and no stale paths.**
+
+- [ ] **Step 4: Run `dotnet test TerraformRegistry.Tests/TerraformRegistry.Tests.csproj --configuration Release --no-restore`; report the expected SDK 10.0.301 limitation without changing `global.json`.**

--- a/docs/superpowers/specs/2026-07-15-remediation-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-15-remediation-cleanup-design.md
@@ -1,0 +1,44 @@
+# Remediation Cleanup Design
+
+## Purpose
+
+Retire the completed remediation campaign without removing the ongoing CI and
+release safeguards it introduced. The remaining automation will use a neutral
+`scripts/verification/` namespace that reflects its continuing purpose.
+
+## Retained verification
+
+Move these durable checks from `scripts/remediation/` to
+`scripts/verification/` and update every in-repository caller:
+
+- supply-chain input pinning;
+- release-runbook contract checks;
+- storage-emulator lifecycle and Terraform smoke checks;
+- the Terraform backend matrix; and
+- pre-publication final-candidate certification.
+
+The corresponding always-on or release-candidate CI jobs retain their current
+behavior. The release operations and build-input documentation remains, with
+paths and wording updated to use the new namespace.
+
+## Retired campaign material
+
+Remove one-off audit gates, their contract scripts, and workflows that only
+run for named temporary branches. Remove remediation-only branch filters from
+CI and security workflows. Remove the CI/security bootstrap document because
+it describes the concluded remediation branching process.
+
+This includes phase 0 and phase 1 deployment gates, bounded-ingestion,
+mirror-containment, publication-fault, fault/load, and operability
+certifications, plus the real-Azure phase 1 workflow.
+
+## Verification
+
+Use repository searches to prove no `scripts/remediation/` paths or removed
+job names remain. Run shell syntax checks for retained scripts and focused
+contract checks that do not need Docker, Terraform, cloud credentials, or a
+.NET SDK. Validate the workflow YAML using Ruby's built-in YAML parser when
+available.
+
+The full .NET test suite is not runnable in this environment because the
+repository requires SDK 10.0.301 while only 10.0.109 is installed.


### PR DESCRIPTION
Replays the local develop-only remediation cleanup changes onto the current `develop` base without a merge commit.\n\nNet change: adds the approved remediation cleanup design and implementation plan documents.